### PR TITLE
Fix #78

### DIFF
--- a/src/ForwardDiffNumber.jl
+++ b/src/ForwardDiffNumber.jl
@@ -165,3 +165,7 @@ function to_nanmath(x::Expr)
 end
 
 to_nanmath(x) = x
+
+# Overloading of `promote_array_type` #
+#-------------------------------------#
+Base.promote_array_type{S<:ForwardDiff.ForwardDiffNumber, A<:AbstractFloat}(F, ::Type{S}, ::Type{A}) = S

--- a/src/GradientNumber.jl
+++ b/src/GradientNumber.jl
@@ -214,5 +214,4 @@ end
 
 # Overloading of `promote_array_type` #
 #-------------------------------------#
-
-Base.promote_array_type{S<:ForwardDiff.GradientNumber, A<:AbstractFloat}(F, ::Type{S}, ::Type{A}) = S
+Base.promote_array_type{S<:ForwardDiff.ForwardDiffNumber, A<:AbstractFloat}(F, ::Type{S}, ::Type{A}) = S

--- a/src/GradientNumber.jl
+++ b/src/GradientNumber.jl
@@ -211,3 +211,8 @@ for Y in (:Real, :GradientNumber), X in (:Real, :GradientNumber)
         end
     end
 end
+
+# Overloading of `promote_array_type` #
+#-------------------------------------#
+
+Base.promote_array_type{S<:ForwardDiff.GradientNumber, A<:AbstractFloat}(F, ::Type{S}, ::Type{A}) = S

--- a/test/test_jacobians.jl
+++ b/test/test_jacobians.jl
@@ -124,13 +124,40 @@ for fsym in ForwardDiff.auto_defined_unary_funcs
         end
     end
 
-    # Test jacobian of functions involving `.-`, `.+`, etc. #
+
+    
+    # Test overloading of `promote_array_type`
     #-------------------------------------------------------#
+
+
+    promtyp = Base.promote_array_type(Base.DotAddFun(),
+                                  ForwardDiff.GradientNumber{2, Float64,
+                                  Tuple{Float64, Float64}}, Float64)
+    
+    gradnum = ForwardDiff.GradientNumber{2,Float64,Tuple{Float64,Float64}}
+    
+    @test promtyp <: gradnum
+    
+    # jacobian of functions involving `.-`, `.+`, etc.      # 
+    #-------------------------------------------------------#
+
     a = ones(N)
-    ops = [:-, :+]
-    for op in ops
-        @eval fn(x) = ($op)(a, x)
-        D = reduce(&, @eval (($op)(eye(N)))-ForwardDiff.jacobian(fn, a) .== 0)
-        @test D
-    end
+
+    fn(x) = x - a
+    jac = ForwardDiff.jacobian(fn, a)
+    @test reduce(&, -jac + eye(N) .== 0)
+
+    fn(x) = x + a
+    jac = ForwardDiff.jacobian(fn, a)
+    @test reduce(&, -jac + eye(N) .== 0)
+
+    fn(x) = x./a
+    jac = ForwardDiff.jacobian(fn, a)
+    @test reduce(&, -jac + eye(N) .== 0)
+
+    fn(x) = x.*a
+    jac = ForwardDiff.jacobian(fn, a)
+    @test reduce(&, -jac + eye(N) .== 0)
+
+    
 end

--- a/test/test_jacobians.jl
+++ b/test/test_jacobians.jl
@@ -123,4 +123,14 @@ for fsym in ForwardDiff.auto_defined_unary_funcs
             throw(err)
         end
     end
+
+    # Test jacobian of functions involving `.-`, `.+`, etc. #
+    #-------------------------------------------------------#
+    a = ones(N)
+    ops = [:-, :+]
+    for op in ops
+        @eval fn(x) = ($op)(a, x)
+        D = reduce(&, @eval (($op)(eye(N)))-ForwardDiff.jacobian(fn, a) .== 0)
+        @test D
+    end
 end

