### PR TITLE
make norm on vectors of ForwardDiffs work

### DIFF
--- a/src/ForwardDiff.jl
+++ b/src/ForwardDiff.jl
@@ -1,5 +1,5 @@
 module ForwardDiff
-    
+
     if VERSION < v"0.4-"
         warn("ForwardDiff.jl is only officially compatible with Julia v0.4-. You're currently running Julia $VERSION.")
     end
@@ -7,11 +7,11 @@ module ForwardDiff
     import Calculus
     import NaNMath
     import Base: *, /, +, -, ^, getindex, length,
-                 hash, ==, isequal, copy, zero, 
-                 one, rand, convert, promote_rule, 
-                 read, write, isless, isreal, isnan, 
-                 isfinite, eps, conj, transpose, 
-                 ctranspose, eltype, abs, abs2, start, 
+                 hash, ==, isequal, copy, zero,
+                 one, rand, convert, promote_rule,
+                 read, write, isless, isreal, isnan,
+                 isfinite, isinf, eps, conj, transpose,
+                 ctranspose, float, eltype, abs, abs2, start,
                  next, done, atan2
 
     const supported_unary_funcs = map(first, Calculus.symbolic_derivatives_1arg())

--- a/src/ForwardDiffNumber.jl
+++ b/src/ForwardDiffNumber.jl
@@ -5,11 +5,11 @@ abstract ForwardDiffNumber{N,T<:Number,C} <: Number
 #    eltype(::Type{F}) --> T from ForwardDiffNumber{N,T,C}
 #    value(n::F) --> the value of n
 #    grad(n::F) --> a container corresponding to all first order partials
-#    hess(n::F) --> a container corresponding to the lower 
-#                   triangular half of the symmetric 
+#    hess(n::F) --> a container corresponding to the lower
+#                   triangular half of the symmetric
 #                   Hessian (including the diagonal)
-#    tens(n::F) --> a container of corresponding to lower 
-#                   tetrahedral half of the symmetric 
+#    tens(n::F) --> a container of corresponding to lower
+#                   tetrahedral half of the symmetric
 #                   Tensor (including the diagonal)
 #    isconstant(n::F) --> returns true if all partials stored by n are zero
 #
@@ -67,6 +67,7 @@ eps{F<:ForwardDiffNumber}(::Type{F}) = eps(eltype(F))
 
 isnan(n::ForwardDiffNumber) = isnan(value(n))
 isfinite(n::ForwardDiffNumber) = isfinite(value(n))
+isinf(n::ForwardDiffNumber) = isinf(value(n))
 isreal(n::ForwardDiffNumber) = isconstant(n)
 
 ##################
@@ -75,8 +76,9 @@ isreal(n::ForwardDiffNumber) = isconstant(n)
 conj(n::ForwardDiffNumber) = n
 transpose(n::ForwardDiffNumber) = n
 ctranspose(n::ForwardDiffNumber) = n
+float(n::ForwardDiffNumber) = n
 
-# NaNMath Helper Functions # 
+# NaNMath Helper Functions #
 #--------------------------#
 function to_nanmath(x::Expr)
     if x.head == :call


### PR DESCRIPTION
This fixes that `norm` on a vector of ForwardDiff numbers no longer returns a float.

Before:

```julia
a = ForwardDiff.GradientNumber{9,Float64,Tuple{Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64}}(2.0202020202020195e8,ForwardDiff.Partials{Float64,Tuple{Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64}}((1.5384615384615384e11,-7.69230769230769e10,-7.69230769230769e10,0.0,0.0,0.0,0.0,0.0,0.0)));

norm([a,a,a])

# 3.4990925405431855e8
```

Now:

```jl
norm([a,a,a])

# ForwardDiff.GradientNumber{9,Float64,Tuple{Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64}}(3.4990925405431855e8,ForwardDiff.Partials{Float64,Tuple{Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64}}((2.6646935501059653e11,-1.3323467750529822e11,-1.3323467750529822e11,0.0,0.0,0.0,0.0,0.0,0.0)))

norm(a_vec) == sqrt(dot(a_vec, a_vec))

# true
```

Maybe

```jl
float(n::ForwardDiffNumber) = n
```

should be a bit better and try to convert all components to float?
