### PR TITLE
Allow access to lower-order values by providing a `ForwardDiffResult`s interface

### DIFF
--- a/src/ForwardDiff.jl
+++ b/src/ForwardDiff.jl
@@ -42,7 +42,7 @@ module ForwardDiff
     include("TensorNumber.jl")
     include("fad_api/fad_api.jl")
 
-    export AllInfo,
+    export AllResults,
            ForwardDiffCache,
            value,
            value!,

--- a/src/ForwardDiff.jl
+++ b/src/ForwardDiff.jl
@@ -42,7 +42,11 @@ module ForwardDiff
     include("TensorNumber.jl")
     include("fad_api/fad_api.jl")
 
-    export derivative!,
+    export AllInfo,
+           ForwardDiffCache,
+           value,
+           value!,
+           derivative!,
            derivative,
            gradient!,
            jacobian!,
@@ -50,7 +54,6 @@ module ForwardDiff
            hessian!,
            hessian,
            tensor!,
-           tensor,
-           ForwardDiffCache
+           tensor
 
 end # module ForwardDiff

--- a/src/TensorNumber.jl
+++ b/src/TensorNumber.jl
@@ -123,14 +123,14 @@ end
 #   t₁ = grad(t, i) # coeff of ϵ₁
 #   t₂ = grad(t, j) # coeff of ϵ₂
 #   t₃ = grad(t, k) # coeff of ϵ₃
-#   t₄ = hess(t, a) = hess(t, t_inds_2_h_ind(i, j)) # coeff of ϵ₁ϵ₂
-#   t₅ = hess(t, b) = hess(t, t_inds_2_h_ind(i, k)) # coeff of ϵ₁ϵ₃
-#   t₆ = hess(t, c) = hess(t, t_inds_2_h_ind(j, k)) # coeff of ϵ₂ϵ₃
+#   t₄ = hess(t, a) = hess(t, hess_inds(i, j)) # coeff of ϵ₁ϵ₂
+#   t₅ = hess(t, b) = hess(t, hess_inds(i, k)) # coeff of ϵ₁ϵ₃
+#   t₆ = hess(t, c) = hess(t, hess_inds(j, k)) # coeff of ϵ₂ϵ₃
 #   t₇ = tens(t, q) # coeff of ϵ₁ϵ₂ϵ₃
 #
 # see http://adl.stanford.edu/hyperdual/Fike_AIAA-2011-886.pdf for details.
 
-function t_inds_2_h_ind(i, j)
+function hess_inds(i, j)
     if i < j
         return div(j*(j-1), 2) + i
     else
@@ -143,7 +143,7 @@ function loadtens_deriv!{N}(t::TensorNumber{N}, deriv1, deriv2, deriv3, output)
     for i in 1:N
         for j in i:N
             for k in i:j
-                a, b, c = t_inds_2_h_ind(i,j), t_inds_2_h_ind(i,k), t_inds_2_h_ind(j,k)
+                a, b, c = hess_inds(i,j), hess_inds(i,k), hess_inds(j,k)
                 g_i, g_j, g_k = grad(t,i), grad(t,j), grad(t,k)
                 output[q] = deriv1*tens(t,q) + deriv2*(g_k*hess(t,a) + g_j*hess(t,b) + g_i*hess(t,c)) + deriv3*g_i*g_j*g_k
                 q += 1
@@ -162,7 +162,7 @@ function loadtens_mul!{N}(t1::TensorNumber{N}, t2::TensorNumber{N}, output)
     for i in 1:N
         for j in i:N
             for k in i:j
