### PR TITLE
Fix bug with typed_fad_gradient!()

### DIFF
--- a/src/typed_fad/GraDual.jl
+++ b/src/typed_fad/GraDual.jl
@@ -170,7 +170,7 @@ atanh{T<:Real, n}(x::GraDual{T, n}) = GraDual{T, n}(atanh(x.v), x.g/(1-x.v*x.v))
 function typed_fad_gradient!{T<:Real}(f::Function, ::Type{T})
   function g!(x::Vector{T}, gradient_output::Matrix{T})
     fvalue = f(GraDual(x))
-    m = size(gradient_output)[1]
+    m = length(fvalue)
     for i in 1:m
       gradient_output[i, :] = fvalue[i].g[:]
     end

--- a/src/typed_fad/GraDual.jl
+++ b/src/typed_fad/GraDual.jl
@@ -170,9 +170,9 @@ atanh{T<:Real, n}(x::GraDual{T, n}) = GraDual{T, n}(atanh(x.v), x.g/(1-x.v*x.v))
 function typed_fad_gradient!{T<:Real}(f::Function, ::Type{T})
   function g!(x::Vector{T}, gradient_output::Matrix{T})
     fvalue = f(GraDual(x))
-    m, n = size(gradient_output)
-    for i in 1:m, j in 1:n
-      gradient_output[i, j] = fvalue[i].g[j]
+    m = size(gradient_output)[1]
+    for i in 1:m
+      gradient_output[i, :] = fvalue[i].g[:]
     end
   end
   return g!

--- a/src/typed_fad/GraDual.jl
+++ b/src/typed_fad/GraDual.jl
@@ -35,15 +35,15 @@ const jacobian = grad
 
 convert{T<:Real, n}(::Type{GraDual{T, n}}, x::GraDual{T, n}) = x
 convert{T<:Real, n}(::Type{GraDual{T, n}}, x::T) = GraDual{T, n}(x, zeros(T, n))
-convert{T<:Real, S<:Real, n}(::Type{GraDual{T, n}}, x::S) = 
+convert{T<:Real, S<:Real, n}(::Type{GraDual{T, n}}, x::S) =
   GraDual{T, n}(convert(T, x), zeros(T, n))
-convert{T<:Real, S<:Real, n}(::Type{GraDual{T, n}}, x::GraDual{S, n}) = 
+convert{T<:Real, S<:Real, n}(::Type{GraDual{T, n}}, x::GraDual{S, n}) =
   GraDual{T, n}(convert(T, x.v), convert(Vector{T}, x.g))
 convert{T<:Real, S<:Real, n}(::Type{T}, x::GraDual{S, n}) =
   (grad(x) == zeros(S, n) ? convert(T, x.v) : throw(InexactError()))
-  
+
 promote_rule{T<:Real, n}(::Type{GraDual{T, n}}, ::Type{T}) = GraDual{T, n}
-promote_rule{T<:Real, S<:Real, n}(::Type{GraDual{T, n}}, ::Type{S}) = 
+promote_rule{T<:Real, S<:Real, n}(::Type{GraDual{T, n}}, ::Type{S}) =
   GraDual{promote_type(T, S), n}
 promote_rule{T<:Real, S<:Real, n}(::Type{GraDual{T, n}}, ::Type{GraDual{S,n}}) =
   GraDual{promote_type(T, S), n}
@@ -56,9 +56,9 @@ iszero{T<:Real, n}(x::GraDual{T, n}) = isconstant(x) && (x.v == zero(T))
 isfinite{T<:Real, n}(x::GraDual{T, n}) =
   isfinite(x.v) && (isfinite(x.g) == ones(T, n))
 
-=={T<:Real, n}(x1::GraDual{T, n}, x2::GraDual{T, n}) = 
+=={T<:Real, n}(x1::GraDual{T, n}, x2::GraDual{T, n}) =
   (x1.v == x2.v) && (x1.g == x2.g)
-  
+
 show(io::IO, x::GraDual) = print(io, "GraDual(", value(x), ",\n", grad(x), ")")
 
 function conj{T<:Real, n}(x::GraDual{T, n})
@@ -168,10 +168,11 @@ acosh{T<:Real, n}(x::GraDual{T, n}) =
 atanh{T<:Real, n}(x::GraDual{T, n}) = GraDual{T, n}(atanh(x.v), x.g/(1-x.v*x.v))
 
 function typed_fad_gradient!{T<:Real}(f::Function, ::Type{T})
-  function g!(x::Vector{T}, gradient_output::Vector{T})
+  function g!(x::Vector{T}, gradient_output::Matrix{T})
     fvalue = f(GraDual(x))
-    for i = 1:length(gradient_output)
-      gradient_output[i] = fvalue.g[i]
+    m, n = size(gradient_output)
+    for i in 1:m, j in 1:n
+      gradient_output[i, j] = fvalue[i].g[j]
     end
   end
   return g!

--- a/test/GraDual.jl
+++ b/test/GraDual.jl
@@ -31,7 +31,7 @@ gradf(x) = [dfdx(x), dfdy(x), dfdz(x)]
 args = [2.3, -1.5, -4.]
 
 g! = forwarddiff_gradient!(f, Float64, fadtype=:typed)
-output = zeros(3)
+output = Array(Float64, 1, 3)
 g!(args, output)
 @test_approx_eq output gradf(args)
 
@@ -85,7 +85,7 @@ output = f(GraDual(args)...)
 @test_approx_eq value(output) f(args...)
 @test_approx_eq grad(output) gradf(args...)
 
-# Testing exp, log, log2 and and log10 
+# Testing exp, log, log2 and and log10
 
 f(x, y, z) = log2(x)*exp(y*z)+log(x^4*y)/log10(z)
 


### PR DESCRIPTION
Current implementation of `typed_fad_gradient!()` contains a bug related to access to non-existent field of a structure and is inconsistent with `typed_fad_gradient()`. When trying to call `forwarddiff_jacobian!()` of a function that returns `Vector`, an error occurs. In this example:

```Julia
using ForwardDiff

F(x) = [x[1]^2, x[1]*x[2], x[2]^2]

J! = forwarddiff_jacobian!(F, Float64, fadtype=:typed)

A = zeros(3, 2)
J!([1., 1.], A)
```
after execution got
```
`g!` has no method matching g!(::Array{Float64,1}, ::Array{Float64,2})
````

If try to make `A=zeros(6)` got
```
type Array has no field g
```

After that fix, one can use `Matrix` of the same shape as in the output of `forwarddiff_jacobian()`.