--- a/test/test_jacobians.jl
+++ b/test/test_jacobians.jl
@@ -129,35 +129,56 @@ for fsym in ForwardDiff.auto_defined_unary_funcs
     # Test overloading of `promote_array_type`
     #-------------------------------------------------------#
 
-
     promtyp = Base.promote_array_type(Base.DotAddFun(),
                                   ForwardDiff.GradientNumber{2, Float64,
-                                  Tuple{Float64, Float64}}, Float64)
-    
-    gradnum = ForwardDiff.GradientNumber{2,Float64,Tuple{Float64,Float64}}
-    
+                                  Tuple{Float64, Float64}}, Float64)    
+    gradnum = ForwardDiff.GradientNumber{2,Float64,Tuple{Float64,Float64}}    
     @test promtyp <: gradnum
+
+    promtyp = Base.promote_array_type(Base.DotAddFun(),
+                                      ForwardDiff.HessianNumber{2, Float64,
+                                      Tuple{Float64, Float64}}, Float64)    
+    hessnum = ForwardDiff.HessianNumber{2,Float64,Tuple{Float64,Float64}}    
+    @test promtyp <: hessnum
+
+    promtyp = Base.promote_array_type(Base.DotAddFun(),
+                                      ForwardDiff.TensorNumber{2, Float64,
+                                      Tuple{Float64, Float64}}, Float64)    
+    tensnum = ForwardDiff.TensorNumber{2,Float64,Tuple{Float64,Float64}}    
+    @test promtyp <: tensnum
+
     
-    # jacobian of functions involving `.-`, `.+`, etc.      # 
+    # functions involving `.-`, `.+`, etc.                  # 
     #-------------------------------------------------------#
 
-    a = ones(N)
+    a    = ones(N)
 
-    fn(x) = x - a
-    jac = ForwardDiff.jacobian(fn, a)
-    @test reduce(&, -jac + eye(N) .== 0)
-
-    fn(x) = x + a
-    jac = ForwardDiff.jacobian(fn, a)
-    @test reduce(&, -jac + eye(N) .== 0)
-
-    fn(x) = x./a
-    jac = ForwardDiff.jacobian(fn, a)
-    @test reduce(&, -jac + eye(N) .== 0)
-
-    fn(x) = x.*a
-    jac = ForwardDiff.jacobian(fn, a)
-    @test reduce(&, -jac + eye(N) .== 0)
-
+    ## Test jacobian    
+    jac0 = reshape(vcat([[zeros(N*(i-1)); a; zeros(N^2-N*i)] for i = 1:N]...), N^2, N)
     
+    for op = [:-, :+, :./, :.*]
+        @eval fn(x) = [($op)(x[1], a); ($op)(x[2], a); ($op)(x[3], a); ($op)(x[4], a)]
+        jac = ForwardDiff.jacobian(fn, a)
+        @test reduce(&, -jac + jac0 .== 0)
+    end
+
+    ## Test hessian
+    for op = [:-, :+, :./, :.*]
+        @eval fn(x) = sum([($op)(x[1], a); ($op)(x[2], a); ($op)(x[3], a); ($op)(x[4], a)])
+        hess = ForwardDiff.hessian(fn, a)
+        @test reduce(&, -hess + zeros(N, N) .== 0)
+    end
+
+    ## Test tensor
+    for op = [:-, :+, :./, :.*]
+        @eval fn(x) = sum([($op)(x[1], a); ($op)(x[2], a); ($op)(x[3], a); ($op)(x[4], a)])
+        tens = ForwardDiff.tensor(fn, a)
+        @test reduce(&, -tens + zeros(N, N, N) .== 0)
+    end
+
 end
+
+
+
+
+fn(x) = sum(x - a)


### PR DESCRIPTION
This PR propose a simple fix to #78 by overloading  `Base.promote_array_type` to return a `Forward.GradientNumber` instead of `Float64`. 