-                a, b, c = t_inds_2_h_ind(i,j), t_inds_2_h_ind(i,k), t_inds_2_h_ind(j,k)
+                a, b, c = hess_inds(i,j), hess_inds(i,k), hess_inds(j,k)
                 output[q] = (tens(t1,q)*t2val +
                              hess(t1,c)*grad(t2,i) +
                              hess(t1,b)*grad(t2,j) +
@@ -193,7 +193,7 @@ function loadtens_div!{N}(t1::TensorNumber{N}, t2::TensorNumber{N}, output)
     for i in 1:N
         for j in i:N
             for k in i:j
-                a, b, c = t_inds_2_h_ind(i,j), t_inds_2_h_ind(i,k), t_inds_2_h_ind(j,k)
+                a, b, c = hess_inds(i,j), hess_inds(i,k), hess_inds(j,k)
                 t1_gi, t1_gj, t1_gk = grad(t1,i), grad(t1,j), grad(t1,k)
                 t2_gi, t2_gj, t2_gk = grad(t2,i), grad(t2,j), grad(t2,k)
                 t1_ha, t1_hb, t1_hc = hess(t1,a), hess(t1,b), hess(t1,c)
@@ -239,7 +239,7 @@ function loadtens_exp!{N}(t1::TensorNumber{N}, t2::TensorNumber{N}, output)
     for i in 1:N
         for j in i:N
             for k in i:j
-                a, b, c = t_inds_2_h_ind(i,j), t_inds_2_h_ind(i,k), t_inds_2_h_ind(j,k)
+                a, b, c = hess_inds(i,j), hess_inds(i,k), hess_inds(j,k)
                 
                 t1_gi, t1_gj, t1_gk = grad(t1,i), grad(t1,j), grad(t1,k)
                 t2_gi, t2_gj, t2_gk = grad(t2,i), grad(t2,j), grad(t2,k)

--- a/src/fad_api/ForwardDiffResult.jl
+++ b/src/fad_api/ForwardDiffResult.jl
@@ -1,13 +1,6 @@
 # This file contains methods to handle the results
 # of ForwardDiff calculations (generally either 
 # ForwardDiffNumbers or Arrays of ForwardDiffNumbers. 
-#
-# Note that in the case where the result is an Array, the
-# below methods work under the assumption that the result
-# contains elements of homogenous type, even if the actual 
-# eltype of the array is ambiguous due to poor type 
-# inferencing (hence the use of `eltype(first(...))` in 
-# a lot of places).
 
 immutable ForwardDiffResult{T}
     data::T
@@ -37,7 +30,7 @@ function get_value!(output::Array, arr::Array)
     return _load_value!(output, arr)
 end
 
-get_value(arr::Array) = _load_value!(similar(arr, eltype(first(arr))), arr)
+get_value{F}(arr::Array{F}) = _load_value!(similar(arr, eltype(F)), arr)
 get_value(n::ForwardDiffNumber) = value(n)
 
 ###############
@@ -54,11 +47,11 @@ function _load_derivative!(output::Array, arr::Array)
 end
 
 function get_derivative!(output::Array, arr::Array)
-    @assert length(arr) == length(output)
+    @assert length(output) == length(arr)
     return _load_derivative!(output, arr)
 end
 
-get_derivative(arr::Array) = _load_derivative!(similar(arr, eltype(first(arr))), arr)
+get_derivative{F}(arr::Array{F}) = _load_derivative!(similar(arr, eltype(F)), arr)
 get_derivative(n::ForwardDiffNumber{1}) = first(grad(n))
 
 #############
@@ -98,15 +91,14 @@ function _load_jacobian!(output, arr::Array)
     return output
 end
 
-function get_jacobian!(output, arr::Array)
+function get_jacobian!{F}(output, arr::Array{F})
     @assert size(output, 1) == length(arr)
-    @assert size(output, 2) == npartials(first(arr))
+    @assert size(output, 2) == npartials(F)
     return _load_jacobian!(output, arr)
 end
 
-function get_jacobian(arr::Array)
-    init = first(arr)
-    output = Array(eltype(init), length(arr), npartials(init))
+function get_jacobian{F}(arr::Array{F})
+    output = Array(eltype(F), length(arr), npartials(F))
     return _load_jacobian!(output, arr)
 end
 

--- a/src/fad_api/ForwardDiffResult.jl
+++ b/src/fad_api/ForwardDiffResult.jl
@@ -1,0 +1,178 @@
+# This file contains methods to handle the results
+# of ForwardDiff calculations (generally either 
+# ForwardDiffNumbers or Arrays of ForwardDiffNumbers. 
+#
+# Note that in the case where the result is an Array, the
+# below methods work under the assumption that the result
+# contains elements of homogenous type, even if the actual 
+# eltype of the array is ambiguous due to poor type 
+# inferencing (hence the use of `eltype(first(...))` in 
+# a lot of places).
+
+immutable ForwardDiffResult{T}
+    data::T
+    ForwardDiffResult(data::ForwardDiffNumber) = new(data)
+    ForwardDiffResult(data::Array) = new(data)
+end
+
+ForwardDiffResult{T}(data::T) = ForwardDiffResult{T}(data)
+
+data(result::ForwardDiffResult) = result.data
+
+##########
+# Values #
+##########
+value!(output, result::ForwardDiffResult) = get_value!(output, data(result))
+value(result::ForwardDiffResult) =  get_value(data(result))
+
+function _load_value!(output::Array, arr::Array)
+    @simd for i in eachindex(output)
+        @inbounds output[i] = get_value(arr[i])
+    end
+    return output
+end
+
+function get_value!(output::Array, arr::Array)
+    @assert length(arr) == length(output)
+    return _load_value!(output, arr)
+end
+
+get_value(arr::Array) = _load_value!(similar(arr, eltype(first(arr))), arr)
+get_value(n::ForwardDiffNumber) = value(n)
+
+###############
+# Derivatives #
+###############
+derivative!(output, result::ForwardDiffResult) = get_derivative!(output, data(result))
+derivative(result::ForwardDiffResult) =  get_derivative(data(result))
+
+function _load_derivative!(output::Array, arr::Array)
+    @simd for i in eachindex(output)
+        @inbounds output[i] = get_derivative(arr[i])
+    end
+    return output
+end
+
+function get_derivative!(output::Array, arr::Array)
+    @assert length(arr) == length(output)
+    return _load_derivative!(output, arr)
+end
+
+get_derivative(arr::Array) = _load_derivative!(similar(arr, eltype(first(arr))), arr)
+get_derivative(n::ForwardDiffNumber{1}) = first(grad(n))
+
+#############
+# Gradients #
+#############
+gradient!(output, result::ForwardDiffResult) = get_gradient!(output, data(result))
+gradient(result::ForwardDiffResult) = get_gradient(data(result))
+
+function _load_gradient!(output, n::ForwardDiffNumber)
+    @simd for i in eachindex(output)
+        @inbounds output[i] = grad(n, i)
+    end
+    return output
+end
+
+function get_gradient!{N}(output, n::ForwardDiffNumber{N})
+    @assert length(output) == N
+    return _load_gradient!(output, n)
+end
+
+get_gradient{N,T}(n::ForwardDiffNumber{N,T,NTuple{N,T}}) = _load_gradient!(Array(T, N), n)
+get_gradient{N,T}(n::ForwardDiffNumber{N,T,Vector{T}}) = grad(n)
+
+#############
+# Jacobians #
+#############
+jacobian!(output, result::ForwardDiffResult) = get_jacobian!(output, data(result))
+jacobian(result::ForwardDiffResult) = get_jacobian(data(result))
+
+function _load_jacobian!(output, arr::Array)
+    nrows, ncols = size(output)
+    for i in 1:nrows
+        @simd for j in 1:ncols
+            @inbounds output[i,j] = grad(result[i], j)
+        end
+    end
+    return output
+end
+
+function get_jacobian!(output, arr::Array)
+    @assert size(output, 1) == length(arr)
+    @assert size(output, 2) == npartials(first(arr))
+    return _load_jacobian!(output, arr)
+end
+
+function get_jacobian(arr::Array)
+    init = first(arr)
+    output = Array(eltype(init), length(arr), npartials(init))
+    return _load_jacobian!(output, arr)
+end
+
+############
+# Hessians #
+############
+hessian!(output, result::ForwardDiffResult) = get_hessian!(output, data(result))
+hessian(result::ForwardDiffResult) = get_hessian(data(result))
+
+function _load_hessian!{N}(output, n::ForwardDiffNumber{N})
+    q = 1
+    for i in 1:N
+        @simd for j in 1:i
+            val = hess(n, q)
+            @inbounds output[i, j] = val
+            @inbounds output[j, i] = val
+            q += 1
+        end
+    end
+    return output
+end
+
+function get_hessian!{N}(output, n::ForwardDiffNumber{N})
+    @assert size(output) == (N, N)
+    return _load_hessian!(output, n)
+end
+
+get_hessian{N,T}(n::ForwardDiffNumber{N,T}) = _load_hessian!(Array(T, N, N), n)
+
+############
+# Hessians #
+############
+tensor!(output, result::ForwardDiffResult) = get_tensor!(output, data(result))
+tensor(result::ForwardDiffResult) = get_tensor(data(result))
+
+function _load_tensor!{N}(output, n::ForwardDiffNumber{N})
+    q = 1
+    for i in 1:N
+        for j in i:N
+            for k in i:j
+                @inbounds output[j, k, i] = tens(n, q)
+                q += 1
+            end
+        end
+        for j in 1:(i-1)
+            for k in 1:j
+                @inbounds output[j, k, i] = output[i, j, k]
+            end
+        end    
+        for j in i:N
+            for k in 1:(i-1)
+                @inbounds output[j, k, i] = output[i, j, k]
+            end
+        end
+        for j in 1:N
+            for k in (j+1):N
+                @inbounds output[j, k, i] = output[k, j, i]
+            end
+        end
+    end
+    return output
+end
+
+function get_tensor!{N}(output, n::ForwardDiffNumber{N})
+    @assert size(output) == (N, N, N)
+    return _load_tensor!(output, n)
+end
+
+get_tensor{N,T}(n::ForwardDiffNumber{N,T}) = _load_tensor!(Array(T, N, N, N), n)

--- a/src/fad_api/ForwardDiffResult.jl
+++ b/src/fad_api/ForwardDiffResult.jl
@@ -90,9 +90,9 @@ jacobian(result::ForwardDiffResult) = get_jacobian(data(result))
 
 function _load_jacobian!(output, arr::Array)
     nrows, ncols = size(output)
-    for i in 1:nrows
-        @simd for j in 1:ncols
-            @inbounds output[i,j] = grad(result[i], j)
+    for j in 1:ncols
+        @simd for i in 1:nrows
+            @inbounds output[i,j] = grad(arr[i], j)
         end
     end
     return output

--- a/src/fad_api/derivative.jl
+++ b/src/fad_api/derivative.jl
@@ -7,7 +7,7 @@
 @generated function derivative!{A}(output, f, x::Number, ::Type{A}=Void)
     if A <: Void
         return_stmt = :(derivative!(output, result))
-    elseif A <: AllInfo
+    elseif A <: AllResults
         return_stmt = :(derivative!(output, result), result)
     else
         error("invalid argument $A passed to FowardDiff.hessian")
@@ -23,7 +23,7 @@ end
 
     if A <: Void
         return_stmt = :(derivative(result))
-    elseif A <: AllInfo
+    elseif A <: AllResults
         return_stmt = :(derivative(result), result)
     else
         error("invalid argument $A passed to FowardDiff.hessian")

--- a/src/fad_api/derivative.jl
+++ b/src/fad_api/derivative.jl
@@ -4,28 +4,15 @@
 
 # Exposed API methods #
 #---------------------#
-derivative!(output::Array, f, x::Number) = load_derivative!(output, f(GradientNumber(x, one(x))))
-derivative(f, x::Number) = load_derivative(f(GradientNumber(x, one(x))))
+derivative!(output, f, x::Number) = get_derivative!(output, f(GradientNumber(x, one(x))))
+derivative(f, x::Number) = get_derivative(f(GradientNumber(x, one(x))))
 
 function derivative(f; mutates=false)
     if mutates
-        derivf!(output::Array, x::Number) = ForwardDiff.derivative!(output, f, x)
+        derivf!(output, x::Number) = ForwardDiff.derivative!(output, f, x)
         return derivf!
     else
         derivf(x::Number) = ForwardDiff.derivative(f, x)
         return derivf
     end
 end
-
-# Helper functions #
-#------------------#
-function load_derivative!(output::Array, arr::Array)
-    @assert length(arr) == length(output)
-    @simd for i in eachindex(output)
-        @inbounds output[i] = grad(arr[i], 1)
-    end
-    return output
-end
-
-load_derivative(arr::Array) = load_derivative!(similar(arr, eltype(eltype(arr))), arr)
-load_derivative(n::ForwardDiffNumber{1}) = grad(n, 1)

--- a/src/fad_api/fad_api.jl
+++ b/src/fad_api/fad_api.jl
@@ -7,6 +7,8 @@
 const tuple_usage_threshold = 10
 const default_chunk_size = 0
 
+abstract AllInfo
+
 for F in (:GradientNumber, :HessianNumber, :TensorNumber)
     @eval begin
         switch_eltype{N,T,S}(::Type{$F{N,T,NTuple{N,T}}}, ::Type{S}) = $F{N,S,NTuple{N,S}}
@@ -29,6 +31,7 @@ include("cache.jl")
 
 const dummy_cache = make_dummy_cache()
 
+include("ForwardDiffResult.jl")
 include("derivative.jl")
 include("gradient.jl")
 include("jacobian.jl")

--- a/src/fad_api/fad_api.jl
+++ b/src/fad_api/fad_api.jl
@@ -7,7 +7,7 @@
 const tuple_usage_threshold = 10
 const default_chunk_size = 0
 
-abstract AllInfo
+abstract AllResults
 
 for F in (:GradientNumber, :HessianNumber, :TensorNumber)
     @eval begin

--- a/src/fad_api/fad_api.jl
+++ b/src/fad_api/fad_api.jl
@@ -23,7 +23,7 @@ function check_chunk_size(xlen::Int, chunk_size::Int)
     end
 end
 
-function chunk_size_matches_full(xlen::Int, chunk_size::Int)
+function chunk_size_matches_vec_mode(xlen::Int, chunk_size::Int)
     return (chunk_size == default_chunk_size) || (chunk_size == xlen)
 end
 

--- a/src/fad_api/gradient.jl
+++ b/src/fad_api/gradient.jl
@@ -75,7 +75,7 @@ end
                                                         cache::ForwardDiffCache)
     check_chunk_size(xlen, chunk_size)
     G = workvec_eltype(GradientNumber, T, Val{xlen}, Val{chunk_size})
-    if chunk_size_matches_full(xlen, chunk_size)
+    if chunk_size_matches_vec_mode(xlen, chunk_size)
         # Vector-Mode
         ResultType = switch_eltype(G, S)
         body = quote

--- a/src/fad_api/gradient.jl
+++ b/src/fad_api/gradient.jl
@@ -43,14 +43,14 @@ function gradient{A}(f, ::Type{A}=Void;
                      chunk_size::Int=default_chunk_size,
                      cache::ForwardDiffCache=ForwardDiffCache())
     if mutates
-        function g!{T}(output::Vector{T}, x::Vector)
+        function g!(output::Vector, x::Vector)
             return ForwardDiff.gradient!(output, f, x, A;
                                          chunk_size=chunk_size,
                                          cache=cache)
         end
         return g!
     else
-        function g{T}(x::Vector{T})
+        function g(x::Vector)
             return ForwardDiff.gradient(f, x, A;
                                         chunk_size=chunk_size,
                                         cache=cache)

--- a/src/fad_api/gradient.jl
+++ b/src/fad_api/gradient.jl
@@ -9,7 +9,7 @@
                                    cache::ForwardDiffCache=dummy_cache)
     if A <: Void
         return_stmt = :(gradient!(output, result)::Vector{T})
-    elseif A <: AllInfo
+    elseif A <: AllResults
         return_stmt = :(gradient!(output, result)::Vector{T}, result)
     else
         error("invalid argument $A passed to FowardDiff.gradient")
@@ -26,7 +26,7 @@ end
                                   cache::ForwardDiffCache=dummy_cache)
     if A <: Void
         return_stmt = :(gradient(result)::Vector{T})
-    elseif A <: AllInfo
+    elseif A <: AllResults
         return_stmt = :(gradient(result)::Vector{T}, result)
     else
         error("invalid argument $A passed to FowardDiff.gradient")

--- a/src/fad_api/gradient.jl
+++ b/src/fad_api/gradient.jl
@@ -4,67 +4,101 @@
 
 # Exposed API methods #
 #---------------------#
-function gradient!{T}(output::Vector{T},
-                      f,
-                      x::Vector;
-                      chunk_size::Int=default_chunk_size,
-                      cache::ForwardDiffCache=dummy_cache)
-    xlen = length(x)
-    @assert xlen == length(output) "The output vector must be the same length as the input vector"
-    return _calc_gradient!(output, f, x, Val{xlen}, Val{chunk_size}, cache)::Vector{T}
-end
-
-function gradient{T}(f,
-                     x::Vector{T};
-                     chunk_size::Int=default_chunk_size,
-                     cache::ForwardDiffCache=dummy_cache)
-    return _calc_gradient!(similar(x), f, x, Val{length(x)}, Val{chunk_size}, cache)::Vector{T}
-end
-
-function gradient(f; mutates=false)
-    cache = ForwardDiffCache()
-    if mutates
-        function gradf!{T}(output::Vector{T}, x::Vector; chunk_size::Int=default_chunk_size)
-            return ForwardDiff.gradient!(output, f, x, chunk_size=chunk_size, cache=cache)::Vector{T}
-        end
-        return gradf!
+@generated function gradient!{T,A}(output::Vector{T}, f, x::Vector, ::Type{A}=Void;
+                                   chunk_size::Int=default_chunk_size,
+                                   cache::ForwardDiffCache=dummy_cache)
+    if A <: Void
+        return_stmt = :(gradient!(output, result)::Vector{T})
+    elseif A <: AllInfo
+        return_stmt = :(gradient!(output, result)::Vector{T}, result)
     else
