### PR TITLE
Fix #78 by overloading promote_array_type

### DIFF
--- a/src/ForwardDiffNumber.jl
+++ b/src/ForwardDiffNumber.jl
@@ -165,3 +165,7 @@ function to_nanmath(x::Expr)
 end
 
 to_nanmath(x) = x
+
+# Overloading of `promote_array_type` #
+#-------------------------------------#
+Base.promote_array_type{S<:ForwardDiff.ForwardDiffNumber, A<:AbstractFloat}(F, ::Type{S}, ::Type{A}) = S

--- a/test/test_behaviors.jl
+++ b/test/test_behaviors.jl
@@ -60,7 +60,7 @@ promtyp = Base.promote_array_type(Base.DotAddFun(),
                                   ForwardDiff.ForwardDiffNumber{2, Float64,
                                   Tuple{Float64, Float64}}, Float64)
 fdiffnum = ForwardDiff.ForwardDiffNumber{2,Float64,Tuple{Float64,Float64}}    
-@test promtyp <: fordiffnum
+@test promtyp <: fdiffnum
 
 
 promtyp = Base.promote_array_type(Base.DotAddFun(),


### PR DESCRIPTION
This updated PR fix #78. The problem was due to `promote_array_type` not having methods for ForwardDiffNumber. 