### PR TITLE
Disable forced inlining in arithmetic

### DIFF
--- a/src/GradientNumber.jl
+++ b/src/GradientNumber.jl
@@ -80,44 +80,44 @@ end
 
 # Addition/Subtraction #
 #----------------------#
-@inline +{N}(g1::GradientNumber{N}, g2::GradientNumber{N}) = promote_typeof(g1, g2)(value(g1)+value(g2), partials(g1)+partials(g2))
-@inline +(g::GradientNumber, x::Real) = promote_typeof(g, x)(value(g)+x, partials(g))
-@inline +(x::Real, g::GradientNumber) = g+x
++{N}(g1::GradientNumber{N}, g2::GradientNumber{N}) = promote_typeof(g1, g2)(value(g1)+value(g2), partials(g1)+partials(g2))
++(g::GradientNumber, x::Real) = promote_typeof(g, x)(value(g)+x, partials(g))
++(x::Real, g::GradientNumber) = g+x
 
-@inline -(g::GradientNumber) = typeof(g)(-value(g), -partials(g))
-@inline -{N}(g1::GradientNumber{N}, g2::GradientNumber{N}) = promote_typeof(g1, g2)(value(g1)-value(g2), partials(g1)-partials(g2))
-@inline -(g::GradientNumber, x::Real) = promote_typeof(g, x)(value(g)-x, partials(g))
-@inline -(x::Real, g::GradientNumber) = promote_typeof(g, x)(x-value(g), -partials(g))
+-(g::GradientNumber) = typeof(g)(-value(g), -partials(g))
+-{N}(g1::GradientNumber{N}, g2::GradientNumber{N}) = promote_typeof(g1, g2)(value(g1)-value(g2), partials(g1)-partials(g2))
+-(g::GradientNumber, x::Real) = promote_typeof(g, x)(value(g)-x, partials(g))
+-(x::Real, g::GradientNumber) = promote_typeof(g, x)(x-value(g), -partials(g))
 
 # Multiplication #
 #----------------#
-@inline *(g::GradientNumber, x::Bool) = x ? g : (signbit(value(g))==0 ? zero(g) : -zero(g))
-@inline *(x::Bool, g::GradientNumber) = g*x
+*(g::GradientNumber, x::Bool) = x ? g : (signbit(value(g))==0 ? zero(g) : -zero(g))
+*(x::Bool, g::GradientNumber) = g*x
 
-@inline function *{N}(g1::GradientNumber{N}, g2::GradientNumber{N})
+function *{N}(g1::GradientNumber{N}, g2::GradientNumber{N})
     a1, a2 = value(g1), value(g2)
     return promote_typeof(g1, g2)(a1*a2, _mul_partials(partials(g1), partials(g2), a2, a1))
 end
 
-@inline *(g::GradientNumber, x::Real) = promote_typeof(g, x)(value(g)*x, partials(g)*x)
-@inline *(x::Real, g::GradientNumber) = g*x
+*(g::GradientNumber, x::Real) = promote_typeof(g, x)(value(g)*x, partials(g)*x)
+*(x::Real, g::GradientNumber) = g*x
 
 # Division #
 #----------#
-@inline function /{N}(g1::GradientNumber{N}, g2::GradientNumber{N})
+function /{N}(g1::GradientNumber{N}, g2::GradientNumber{N})
     a1, a2 = value(g1), value(g2)
     div_a = a1/a2
     return promote_typeof(g1, g2, div_a)(div_a, _div_partials(partials(g1), partials(g2), a1, a2))
 end
 
-@inline function /(x::Real, g::GradientNumber)
+function /(x::Real, g::GradientNumber)
     a = value(g)
     div_a = x/a
     deriv = -(div_a/a)
     return gradnum_from_deriv(g, div_a, deriv)
 end
 
-@inline function /(g::GradientNumber, x::Real)
+function /(g::GradientNumber, x::Real)
     div_a = value(g)/x
     return promote_typeof(g, div_a)(div_a, partials(g)/x)
 end


### PR DESCRIPTION
I have a workload where I discovered that I got significantly better performance by deleting the `@inline` calls in the arithmetic functions. The workload is a little bit complicated, so I'll just show timing info. 

Using master:
```
julia> @time RegisterAffineAD.optimize_rigid(fixed, moving)

******************************************************************************
This program contains Ipopt, a library for large-scale nonlinear optimization.
 Ipopt is released as open source code under the Eclipse Public License (EPL).
         For more information visit http://projects.coin-or.org/Ipopt
******************************************************************************

  7.253977 seconds (138.38 M allocations: 7.238 GB, 20.80% gc time)
([-0.26290299117443555,-0.04562260395244045,0.09707317047564838],0.0007446994302309248)

julia> @time RegisterAffineAD.optimize_rigid(fixed, moving)
  5.894770 seconds (137.43 M allocations: 7.197 GB, 24.73% gc time)
([-0.26290299117443555,-0.04562260395244045,0.09707317047564838],0.0007446994302309248)

julia> @time RegisterAffineAD.optimize_rigid(fixed, moving)
  5.984184 seconds (137.43 M allocations: 7.197 GB, 24.45% gc time)
([-0.26290299117443555,-0.04562260395244045,0.09707317047564838],0.0007446994302309248)

julia> @time RegisterAffineAD.optimize_rigid(fixed, moving)
  5.896002 seconds (137.43 M allocations: 7.197 GB, 24.55% gc time)
([-0.26290299117443555,-0.04562260395244045,0.09707317047564838],0.0007446994302309248)
```

Using this PR:
```
julia> @time RegisterAffineAD.optimize_rigid(fixed, moving)

******************************************************************************
This program contains Ipopt, a library for large-scale nonlinear optimization.
 Ipopt is released as open source code under the Eclipse Public License (EPL).
         For more information visit http://projects.coin-or.org/Ipopt
******************************************************************************

  5.137296 seconds (969.36 k allocations: 1.095 GB, 2.14% gc time)
([-0.26290299117443555,-0.04562260395244045,0.09707317047564838],0.0007446994302309248)

julia> @time RegisterAffineAD.optimize_rigid(fixed, moving)
  4.066025 seconds (15.38 k allocations: 1.054 GB, 4.84% gc time)
([-0.26290299117443555,-0.04562260395244045,0.09707317047564838],0.0007446994302309248)

julia> @time RegisterAffineAD.optimize_rigid(fixed, moving)
  3.983676 seconds (14.87 k allocations: 1.054 GB, 1.79% gc time)
([-0.26290299117443555,-0.04562260395244045,0.09707317047564838],0.0007446994302309248)

julia> @time RegisterAffineAD.optimize_rigid(fixed, moving)
  4.142620 seconds (14.87 k allocations: 1.054 GB, 2.05% gc time)
([-0.26290299117443555,-0.04562260395244045,0.09707317047564838],0.0007446994302309248)
```

It seems there are 121 remaining uses of `@inline` in the code. I bet there are many other places where it might be a good idea to remove it. (I generally try to not use it unless I've checked that it actually improves performance; don't know whether that was done here or not.)