-        function gradf{T}(x::Vector{T}; chunk_size::Int=default_chunk_size)
-            return ForwardDiff.gradient(f, x, chunk_size=chunk_size, cache=cache)::Vector{T}
-        end
-        return gradf
+        error("invalid argument $A passed to FowardDiff.gradient")
+    end
+
+    return quote
+        result = _calc_gradient(f, x, T, chunk_size, cache)
+        return $return_stmt
     end
 end
-    
+
+@generated function gradient{T,A}(f, x::Vector{T}, ::Type{A}=Void;
+                                  chunk_size::Int=default_chunk_size,
+                                  cache::ForwardDiffCache=dummy_cache)
+    if A <: Void
+        return_stmt = :(gradient(result)::Vector{T})
+    elseif A <: AllInfo
+        return_stmt = :(gradient(result)::Vector{T}, result)
+    else
+        error("invalid argument $A passed to FowardDiff.gradient")
+    end
+
+    return quote
+        result = _calc_gradient(f, x, T, chunk_size, cache)
+        return $return_stmt
+    end
+end
+
+function gradient{A}(f, ::Type{A}=Void;
+                     mutates::Bool=false,
+                     chunk_size::Int=default_chunk_size,
+                     cache::ForwardDiffCache=ForwardDiffCache())
+    if mutates
+        function g!{T}(output::Vector{T}, x::Vector)
+            return ForwardDiff.gradient!(output, f, x, A;
+                                         chunk_size=chunk_size,
+                                         cache=cache)
+        end
+        return g!
+    else
+        function g{T}(x::Vector{T})
+            return ForwardDiff.gradient(f, x, A;
+                                        chunk_size=chunk_size,
+                                        cache=cache)
+        end
+        return g
+    end
+end
+
 # Calculate gradient of a given function #
 #----------------------------------------#
-@generated function _calc_gradient!{S,T,xlen,chunk_size}(output::Vector{S}, f, x::Vector{T}, 
-                                                         X::Type{Val{xlen}}, C::Type{Val{chunk_size}},
-                                                         cache::ForwardDiffCache)
+function _calc_gradient{S}(f, x::Vector, ::Type{S},
+                           chunk_size::Int,
+                           cache::ForwardDiffCache)
+    X = Val{length(x)}
+    C = Val{chunk_size}
+    return _calc_gradient(f, x, S, X, C, cache)
+end
+
+@generated function _calc_gradient{T,S,xlen,chunk_size}(f, x::Vector{T}, ::Type{S},
+                                                        X::Type{Val{xlen}},
+                                                        C::Type{Val{chunk_size}},
+                                                        cache::ForwardDiffCache)
     check_chunk_size(xlen, chunk_size)
-
-    full_bool = chunk_size_matches_full(xlen, chunk_size)
     G = workvec_eltype(GradientNumber, T, Val{xlen}, Val{chunk_size})
-
-    if full_bool
+    if chunk_size_matches_full(xlen, chunk_size)
+        # Vector-Mode
+        ResultType = switch_eltype(G, S)
         body = quote
             @simd for i in eachindex(x)
                 @inbounds gradvec[i] = G(x[i], partials[i])
             end
 
-            result::ResultType = f(gradvec)
-
-            @simd for i in eachindex(output)
-                @inbounds output[i] = grad(result, i)
-            end
+            result::$ResultType = f(gradvec)
         end
     else
+        # Chunk-Mode
+        ChunkType = switch_eltype(G, S)
+        ResultType = GradientNumber{xlen,S,Vector{S}}
         body = quote
+            N = npartials(G)
             gradzeros = get_zeros!(cache, G)
+            output = Vector{S}(xlen)
 
             @simd for i in eachindex(x)
                 @inbounds gradvec[i] = G(x[i], gradzeros)
             end
+
+            local chunk_result::$ChunkType
 
             for i in 1:N:xlen
                 offset = i-1
@@ -74,7 +108,7 @@ end
                     @inbounds gradvec[q] = G(x[q], partials[j])
                 end
 
-                chunk_result::ResultType = f(gradvec)
+                chunk_result = f(gradvec)
 
                 @simd for j in 1:N
                     q = j+offset
@@ -82,19 +116,18 @@ end
                     @inbounds gradvec[q] = G(x[q], gradzeros)
                 end
             end
+
+            result::$ResultType = ($ResultType)(value(chunk_result), output)
         end
     end
 
-    return quote 
+    return quote
         G = $G
-        N = npartials(G)
-        ResultType = switch_eltype(G, S)
-
         gradvec = get_workvec!(cache, GradientNumber, T, X, C)
         partials = get_partials!(cache, G)
 
         $body
 
-        return output::Vector{S}
+        return ForwardDiffResult(result)
     end
 end

--- a/src/fad_api/hessian.jl
+++ b/src/fad_api/hessian.jl
@@ -9,7 +9,7 @@
                                   cache::ForwardDiffCache=dummy_cache)
     if A <: Void
         return_stmt = :(hessian!(output, result)::Matrix{T})
-    elseif A <: AllInfo
+    elseif A <: AllResults
         return_stmt = :(hessian!(output, result)::Matrix{T}, result)
     else
         error("invalid argument $A passed to FowardDiff.hessian")
@@ -26,7 +26,7 @@ end
                                  cache::ForwardDiffCache=dummy_cache)
     if A <: Void
         return_stmt = :(hessian(result)::Matrix{T})
-    elseif A <: AllInfo
+    elseif A <: AllResults
         return_stmt = :(hessian(result)::Matrix{T}, result)
     else
         error("invalid argument $A passed to FowardDiff.hessian")

--- a/src/fad_api/hessian.jl
+++ b/src/fad_api/hessian.jl
@@ -4,80 +4,110 @@
 
 # Exposed API methods #
 #---------------------#
-function hessian!{T}(output::Matrix{T},
-                     f,
-                     x::Vector;
-                     chunk_size::Int=default_chunk_size,
-                     cache::ForwardDiffCache=dummy_cache)
-    xlen = length(x)
-    @assert (xlen, xlen) == size(output) "The output matrix must have size (length(input), length(input))"
-    return _calc_hessian!(output, f, x, Val{xlen}, Val{chunk_size}, cache)::Matrix{T}
-end
-
-function hessian{T}(f,
-                    x::Vector{T};
-                    chunk_size::Int=default_chunk_size,
-                    cache::ForwardDiffCache=dummy_cache)
-    xlen = length(x)
-    output = similar(x, xlen, xlen)
-    return _calc_hessian!(output, f, x, Val{xlen}, Val{chunk_size}, cache)::Matrix{T}
-end
-
-function hessian(f; mutates=false)
-    cache = ForwardDiffCache()
-    if mutates
-        function hessf!{T}(output::Matrix{T}, x::Vector; chunk_size::Int=default_chunk_size)
-            return ForwardDiff.hessian!(output, f, x, chunk_size=chunk_size, cache=cache)::Matrix{T}
-        end
-        return hessf!
+@generated function hessian!{T,A}(output::Matrix{T}, f, x::Vector, ::Type{A}=Void;
+                                  chunk_size::Int=default_chunk_size,
+                                  cache::ForwardDiffCache=dummy_cache)
+    if A <: Void
+        return_stmt = :(hessian!(output, result)::Matrix{T})
+    elseif A <: AllInfo
+        return_stmt = :(hessian!(output, result)::Matrix{T}, result)
     else
-        function hessf{T}(x::Vector{T}; chunk_size::Int=default_chunk_size)
-            return ForwardDiff.hessian(f, x, chunk_size=chunk_size, cache=cache)::Matrix{T}
+        error("invalid argument $A passed to FowardDiff.gradient")
+    end
+
+    return quote
+        result = _calc_hessian(f, x, T, chunk_size, cache)
+        return $return_stmt
+    end
+end
+
+@generated function hessian{T,A}(f, x::Vector{T}, ::Type{A}=Void;
+                                 chunk_size::Int=default_chunk_size,
+                                 cache::ForwardDiffCache=dummy_cache)
+    if A <: Void
+        return_stmt = :(hessian(result)::Matrix{T})
+    elseif A <: AllInfo
+        return_stmt = :(hessian(result)::Matrix{T}, result)
+    else
+        error("invalid argument $A passed to FowardDiff.gradient")
+    end
+
+    return quote
+        result = _calc_hessian(f, x, T, chunk_size, cache)
+        return $return_stmt
+    end
+end
+
+function hessian{A}(f, ::Type{A}=Void;
+                    mutates::Bool=false,
+                    chunk_size::Int=default_chunk_size,
+                    cache::ForwardDiffCache=ForwardDiffCache())
+    if mutates
+        function h!(output::Matrix, x::Vector)
+            return ForwardDiff.hessian!(output, f, x, A;
+                                        chunk_size=chunk_size,
+                                        cache=cache)
         end
-        return hessf
+        return h!
+    else
+        function h(x::Vector)
+            return ForwardDiff.hessian(f, x, A;
+                                       chunk_size=chunk_size,
+                                       cache=cache)
+        end
+        return h
     end
 end
 
 # Calculate Hessian of a given function #
 #---------------------------------------#
+function _calc_hessian{S}(f, x::Vector, ::Type{S},
+                          chunk_size::Int,
+                          cache::ForwardDiffCache)
+    X = Val{length(x)}
+    C = Val{chunk_size}
+    return _calc_hessian(f, x, S, X, C, cache)
+end
+
 gradnum_type{N,T,C}(::Type{HessianNumber{N,T,C}}) = GradientNumber{N,T,C}
 
-@generated function _calc_hessian!{S,T,xlen,chunk_size}(output::Matrix{S}, f, x::Vector{T}, 
-                                                        X::Type{Val{xlen}}, C::Type{Val{chunk_size}},
-                                                        cache::ForwardDiffCache)
+@generated function _calc_hessian{T,S,xlen,chunk_size}(f, x::Vector{T}, ::Type{S},
+                                                       X::Type{Val{xlen}},
+                                                       C::Type{Val{chunk_size}},
+                                                       cache::ForwardDiffCache)
     check_chunk_size(xlen, chunk_size)
-    full_bool = chunk_size_matches_full(xlen, chunk_size)
-    
-    # chunk_size is incremented by one when users 
-    # input a non-xlen chunk_size (this allows 
-    # simplification of loop alignment for the 
+
+    # chunk_size is incremented by one when users
+    # input a non-xlen chunk_size (this allows
+    # simplification of loop alignment for the
     # chunk-based calculation code)
-    C2 = Val{full_bool ? chunk_size : chunk_size+1}
+    vec_mode_bool = chunk_size_matches_vec_mode(xlen, chunk_size)
+    C2 = Val{vec_mode_bool ? chunk_size : chunk_size+1}
     H = workvec_eltype(HessianNumber, T, Val{xlen}, C2)
