### PR TITLE
Turn on precompilation for ForwardDiff

### DIFF
--- a/src/ForwardDiff.jl
+++ b/src/ForwardDiff.jl
@@ -1,3 +1,5 @@
+isdefined(Base, :__precompile__) && __precompile__()
+
 module ForwardDiff
 
     if VERSION < v"0.4-"


### PR DESCRIPTION
I get this when running `using ForwardDiff`:

```julia
julia> using ForwardDiff
INFO: Recompiling stale cache file /Users/jarrettrevels/.julia/lib/v0.5/ForwardDiff.ji for module ForwardDiff.
WARNING: eval from module Calculus to ForwardDiff:
Expr(:call, :/, 1, 2)::Any
  ** incremental compilation may be broken for this module **

WARNING: eval from module Calculus to ForwardDiff:
Expr(:call, :/, 1, 3)::Any
  ** incremental compilation may be broken for this module **

WARNING: eval from module Calculus to ForwardDiff:
Expr(:call, :log, 10)::Any
  ** incremental compilation may be broken for this module **

WARNING: eval from module Calculus to ForwardDiff:
Expr(:call, :log, 2)::Any
  ** incremental compilation may be broken for this module **

WARNING: eval from module Calculus to ForwardDiff:
Expr(:call, :log, 2)::Any
  ** incremental compilation may be broken for this module **
...
```

With a lot more of the same post-ellipses. Is this a side effect ForwardDiff's heavy reliance on code generation? FWIW, I already pulled johnmyleswhite/Calculus.jl#76 before running this, so it shouldn't have anything to do with Calculus precompilation AFAIK (that PR is what reminded me I should probably do this).