### PR TITLE
Fix #20: Add isless(a,b) for GraDual type

### DIFF
--- a/src/typed_fad/GraDual.jl
+++ b/src/typed_fad/GraDual.jl
@@ -58,7 +58,10 @@ isfinite{T<:Real, n}(x::GraDual{T, n}) =
 
 =={T<:Real, n}(x1::GraDual{T, n}, x2::GraDual{T, n}) = 
   (x1.v == x2.v) && (x1.g == x2.g)
-  
+
+isless(x1::GraDual, x2) = isless(value(x1), x2)
+isless(x1, x2::GraDual) = isless(x1, value(x2))
+
 show(io::IO, x::GraDual) = print(io, "GraDual(", value(x), ",\n", grad(x), ")")
 
 function conj{T<:Real, n}(x::GraDual{T, n})


### PR DESCRIPTION
Add isless(x1::GraDual, x2) and isless(x1, x2::GraDual) so that functions taking a minimum, maximum, etc are differentiable.