+    N = npartials(H)
     G = gradnum_type(H)
 
-    if full_bool
+    if vec_mode_bool
+        # Vector-Mode
+        ResultHess = switch_eltype(H, S)
         body = quote
             @simd for i in eachindex(x)
                 @inbounds hessvec[i] = HessianNumber(G(x[i], partials[i]), hesszeros)
             end
 
-            result::ResultType = f(hessvec)
-
-            q = 1
-            for i in 1:N
-                for j in 1:i
-                    val = hess(result, q)
-                    @inbounds output[i, j] = val
-                    @inbounds output[j, i] = val
-                    q += 1
-                end
-            end
+            result::$ResultHess = f(hessvec)
         end
     else
+        # Chunk-Mode
+        ChunkType = switch_eltype(H, S)
+        ResultGrad = GradientNumber{xlen,S,Vector{S}}
+        ResultHess = HessianNumber{xlen,S,Vector{S}}
         body = quote
+            N = $N
             M = N-1
             gradzeros = get_zeros!(cache, G)
+            output_grad = Vector{S}(xlen)
+            output_hess = Vector{S}(halfhesslen(xlen))
 
             @simd for i in eachindex(x)
                 @inbounds hessvec[i] = HessianNumber(G(x[i], gradzeros), hesszeros) 
@@ -106,27 +136,30 @@ gradnum_type{N,T,C}(::Type{HessianNumber{N,T,C}}) = GradientNumber{N,T,C}
             # -------------------------
             # |   |   |   |   | 3 | 3 |
             # -------------------------
+
+            local chunk_result::$ChunkType
+
             for i in 1:M:xlen
+                offset = i-1
+
                 @simd for j in 1:M
-                    q = i+j-1
+                    q = j+offset
                     @inbounds hessvec[q] = HessianNumber(G(x[q], partials[j]), hesszeros)
                 end
 
-                chunk_result::ResultType = f(hessvec)
+                chunk_result = f(hessvec)
                 
                 q = 1
-                for j in i:(i+M-1)
+                for j in i:(M+offset)
                     for k in i:j
-                        val = hess(chunk_result, q)
-                        @inbounds output[j, k] = val
-                        @inbounds output[k, j] = val
+                        @inbounds output_hess[hess_inds(j, k)] = hess(chunk_result, q)
                         q += 1
                     end
                 end
 
-                offset = i-1
                 @simd for j in 1:M
                     q = j+offset
+                    @inbounds output_grad[q] = grad(chunk_result, j)
                     @inbounds hessvec[q] = HessianNumber(G(x[q], gradzeros), hesszeros)
                 end
             end
@@ -150,6 +183,7 @@ gradnum_type{N,T,C}(::Type{HessianNumber{N,T,C}}) = GradientNumber{N,T,C}
             # -------------------------
             # | 2 | 4 | 5 | 6 | x | x |
             # -------------------------
+
             for offset in M:M:(xlen-M)
                 col_offset = offset - M
                 for j in 1:M
@@ -161,35 +195,32 @@ gradnum_type{N,T,C}(::Type{HessianNumber{N,T,C}}) = GradientNumber{N,T,C}
                             @inbounds hessvec[row] = HessianNumber(G(x[row], partials[i+1]), hesszeros)
                         end
 
-                        chunk_result::ResultType = f(hessvec)
+                        chunk_result = f(hessvec)
 
                         for i in 1:M
                             row = row_offset + i
                             q = halfhesslen(i) + 1
-                            val = hess(chunk_result, q)
-                            @inbounds output[row, col] = val
-                            @inbounds output[col, row] = val
+                            @inbounds output_hess[hess_inds(row, col)] = hess(chunk_result, q)
                             @inbounds hessvec[row] = HessianNumber(G(x[row], gradzeros), hesszeros)
                         end
                     end
                     @inbounds hessvec[col] = HessianNumber(G(x[col], gradzeros), hesszeros)
                 end
             end
+
+            result::$ResultHess = ($ResultHess)(($ResultGrad)(value(chunk_result), output_grad), output_hess)
         end
     end
 
-    return quote 
+    return quote
         H = $H
         G = $G
-        N = npartials(H)
-        ResultType = switch_eltype(H, S)
-
         hessvec = get_workvec!(cache, HessianNumber, T, X, $C2)
         partials = get_partials!(cache, H)
         hesszeros = get_zeros!(cache, H)
         
         $body
 
-        return output::Matrix{S}
+        return ForwardDiffResult(result)
     end
 end

--- a/src/fad_api/hessian.jl
+++ b/src/fad_api/hessian.jl
@@ -213,8 +213,7 @@ gradnum_type{N,T,C}(::Type{HessianNumber{N,T,C}}) = GradientNumber{N,T,C}
     end
 
     return quote
-        H = $H
-        G = $G
+        H, G = $H, $G
         hessvec = get_workvec!(cache, HessianNumber, T, X, $C2)
         partials = get_partials!(cache, H)
         hesszeros = get_zeros!(cache, H)

--- a/src/fad_api/hessian.jl
+++ b/src/fad_api/hessian.jl
@@ -12,7 +12,7 @@
     elseif A <: AllInfo
         return_stmt = :(hessian!(output, result)::Matrix{T}, result)
     else
-        error("invalid argument $A passed to FowardDiff.gradient")
+        error("invalid argument $A passed to FowardDiff.hessian")
     end
 
     return quote
@@ -29,7 +29,7 @@ end
     elseif A <: AllInfo
         return_stmt = :(hessian(result)::Matrix{T}, result)
     else
-        error("invalid argument $A passed to FowardDiff.gradient")
+        error("invalid argument $A passed to FowardDiff.hessian")
     end
 
     return quote

--- a/src/fad_api/jacobian.jl
+++ b/src/fad_api/jacobian.jl
@@ -75,7 +75,7 @@ end
                                                         cache::ForwardDiffCache)
     check_chunk_size(xlen, chunk_size)
     G = workvec_eltype(GradientNumber, T, Val{xlen}, Val{chunk_size})
-    if chunk_size_matches_full(xlen, chunk_size)
+    if chunk_size_matches_vec_mode(xlen, chunk_size)
         # Vector-Mode
         ResultType = switch_eltype(G, S)
         body = quote

--- a/src/fad_api/jacobian.jl
+++ b/src/fad_api/jacobian.jl
@@ -9,7 +9,7 @@
                                    cache::ForwardDiffCache=dummy_cache)
     if A <: Void
         return_stmt = :(jacobian!(output, result)::Matrix{T})
-    elseif A <: AllInfo
+    elseif A <: AllResults
         return_stmt = :(jacobian!(output, result)::Matrix{T}, result)
     else
         error("invalid argument $A passed to FowardDiff.jacobian")
@@ -26,7 +26,7 @@ end
                                   cache::ForwardDiffCache=dummy_cache)
     if A <: Void
         return_stmt = :(jacobian(result)::Matrix{T})
-    elseif A <: AllInfo
+    elseif A <: AllResults
         return_stmt = :(jacobian(result)::Matrix{T}, result)
     else
         error("invalid argument $A passed to FowardDiff.jacobian")

--- a/src/fad_api/jacobian.jl
+++ b/src/fad_api/jacobian.jl
@@ -4,155 +4,122 @@
 
 # Exposed API methods #
 #---------------------#
-function jacobian!{T}(output::Matrix{T},
-                      f,
-                      x::Vector;
-                      chunk_size::Int=default_chunk_size,
-                      cache::ForwardDiffCache=dummy_cache)
-    xlen = length(x)
-    @assert xlen == size(output, 2) "The output matrix must have a number of columns equal to the length of the input vector"
-    return _calc_jacobian!(output, f, x, Val{xlen}, Val{chunk_size}, cache)::Matrix{T}
-end
-
-function jacobian{T}(f,
-                     x::Vector{T};
-                     chunk_size::Int=default_chunk_size,
-                     cache::ForwardDiffCache=dummy_cache)
-    return _calc_jacobian(f, x, Val{length(x)}, Val{chunk_size}, cache)::Matrix{T}
-end
-
-function jacobian(f; mutates=false)
-    cache = ForwardDiffCache()
-    if mutates
-        function jacf!{T}(output::Matrix{T}, x::Vector; chunk_size::Int=default_chunk_size)
-            return ForwardDiff.jacobian!(output, f, x, chunk_size=chunk_size, cache=cache)::Matrix{T}
-        end
-        return jacf!
+@generated function jacobian!{T,A}(output::Matrix{T}, f, x::Vector, ::Type{A}=Void;
+                                   chunk_size::Int=default_chunk_size,
+                                   cache::ForwardDiffCache=dummy_cache)
+    if A <: Void
+        return_stmt = :(jacobian!(output, result)::Matrix{T})
+    elseif A <: AllInfo
+        return_stmt = :(jacobian!(output, result)::Matrix{T}, result)
     else
-        function jacf{T}(x::Vector{T}; chunk_size::Int=default_chunk_size)
-            return ForwardDiff.jacobian(f, x, chunk_size=chunk_size, cache=cache)::Matrix{T}
+        error("invalid argument $A passed to FowardDiff.gradient")
+    end
+
+    return quote
+        result = _calc_jacobian(f, x, T, chunk_size, cache)
+        return $return_stmt
+    end
+end
+
+@generated function jacobian{T,A}(f, x::Vector{T}, ::Type{A}=Void;
+                                  chunk_size::Int=default_chunk_size,
+                                  cache::ForwardDiffCache=dummy_cache)
+    if A <: Void
+        return_stmt = :(jacobian(result)::Matrix{T})
+    elseif A <: AllInfo
+        return_stmt = :(jacobian(result)::Matrix{T}, result)
+    else
+        error("invalid argument $A passed to FowardDiff.gradient")
+    end
+
+    return quote
+        result = _calc_jacobian(f, x, T, chunk_size, cache)
+        return $return_stmt
+    end
+end
+
+function jacobian{A}(f, ::Type{A}=Void;
+                     mutates::Bool=false,
+                     chunk_size::Int=default_chunk_size,
+                     cache::ForwardDiffCache=ForwardDiffCache())
+    if mutates
+        function j!(output::Matrix, x::Vector)
+            return ForwardDiff.jacobian!(output, f, x, A;
+                                         chunk_size=chunk_size,
+                                         cache=cache)
         end
-        return jacf
+        return j!
+    else
+        function j(x::Vector)
+            return ForwardDiff.jacobian(f, x, A;
+                                        chunk_size=chunk_size,
+                                        cache=cache)
+        end
+        return j
     end
 end
 
 # Calculate Jacobian of a given function #
 #----------------------------------------#
-@generated function _calc_jacobian!{S,T,xlen,chunk_size}(output::Matrix{S}, f, x::Vector{T}, 
-                                                         X::Type{Val{xlen}}, C::Type{Val{chunk_size}},
-                                                         cache::ForwardDiffCache)
-    check_chunk_size(xlen, chunk_size)
-
-    full_bool = chunk_size_matches_full(xlen, chunk_size)
-    G = workvec_eltype(GradientNumber, T, Val{xlen}, Val{chunk_size})
-
-    if full_bool
-        body = quote
-            @simd for i in eachindex(x)
-                @inbounds gradvec[i] = G(x[i], partials[i])
-            end
-
-            result::Vector{ResultType} = f(gradvec)
-
-            for i in eachindex(result), j in eachindex(x)
-                output[i,j] = grad(result[i], j)
-            end
-        end
-    else
-        body = quote
-            gradzeros = get_zeros!(cache, G)
-
-            @simd for i in eachindex(x)
-                @inbounds gradvec[i] = G(x[i], gradzeros)
-            end
-
-            for i in 1:N:xlen
-                offset = i-1
-
-                @simd for j in 1:N
-                    m = j+offset
-                    @inbounds gradvec[m] = G(x[m], partials[j])
-                end
-                
-                chunk_result::Vector{ResultType} = f(gradvec)
-
-                for j in 1:N
-                    m = j+offset
-                    for n in 1:size(output,1)
-                        @inbounds output[n,m] = grad(chunk_result[n], j)
-                    end
-                    @inbounds gradvec[m] = G(x[m], gradzeros)
-                end
-            end
-        end
-    end
-
-    return quote
-        G = $G
-        N = npartials(G)
-        ResultType = switch_eltype(G, S)
-
-        gradvec = get_workvec!(cache, GradientNumber, T, X, C)
-        partials = get_partials!(cache, G)
-        
-        $body
-
-        return output::Matrix{S}
-    end
+function _calc_jacobian{S}(f, x::Vector, ::Type{S},
+                           chunk_size::Int,
+                           cache::ForwardDiffCache)
+    X = Val{length(x)}
+    C = Val{chunk_size}
+    return _calc_jacobian(f, x, S, X, C, cache)
 end
 
-@generated function _calc_jacobian{T,xlen,chunk_size}(f, x::Vector{T}, 
-                                                      X::Type{Val{xlen}}, C::Type{Val{chunk_size}},
-                                                      cache::ForwardDiffCache)
+@generated function _calc_jacobian{T,S,xlen,chunk_size}(f, x::Vector{T}, ::Type{S},
+                                                        X::Type{Val{xlen}},
+                                                        C::Type{Val{chunk_size}},
+                                                        cache::ForwardDiffCache)
     check_chunk_size(xlen, chunk_size)
-
-    full_bool = chunk_size_matches_full(xlen, chunk_size)
     G = workvec_eltype(GradientNumber, T, Val{xlen}, Val{chunk_size})
-
-    if full_bool
+    if chunk_size_matches_full(xlen, chunk_size)
+        # Vector-Mode
+        ResultType = switch_eltype(G, S)
         body = quote
             @simd for i in eachindex(x)
                 @inbounds gradvec[i] = G(x[i], partials[i])
             end
 
-            result::Vector{ResultType} = f(gradvec)
-
-            output = Array(T, length(result), length(x))
-
-            for i in eachindex(result), j in eachindex(x)
-                output[i,j] = grad(result[i], j)
-            end
+            result::Vector{$ResultType} = f(gradvec)
         end
     else
+        # Chunk-Mode
+        ChunkType = switch_eltype(G, S)
+        ResultType = GradientNumber{xlen,S,Vector{S}}
         body = quote
+            N = npartials(G)
             gradzeros = get_zeros!(cache, G)
-            
+
             @simd for i in eachindex(x)
                 @inbounds gradvec[i] = G(x[i], gradzeros)
             end
 
-            # Perform the first chunk "manually" so that
-            # we get to inspect the size of the output
-            @simd for j in 1:N
-                m = j
-                @inbounds gradvec[m] = G(x[m], partials[j])
-            end
-            
-            first_result::Vector{ResultType} = f(gradvec)
+            # Perform the first chunk "manually" to retrieve
+            # the info we need to build our output
 
-            # Now that we know the shape of the first result,
-            # we can construct an output matrix
-            output = Array(T, length(first_result), xlen)
+            @simd for i in 1:N
+                @inbounds gradvec[i] = G(x[i], partials[i])
+            end
+
+            first_result::Vector{$ChunkType} = f(gradvec)
+
+            nrows, ncols = length(first_result), xlen
+            output = Vector{S}[Vector{S}(ncols) for i in 1:nrows]
 
             for j in 1:N
-                m = j
-                for n in 1:size(output,1)
-                    @inbounds output[n,m] = grad(first_result[n], j)
+                @simd for i in 1:nrows
+                    @inbounds output[i][j] = grad(first_result[i], j)
                 end
-                @inbounds gradvec[m] = G(x[m], gradzeros)
+                @inbounds gradvec[j] = G(x[j], gradzeros)
             end
 
-            # Perform the rest of the chunks, filling in the output matrix
+            # Perform the rest of the chunks, filling in the output as we go
+
+            local chunk_result::Vector{$ChunkType}
+
             for i in (N+1):N:xlen
                 offset = i-1
 
@@ -161,29 +128,32 @@ end
                     @inbounds gradvec[m] = G(x[m], partials[j])
                 end
                 
-                chunk_result::Vector{ResultType} = f(gradvec)
+                chunk_result = f(gradvec)
 
                 for j in 1:N
                     m = j+offset
-                    for n in 1:size(output,1)
-                        @inbounds output[n,m] = grad(chunk_result[n], j)
+                    @simd for n in 1:nrows
+                        @inbounds output[n][m] = grad(chunk_result[n], j)
                     end
                     @inbounds gradvec[m] = G(x[m], gradzeros)
                 end
+            end
+
+            result = Vector{$ResultType}(nrows)
+
+            @simd for i in eachindex(result)
+                @inbounds result[i] = ($ResultType)(value(chunk_result[i]), output[i])
             end
         end
     end
 
     return quote
         G = $G
-        N = npartials(G)
-        ResultType = G
-
         gradvec = get_workvec!(cache, GradientNumber, T, X, C)
         partials = get_partials!(cache, G)
-        
+
         $body
 
-        return output::Matrix{T}
+        return ForwardDiffResult(result)
     end
 end

--- a/src/fad_api/jacobian.jl
+++ b/src/fad_api/jacobian.jl
@@ -12,7 +12,7 @@
     elseif A <: AllInfo
         return_stmt = :(jacobian!(output, result)::Matrix{T}, result)
     else
-        error("invalid argument $A passed to FowardDiff.gradient")
+        error("invalid argument $A passed to FowardDiff.jacobian")
     end
 
     return quote
@@ -29,7 +29,7 @@ end
     elseif A <: AllInfo
         return_stmt = :(jacobian(result)::Matrix{T}, result)
     else
-        error("invalid argument $A passed to FowardDiff.gradient")
+        error("invalid argument $A passed to FowardDiff.jacobian")
     end
 
     return quote

--- a/src/fad_api/tensor.jl
+++ b/src/fad_api/tensor.jl
@@ -12,7 +12,7 @@
     elseif A <: AllInfo
         return_stmt = :(tensor!(output, result)::Array{T,3}, result)
     else
-        error("invalid argument $A passed to FowardDiff.gradient")
+        error("invalid argument $A passed to FowardDiff.tensor")
     end
 
     return quote
@@ -29,7 +29,7 @@ end
     elseif A <: AllInfo
         return_stmt = :(tensor(result)::Array{T,3}, result)
     else
-        error("invalid argument $A passed to FowardDiff.gradient")
+        error("invalid argument $A passed to FowardDiff.tensor")
     end
 
     return quote

--- a/src/fad_api/tensor.jl
+++ b/src/fad_api/tensor.jl
@@ -9,7 +9,7 @@
                                  cache::ForwardDiffCache=dummy_cache)
     if A <: Void
         return_stmt = :(tensor!(output, result)::Array{T,3})
-    elseif A <: AllInfo
+    elseif A <: AllResults
         return_stmt = :(tensor!(output, result)::Array{T,3}, result)
     else
         error("invalid argument $A passed to FowardDiff.tensor")
@@ -26,7 +26,7 @@ end
                                 cache::ForwardDiffCache=dummy_cache)
     if A <: Void
         return_stmt = :(tensor(result)::Array{T,3})
-    elseif A <: AllInfo
+    elseif A <: AllResults
         return_stmt = :(tensor(result)::Array{T,3}, result)
     else
         error("invalid argument $A passed to FowardDiff.tensor")

--- a/src/fad_api/tensor.jl
+++ b/src/fad_api/tensor.jl
@@ -4,106 +4,106 @@
 
 # Exposed API methods #
 #---------------------#
-function tensor!{T}(output::Array{T,3},
-                    f,
-                    x::Vector;
-                    chunk_size::Int=default_chunk_size,
-                    cache::ForwardDiffCache=dummy_cache)
-    xlen = length(x)
-    @assert (xlen, xlen, xlen) == size(output) "The output array must have size (length(input), length(input), length(input))"
-    return _calc_tensor!(output, f, x, Val{xlen}, Val{chunk_size}, cache)::Array{T,3}
-end
-
-function tensor{T}(f,
-                   x::Vector{T};
-                   chunk_size::Int=default_chunk_size,
-                   cache::ForwardDiffCache=dummy_cache)
-    xlen = length(x)
-    output = similar(x, xlen, xlen, xlen)
-    return _calc_tensor!(output, f, x, Val{xlen}, Val{chunk_size}, cache)::Array{T,3}
-end
-
-function tensor(f; mutates=false)
-    cache = ForwardDiffCache()
-    if mutates
-        function tensf!{T}(output::Array{T,3}, x::Vector; chunk_size::Int=default_chunk_size)
-            return ForwardDiff.tensor!(output, f, x, chunk_size=chunk_size, cache=cache)::Array{T,3}
-        end
-        return tensf!
+@generated function tensor!{T,A}(output::Array{T,3}, f, x::Vector, ::Type{A}=Void;
+                                 chunk_size::Int=default_chunk_size,
+                                 cache::ForwardDiffCache=dummy_cache)
+    if A <: Void
+        return_stmt = :(tensor!(output, result)::Array{T,3})
+    elseif A <: AllInfo
+        return_stmt = :(tensor!(output, result)::Array{T,3}, result)
     else
-        function tensf{T}(x::Vector{T}; chunk_size::Int=default_chunk_size)
-            return ForwardDiff.tensor(f, x, chunk_size=chunk_size, cache=cache)::Array{T,3}
+        error("invalid argument $A passed to FowardDiff.gradient")
+    end
+
+    return quote
+        result = _calc_tensor(f, x, T, chunk_size, cache)
+        return $return_stmt
+    end
+end
+
+@generated function tensor{T,A}(f, x::Vector{T}, ::Type{A}=Void;
+                                chunk_size::Int=default_chunk_size,
+                                cache::ForwardDiffCache=dummy_cache)
+    if A <: Void
+        return_stmt = :(tensor(result)::Array{T,3})
+    elseif A <: AllInfo
+        return_stmt = :(tensor(result)::Array{T,3}, result)
+    else
+        error("invalid argument $A passed to FowardDiff.gradient")
+    end
+
+    return quote
+        result = _calc_tensor(f, x, T, chunk_size, cache)
+        return $return_stmt
+    end
+end
+
+function tensor{A}(f, ::Type{A}=Void;
+                    mutates::Bool=false,
+                    chunk_size::Int=default_chunk_size,
+                    cache::ForwardDiffCache=ForwardDiffCache())
+    if mutates
+        function t!(output::Array, x::Vector)
+            return ForwardDiff.tensor!(output, f, x, A;
+                                       chunk_size=chunk_size,
+                                       cache=cache)
         end
-        return tensf
+        return t!
+    else
+        function t(x::Vector)
+            return ForwardDiff.tensor(f, x, A;
+                                      chunk_size=chunk_size,
+                                      cache=cache)
+        end
+        return t
     end
 end
 
 # Calculate third order Taylor series term of a given function #
 #--------------------------------------------------------------#
+function _calc_tensor{S}(f, x::Vector, ::Type{S},
+                         chunk_size::Int,
+                         cache::ForwardDiffCache)
+    X = Val{length(x)}
+    C = Val{chunk_size}
+    return _calc_tensor(f, x, S, X, C, cache)
+end
+
 hessnum_type{N,T,C}(::Type{TensorNumber{N,T,C}}) = HessianNumber{N,T,C}
 
-@generated function _calc_tensor!{S,T,xlen,chunk_size}(output::Array{S,3}, f, x::Vector{T}, 
-                                                       X::Type{Val{xlen}}, C::Type{Val{chunk_size}},
-                                                       cache::ForwardDiffCache)
+@generated function _calc_tensor{T,S,xlen,chunk_size}(f, x::Vector{T}, ::Type{S},
+                                                      X::Type{Val{xlen}},
+                                                      C::Type{Val{chunk_size}},
+                                                      cache::ForwardDiffCache)
     check_chunk_size(xlen, chunk_size)
-    full_bool = chunk_size_matches_vec_mode(xlen, chunk_size)
-    
+
     F = workvec_eltype(TensorNumber, T, Val{xlen}, Val{chunk_size})
     H = hessnum_type(F)
     G = gradnum_type(H)
 
-    if full_bool
+    if chunk_size_matches_vec_mode(xlen, chunk_size)
+        # Vector-Mode
+        ResultType = switch_eltype(F, S)
         body = quote
             @simd for i in eachindex(x)
                 @inbounds tensvec[i] = TensorNumber(H(G(x[i], partials[i]), hesszeros), tenszeros)
             end
 
-            result::ResultType = f(tensvec)
-
-            q = 1
-            for i in 1:N
-                for j in i:N
-                    for k in i:j
-                        @inbounds output[j, k, i] = tens(result, q)::S
-                        q += 1
-                    end
-                end
-                for j in 1:(i-1)
-                    for k in 1:j
-                        @inbounds output[j, k, i] = output[i, j, k]
-                    end
-                end    
-                for j in i:N
-                    for k in 1:(i-1)
-                        @inbounds output[j, k, i] = output[i, j, k]
-                    end
-                end
-                for j in 1:N
-                    for k in (j+1):N
-                        @inbounds output[j, k, i] = output[k, j, i]
-                    end
-                end
-            end
+            result::$ResultType = f(tensvec)
         end
     else
         error("chunk_size configuration for ForwardDiff.tensor is not yet supported")
     end
 
     return quote
-
-        F = $F
-        H = $H
-        G = $G
-        N = npartials(F)
-        ResultType = switch_eltype(F, S)
-
+        F, H, G = $F, $H, $G
         tensvec = get_workvec!(cache, TensorNumber, T, X, C)
         partials = get_partials!(cache, F)
         tenszeros = get_zeros!(cache, F)
         hesszeros = get_zeros!(cache, H)
-        
+
         $body
 
-        return output::Array{S,3}
+        return ForwardDiffResult(result)
     end
 end

--- a/src/fad_api/tensor.jl
+++ b/src/fad_api/tensor.jl
@@ -46,7 +46,7 @@ hessnum_type{N,T,C}(::Type{TensorNumber{N,T,C}}) = HessianNumber{N,T,C}
                                                        X::Type{Val{xlen}}, C::Type{Val{chunk_size}},
                                                        cache::ForwardDiffCache)
     check_chunk_size(xlen, chunk_size)
-    full_bool = chunk_size_matches_full(xlen, chunk_size)
+    full_bool = chunk_size_matches_vec_mode(xlen, chunk_size)
     
     F = workvec_eltype(TensorNumber, T, Val{xlen}, Val{chunk_size})
     H = hessnum_type(F)

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -46,11 +46,11 @@ for fsym in ForwardDiff.fad_supported_univar_funcs
             end
 
             @test_approx_eq deriv_result ForwardDiff.derivative(testdf, x)
-            testout, result = ForwardDiff.derivative(testdf, x, AllInfo)
+            testout, result = ForwardDiff.derivative(testdf, x, AllResults)
             test_all_results(testout, result)
 
             @test_approx_eq deriv_result ForwardDiff.derivative(testdf)(x)
-            testout2, result2 = ForwardDiff.derivative(testdf, AllInfo)(x)
+            testout2, result2 = ForwardDiff.derivative(testdf, AllResults)(x)
             test_all_results(testout2, result2)
 
             testdf_arr = t -> [testdf(t) for i in 1:N, j in 1:M, k in 1:L]
@@ -64,11 +64,11 @@ for fsym in ForwardDiff.fad_supported_univar_funcs
             end
 
             test_approx_deriv(deriv_result_arr, ForwardDiff.derivative(testdf_arr, x))
-            testout, result = ForwardDiff.derivative(testdf_arr, x, AllInfo)
+            testout, result = ForwardDiff.derivative(testdf_arr, x, AllResults)
             test_all_results(testout, result)
 
             test_approx_deriv(deriv_result_arr, ForwardDiff.derivative(testdf_arr)(x))
-            testout2, result2 = ForwardDiff.derivative(testdf_arr, AllInfo)(x)
+            testout2, result2 = ForwardDiff.derivative(testdf_arr, AllResults)(x)
             test_all_results(testout2, result2)
 
             testout = similar(testout)
@@ -76,7 +76,7 @@ for fsym in ForwardDiff.fad_supported_univar_funcs
             test_approx_deriv(deriv_result_arr, testout)
 
             testout = similar(testout)
-            results = ForwardDiff.derivative!(testout, testdf_arr, x, AllInfo)
+            results = ForwardDiff.derivative!(testout, testdf_arr, x, AllResults)
             test_all_results(testout, results[2])
 
             testout = similar(testout)
@@ -84,7 +84,7 @@ for fsym in ForwardDiff.fad_supported_univar_funcs
             test_approx_deriv(deriv_result_arr, testout)
 
             testout = similar(testout)
-            results2 = ForwardDiff.derivative(testdf_arr, AllInfo; mutates=true)(testout, x)
+            results2 = ForwardDiff.derivative(testdf_arr, AllResults; mutates=true)(testout, x)
             test_all_results(testout, results[2])
         end
     catch err

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -22,7 +22,7 @@ function deriv_test_x(fsym)
     return rand(randrange)
 end
 
-function test_approx_deriv(a, b)
+function test_approx_deriv(a::Array, b::Array)
     @assert length(a) == length(b)
     for i in eachindex(a)
         @test_approx_eq a[i] b[i]
@@ -36,17 +36,56 @@ for fsym in ForwardDiff.fad_supported_univar_funcs
         @eval begin 
             x = deriv_test_x($fsym)
             testdf = x -> $func_expr
-            result = $deriv
-            
-            @test_approx_eq result ForwardDiff.derivative(testdf, x)
-            @test_approx_eq result ForwardDiff.derivative(testdf)(x)
+            val_result = testdf(x)
+            deriv_result = $deriv
+
+            test_all_results = (testout, results) -> begin
+                @test_approx_eq ForwardDiff.value(results) val_result
+                @test_approx_eq ForwardDiff.derivative(results) deriv_result
+                @test_approx_eq testout deriv_result
+            end
+
+            @test_approx_eq deriv_result ForwardDiff.derivative(testdf, x)
+            testout, result = ForwardDiff.derivative(testdf, x, AllInfo)
+            test_all_results(testout, result)
+
+            @test_approx_eq deriv_result ForwardDiff.derivative(testdf)(x)
+            testout2, result2 = ForwardDiff.derivative(testdf, AllInfo)(x)
+            test_all_results(testout2, result2)
 
             testdf_arr = t -> [testdf(t) for i in 1:N, j in 1:M, k in 1:L]
-            result_arr = [result for i in 1:N, j in 1:M, k in 1:L]
+            val_result_arr = [val_result for i in 1:N, j in 1:M, k in 1:L]
+            deriv_result_arr = [deriv_result for i in 1:N, j in 1:M, k in 1:L]
 
-            test_approx_deriv(result_arr, ForwardDiff.derivative(testdf_arr, x))
-            test_approx_deriv(result_arr, ForwardDiff.derivative(testdf_arr)(x))
-            test_approx_deriv(result_arr, ForwardDiff.derivative!(testout, testdf_arr, x))
+            test_all_results = (testout, results) -> begin
+                test_approx_deriv(ForwardDiff.value(results), val_result_arr)
+                test_approx_deriv(ForwardDiff.derivative(results), deriv_result_arr)
+                test_approx_deriv(testout, deriv_result_arr)
+            end
+
+            test_approx_deriv(deriv_result_arr, ForwardDiff.derivative(testdf_arr, x))
+            testout, result = ForwardDiff.derivative(testdf_arr, x, AllInfo)
+            test_all_results(testout, result)
+
+            test_approx_deriv(deriv_result_arr, ForwardDiff.derivative(testdf_arr)(x))
+            testout2, result2 = ForwardDiff.derivative(testdf_arr, AllInfo)(x)
+            test_all_results(testout2, result2)
+
+            testout = similar(testout)
+            ForwardDiff.derivative!(testout, testdf_arr, x)
+            test_approx_deriv(deriv_result_arr, testout)
+
+            testout = similar(testout)
+            results = ForwardDiff.derivative!(testout, testdf_arr, x, AllInfo)
+            test_all_results(testout, results[2])
+
+            testout = similar(testout)
+            ForwardDiff.derivative(testdf_arr; mutates=true)(testout, x)
+            test_approx_deriv(deriv_result_arr, testout)
+
+            testout = similar(testout)
+            results2 = ForwardDiff.derivative(testdf_arr, AllInfo; mutates=true)(testout, x)
+            test_all_results(testout, results[2])
         end
     catch err
         error("Failure when testing derivative of $fsym: $err")

--- a/test/test_gradients.jl
+++ b/test/test_gradients.jl
@@ -256,8 +256,8 @@ for fsym in map(first, Calculus.symbolic_derivatives_1arg())
     for chunk in chunk_sizes
         try
             testx = grad_test_x(fsym, N)
-            grad_result = grad_test_result(testexpr, testx)
             val_result = testf(testx)
+            grad_result = grad_test_result(testexpr, testx)
 
             # Non-AllInfo
             test_grad = (testout) -> @test_approx_eq testout grad_result
@@ -277,9 +277,9 @@ for fsym in map(first, Calculus.symbolic_derivatives_1arg())
 
             # AllInfo
             test_all_results = (testout, results) -> begin
-                test_grad(testout)
-                test_grad(ForwardDiff.gradient(results))
                 @test_approx_eq ForwardDiff.value(results) val_result
+                test_grad(ForwardDiff.gradient(results))
+                test_grad(testout)
             end
 
             testout = similar(testout)

--- a/test/test_gradients.jl
+++ b/test/test_gradients.jl
@@ -259,7 +259,7 @@ for fsym in map(first, Calculus.symbolic_derivatives_1arg())
             val_result = testf(testx)
             grad_result = grad_test_result(testexpr, testx)
 
-            # Non-AllInfo
+            # Non-AllResults
             test_grad = (testout) -> @test_approx_eq testout grad_result
 
             ForwardDiff.gradient!(testout, testf, testx; chunk_size=chunk)
@@ -275,7 +275,7 @@ for fsym in map(first, Calculus.symbolic_derivatives_1arg())
             gradf = ForwardDiff.gradient(testf; mutates=false, chunk_size=chunk)
             test_grad(gradf(testx))
 
-            # AllInfo
+            # AllResults
             test_all_results = (testout, results) -> begin
                 @test_approx_eq ForwardDiff.value(results) val_result
                 test_grad(ForwardDiff.gradient(results))
@@ -283,19 +283,19 @@ for fsym in map(first, Calculus.symbolic_derivatives_1arg())
             end
 
             testout = similar(testout)
-            results = ForwardDiff.gradient!(testout, testf, testx, AllInfo; chunk_size=chunk)
+            results = ForwardDiff.gradient!(testout, testf, testx, AllResults; chunk_size=chunk)
             test_all_results(testout, results[2])
 
             testout = similar(testout)
-            testout, results2 = ForwardDiff.gradient(testf, testx, AllInfo; chunk_size=chunk)
+            testout, results2 = ForwardDiff.gradient(testf, testx, AllResults; chunk_size=chunk)
             test_all_results(testout, results2)
 
-            gradf! = ForwardDiff.gradient(testf, AllInfo; mutates=true, chunk_size=chunk)
+            gradf! = ForwardDiff.gradient(testf, AllResults; mutates=true, chunk_size=chunk)
             testout = similar(testout)
             results3 = gradf!(testout, testx)
             test_all_results(testout, results3[2])
 
-            gradf = ForwardDiff.gradient(testf, AllInfo; mutates=false, chunk_size=chunk)
+            gradf = ForwardDiff.gradient(testf, AllResults; mutates=false, chunk_size=chunk)
             testout = similar(testout)
             testout, results4 = gradf(testx)
             test_all_results(testout, results4)

--- a/test/test_gradients.jl
+++ b/test/test_gradients.jl
@@ -256,18 +256,50 @@ for fsym in map(first, Calculus.symbolic_derivatives_1arg())
     for chunk in chunk_sizes
         try
             testx = grad_test_x(fsym, N)
-            testresult = grad_test_result(testexpr, testx)
+            grad_result = grad_test_result(testexpr, testx)
+            val_result = testf(testx)
+            
+            # Non-AllInfo
+            test_grad = (testout) -> @test_approx_eq testout grad_result
 
             ForwardDiff.gradient!(testout, testf, testx; chunk_size=chunk)
-            @test_approx_eq testout testresult
-            @test_approx_eq ForwardDiff.gradient(testf, testx, chunk_size=chunk) testresult
+            test_grad(testout)
 
-            gradf! = ForwardDiff.gradient(testf, mutates=true, chunk_size=chunk)
+            test_grad(ForwardDiff.gradient(testf, testx; chunk_size=chunk))
+            
+            gradf! = ForwardDiff.gradient(testf; mutates=true, chunk_size=chunk)
+            testout = similar(testout)
             gradf!(testout, testx)
-            @test_approx_eq testout testresult
+            test_grad(testout)
 
-            gradf = ForwardDiff.gradient(testf, mutates=false, chunk_size=chunk)
-            @test_approx_eq gradf(testx) testresult
+            gradf = ForwardDiff.gradient(testf; mutates=false, chunk_size=chunk)
+            test_grad(gradf(testx))
+
+            # AllInfo
+            test_all_results = (testout, results) -> begin
+                test_grad(testout)
+                test_grad(ForwardDiff.gradient(results))
+                @test_approx_eq ForwardDiff.value(results) val_result
+            end
+
+            testout = similar(testout)
+            results = ForwardDiff.gradient!(testout, testf, testx, AllInfo; chunk_size=chunk)
+            test_all_results(testout, results[2])
+
+            testout = similar(testout)
+            testout, results2 = ForwardDiff.gradient(testf, testx, AllInfo; chunk_size=chunk)
+            test_all_results(testout, results2)
+
+            gradf! = ForwardDiff.gradient(testf, AllInfo; mutates=true, chunk_size=chunk)
+            testout = similar(testout)
+            results3 = gradf!(testout, testx)
+            test_all_results(testout, results3[2])
+
+            gradf = ForwardDiff.gradient(testf, AllInfo; mutates=false, chunk_size=chunk)
+            testout = similar(testout)
+            testout, results4 = gradf(testx)
+            test_all_results(testout, results4)
+
         catch err
             warn("Failure when testing gradients involving $fsym with chunk_size=$chunk:")
             throw(err)

--- a/test/test_gradients.jl
+++ b/test/test_gradients.jl
@@ -258,7 +258,7 @@ for fsym in map(first, Calculus.symbolic_derivatives_1arg())
             testx = grad_test_x(fsym, N)
             grad_result = grad_test_result(testexpr, testx)
             val_result = testf(testx)
-            
+
             # Non-AllInfo
             test_grad = (testout) -> @test_approx_eq testout grad_result
 
@@ -266,7 +266,7 @@ for fsym in map(first, Calculus.symbolic_derivatives_1arg())
             test_grad(testout)
 
             test_grad(ForwardDiff.gradient(testf, testx; chunk_size=chunk))
-            
+
             gradf! = ForwardDiff.gradient(testf; mutates=true, chunk_size=chunk)
             testout = similar(testout)
             gradf!(testout, testx)
@@ -299,7 +299,6 @@ for fsym in map(first, Calculus.symbolic_derivatives_1arg())
             testout = similar(testout)
             testout, results4 = gradf(testx)
             test_all_results(testout, results4)
-
         catch err
             warn("Failure when testing gradients involving $fsym with chunk_size=$chunk:")
             throw(err)

--- a/test/test_gradients.jl
+++ b/test/test_gradients.jl
@@ -262,12 +262,12 @@ for fsym in map(first, Calculus.symbolic_derivatives_1arg())
             @test_approx_eq testout testresult
             @test_approx_eq ForwardDiff.gradient(testf, testx, chunk_size=chunk) testresult
 
-            gradf! = ForwardDiff.gradient(testf, mutates=true)
-            gradf!(testout, testx, chunk_size=chunk)
+            gradf! = ForwardDiff.gradient(testf, mutates=true, chunk_size=chunk)
+            gradf!(testout, testx)
             @test_approx_eq testout testresult
 
-            gradf = ForwardDiff.gradient(testf, mutates=false)
-            @test_approx_eq gradf(testx, chunk_size=chunk) testresult
+            gradf = ForwardDiff.gradient(testf, mutates=false, chunk_size=chunk)
+            @test_approx_eq gradf(testx) testresult
         catch err
             warn("Failure when testing gradients involving $fsym with chunk_size=$chunk:")
             throw(err)

--- a/test/test_hessians.jl
+++ b/test/test_hessians.jl
@@ -229,7 +229,7 @@ chunk_sizes = (ForwardDiff.default_chunk_size, 2, Int(N/2), N)
 for fsym in ForwardDiff.univar_hess_funcs
     testexpr = :($(fsym)(a) + $(fsym)(b) - $(fsym)(c) * $(fsym)(l) - $(fsym)(m) + $(fsym)(r)) 
 
-    @eval function testf(x::Vector) 
+    @eval function testf(x::Vector)
         a,b,c,l,m,r = x
         return $testexpr
     end

--- a/test/test_hessians.jl
+++ b/test/test_hessians.jl
@@ -241,7 +241,7 @@ for fsym in ForwardDiff.univar_hess_funcs
             grad_result = ForwardDiff.gradient(testf, testx)
             hess_result = hess_test_result(testexpr, testx)
 
-            # Non-AllInfo
+            # Non-AllResults
             test_hess = (testout) -> @test_approx_eq testout hess_result
 
             ForwardDiff.hessian!(testout, testf, testx; chunk_size=chunk)
@@ -257,7 +257,7 @@ for fsym in ForwardDiff.univar_hess_funcs
             hessf = ForwardDiff.hessian(testf; mutates=false, chunk_size=chunk)
             test_hess(hessf(testx))
 
-            # AllInfo
+            # AllResults
             test_all_results = (testout, results) -> begin
                 @test_approx_eq ForwardDiff.value(results) val_result
                 @test_approx_eq ForwardDiff.gradient(results) grad_result
@@ -266,19 +266,19 @@ for fsym in ForwardDiff.univar_hess_funcs
             end
 
             testout = similar(testout)
-            results = ForwardDiff.hessian!(testout, testf, testx, AllInfo; chunk_size=chunk)
+            results = ForwardDiff.hessian!(testout, testf, testx, AllResults; chunk_size=chunk)
             test_all_results(testout, results[2])
 
             testout = similar(testout)
-            testout, results2 = ForwardDiff.hessian(testf, testx, AllInfo; chunk_size=chunk)
+            testout, results2 = ForwardDiff.hessian(testf, testx, AllResults; chunk_size=chunk)
             test_all_results(testout, results2)
 
-            hessf! = ForwardDiff.hessian(testf, AllInfo; mutates=true, chunk_size=chunk)
+            hessf! = ForwardDiff.hessian(testf, AllResults; mutates=true, chunk_size=chunk)
             testout = similar(testout)
             results3 = hessf!(testout, testx)
             test_all_results(testout, results3[2])
 
-            hessf = ForwardDiff.hessian(testf, AllInfo; mutates=false, chunk_size=chunk)
+            hessf = ForwardDiff.hessian(testf, AllResults; mutates=false, chunk_size=chunk)
             testout = similar(testout)
             testout, results4 = hessf(testx)
             test_all_results(testout, results4)

--- a/test/test_jacobians.jl
+++ b/test/test_jacobians.jl
@@ -48,8 +48,8 @@ for fsym in ForwardDiff.fad_supported_univar_funcs
     for chunk in chunk_sizes
         try
             testx = jacob_test_x(fsym, N)
-            jacob_result = jacob_test_result(testexprs, testx)
             val_result = testf(testx)
+            jacob_result = jacob_test_result(testexprs, testx)
             
             # Non-AllInfo
             test_jacob = (testout) -> @test_approx_eq testout jacob_result
@@ -69,9 +69,9 @@ for fsym in ForwardDiff.fad_supported_univar_funcs
 
             # AllInfo
             test_all_results = (testout, results) -> begin
-                test_jacob(testout)
-                test_jacob(ForwardDiff.jacobian(results))
                 @test_approx_eq ForwardDiff.value(results) val_result
+                test_jacob(ForwardDiff.jacobian(results))
+                test_jacob(testout)
             end
 
             testout = similar(testout)

--- a/test/test_jacobians.jl
+++ b/test/test_jacobians.jl
@@ -51,7 +51,7 @@ for fsym in ForwardDiff.fad_supported_univar_funcs
             val_result = testf(testx)
             jacob_result = jacob_test_result(testexprs, testx)
             
-            # Non-AllInfo
+            # Non-AllResults
             test_jacob = (testout) -> @test_approx_eq testout jacob_result
 
             ForwardDiff.jacobian!(testout, testf, testx; chunk_size=chunk)
@@ -67,7 +67,7 @@ for fsym in ForwardDiff.fad_supported_univar_funcs
             jacf = ForwardDiff.jacobian(testf; mutates=false, chunk_size=chunk)
             test_jacob(jacf(testx))
 
-            # AllInfo
+            # AllResults
             test_all_results = (testout, results) -> begin
                 @test_approx_eq ForwardDiff.value(results) val_result
                 test_jacob(ForwardDiff.jacobian(results))
@@ -75,19 +75,19 @@ for fsym in ForwardDiff.fad_supported_univar_funcs
             end
 
             testout = similar(testout)
-            results = ForwardDiff.jacobian!(testout, testf, testx, AllInfo; chunk_size=chunk)
+            results = ForwardDiff.jacobian!(testout, testf, testx, AllResults; chunk_size=chunk)
             test_all_results(testout, results[2])
 
             testout = similar(testout)
-            testout, results2 = ForwardDiff.jacobian(testf, testx, AllInfo; chunk_size=chunk)
+            testout, results2 = ForwardDiff.jacobian(testf, testx, AllResults; chunk_size=chunk)
             test_all_results(testout, results2)
 
-            jacf! = ForwardDiff.jacobian(testf, AllInfo; mutates=true, chunk_size=chunk)
+            jacf! = ForwardDiff.jacobian(testf, AllResults; mutates=true, chunk_size=chunk)
             testout = similar(testout)
             results3 = jacf!(testout, testx)
             test_all_results(testout, results3[2])
 
-            jacf = ForwardDiff.jacobian(testf, AllInfo; mutates=false, chunk_size=chunk)
+            jacf = ForwardDiff.jacobian(testf, AllResults; mutates=false, chunk_size=chunk)
             testout = similar(testout)
             testout, results4 = jacf(testx)
             test_all_results(testout, results4)

--- a/test/test_tensors.jl
+++ b/test/test_tensors.jl
@@ -257,7 +257,7 @@ for fsym in ForwardDiff.univar_tens_funcs
         hess_result = ForwardDiff.hessian(testf, testx)
         tens_result = tens_test_result(testexpr, testx)
 
-        # Non-AllInfo
+        # Non-AllResults
         test_tens = (testout) -> @test_approx_eq testout tens_result
 
         ForwardDiff.tensor!(testout, testf, testx)
@@ -273,7 +273,7 @@ for fsym in ForwardDiff.univar_tens_funcs
         tensf = ForwardDiff.tensor(testf; mutates=false)
         test_tens(tensf(testx))
 
-        # AllInfo
+        # AllResults
         test_all_results = (testout, results) -> begin
             @test_approx_eq ForwardDiff.value(results) val_result
             @test_approx_eq ForwardDiff.gradient(results) grad_result
@@ -283,19 +283,19 @@ for fsym in ForwardDiff.univar_tens_funcs
         end
 
         testout = similar(testout)
-        results = ForwardDiff.tensor!(testout, testf, testx, AllInfo)
+        results = ForwardDiff.tensor!(testout, testf, testx, AllResults)
         test_all_results(testout, results[2])
 
         testout = similar(testout)
-        testout, results2 = ForwardDiff.tensor(testf, testx, AllInfo)
+        testout, results2 = ForwardDiff.tensor(testf, testx, AllResults)
         test_all_results(testout, results2)
 
-        tensf! = ForwardDiff.tensor(testf, AllInfo; mutates=true)
+        tensf! = ForwardDiff.tensor(testf, AllResults; mutates=true)
         testout = similar(testout)
         results3 = tensf!(testout, testx)
         test_all_results(testout, results3[2])
 
-        tensf = ForwardDiff.tensor(testf, AllInfo; mutates=false)
+        tensf = ForwardDiff.tensor(testf, AllResults; mutates=false)
         testout = similar(testout)
         testout, results4 = tensf(testx)
         test_all_results(testout, results4)

--- a/test/test_tensors.jl
+++ b/test/test_tensors.jl
@@ -12,7 +12,7 @@ using ForwardDiff:
         npartials,
         isconstant,
         hessnum,
-        t_inds_2_h_ind
+        hess_inds
 
 floatrange = .01:.01:.99
 intrange = 1:10

--- a/test/test_tensors.jl
+++ b/test/test_tensors.jl
@@ -243,29 +243,64 @@ function tens_test_x(fsym, N)
 end
 
 for fsym in ForwardDiff.univar_tens_funcs
-    try 
-        testexpr = :($(fsym)(a) + $(fsym)(b) - $(fsym)(c) * $(fsym)(d))
+    testexpr = :($(fsym)(a) + $(fsym)(b) - $(fsym)(c) * $(fsym)(d))
 
-        @eval function testf(x::Vector) 
-            a,b,c,d = x
-            return $testexpr
-        end
+    @eval function testf(x::Vector)
+        a,b,c,d = x
+        return $testexpr
+    end
 
+    try
         testx = tens_test_x(fsym, N)
-        testresult = tens_test_result(testexpr, testx)
+        val_result = testf(testx)
+        grad_result = ForwardDiff.gradient(testf, testx)
+        hess_result = ForwardDiff.hessian(testf, testx)
+        tens_result = tens_test_result(testexpr, testx)
+
+        # Non-AllInfo
+        test_tens = (testout) -> @test_approx_eq testout tens_result
 
         ForwardDiff.tensor!(testout, testf, testx)
-        @test_approx_eq testout testresult
+        test_tens(testout)
 
-        @test_approx_eq ForwardDiff.tensor(testf, testx) testresult
+        test_tens(ForwardDiff.tensor(testf, testx))
 
-        tensf! = ForwardDiff.tensor(testf, mutates=true)
+        tensf! = ForwardDiff.tensor(testf; mutates=true)
+        testout = similar(testout)
         tensf!(testout, testx)
-        @test_approx_eq testout testresult
+        test_tens(testout)
 
-        tensf = ForwardDiff.tensor(testf, mutates=false)
-        @test_approx_eq tensf(testx) testresult
+        tensf = ForwardDiff.tensor(testf; mutates=false)
+        test_tens(tensf(testx))
+
+        # AllInfo
+        test_all_results = (testout, results) -> begin
+            @test_approx_eq ForwardDiff.value(results) val_result
+            @test_approx_eq ForwardDiff.gradient(results) grad_result
+            @test_approx_eq ForwardDiff.hessian(results) hess_result
+            test_tens(ForwardDiff.tensor(results))
+            test_tens(testout)
+        end
+
+        testout = similar(testout)
+        results = ForwardDiff.tensor!(testout, testf, testx, AllInfo)
+        test_all_results(testout, results[2])
+
+        testout = similar(testout)
+        testout, results2 = ForwardDiff.tensor(testf, testx, AllInfo)
+        test_all_results(testout, results2)
+
+        tensf! = ForwardDiff.tensor(testf, AllInfo; mutates=true)
+        testout = similar(testout)
+        results3 = tensf!(testout, testx)
+        test_all_results(testout, results3[2])
+
+        tensf = ForwardDiff.tensor(testf, AllInfo; mutates=false)
+        testout = similar(testout)
+        testout, results4 = tensf(testx)
+        test_all_results(testout, results4)
     catch err
-        error("Failure when testing Tensors involving $fsym: $err")
+        warn("Failure when testing Tensors involving $fsym:")
+        throw(err)
     end
 end


### PR DESCRIPTION
This PR resolves #37.

### What it does:

* Adds a `ForwardDiffResult` wrapper type which users can interact with without having to understand `ForwardDiffNumber`s

* Centralizes all result-handling methods under `ForwardDiffResult`

* If the abstract type ~~`AllInfo`~~ `AllResults` is passed in to API methods, the "full" results of the calculation are returned along with the normal output. For example:

    ```julia
    julia> using ForwardDiff
    
    julia> f(x) = 3 * sum(x)^5;
    
    julia> x = [1,2,3,4];
    
    julia> f(x)
    300000
   
    julia> ForwardDiff.gradient(f, x) # normal calling behavior is unchanged
    4-element Array{Int64,1}:
    150000
    150000
    150000
    150000

    julia> out, allresults = ForwardDiff.gradient(f, x, AllResults);
    
    julia> out
    4-element Array{Int64,1}:
    150000
    150000
    150000
    150000
    
    julia> value(allresults)
    300000
    
    julia> ForwardDiff.gradient(allresults)
    4-element Array{Int64,1}:
    150000
    150000
    150000
    150000
    ```

    ~~I don't particularly like `AllInfo` as the keyword for triggering this behavior. It's not horrible, but can anybody come up with something better?~~ I changed it to `AllResults`, which I'm still not really a fan of but can live with (unless somebody comes up with a better name).

* Not strictly necessary for this PR, but I changed the closure-generating methods so that all "configuration" now occurs in the call to the generator rather than in calls to the closures. After sitting on the old behavior for a while, this feels like the more intuitive way to do things. Also, taking optional arguments out of the closures' signatures appears to help type inference for some unknown reason.

### To Do:

- [x] Implement `ForwardDiffResult` and related methods
- [x] Refactor `derivative!`/`derivative`
- [x] Refactor `gradient!`/`gradient`
- [x] Refactor `jacobian!`/`jacobian`
- [x] Refactor `hessian!`/`hessian`
- [x] Refactor `tensor!`/`tensor`
