### PR TITLE
Support <=, floor, and ceil

### DIFF
--- a/src/ForwardDiff.jl
+++ b/src/ForwardDiff.jl
@@ -12,12 +12,12 @@ module ForwardDiff
     import Calculus
     import NaNMath
     import Base: *, /, +, -, ^, getindex, length,
-                 hash, ==, <, isequal, copy, zero,
+                 hash, ==, <, <=, isequal, copy, zero,
                  one, float, rand, convert, promote_rule,
                  read, write, isless, isreal, isnan,
                  isfinite, isinf, eps, conj, transpose,
                  ctranspose, eltype, abs, abs2, start,
-                 next, done, atan2
+                 next, done, atan2, floor, ceil
 
     const auto_defined_unary_funcs = map(first, Calculus.symbolic_derivatives_1arg())
 

--- a/src/ForwardDiff.jl
+++ b/src/ForwardDiff.jl
@@ -17,7 +17,7 @@ module ForwardDiff
                  read, write, isless, isreal, isnan,
                  isfinite, isinf, eps, conj, transpose,
                  ctranspose, eltype, abs, abs2, start,
-                 next, done, atan2, floor, ceil
+                 next, done, atan2, floor, ceil, trunc, round
 
     const auto_defined_unary_funcs = map(first, Calculus.symbolic_derivatives_1arg())
 

--- a/src/ForwardDiffNumber.jl
+++ b/src/ForwardDiffNumber.jl
@@ -115,6 +115,9 @@ for T in (Base.Irrational, AbstractFloat, Real)
 
         <(x::$T, n::ForwardDiffNumber) = isless(x, n)
         <(n::ForwardDiffNumber, x::$T) = isless(n, x)
+        <=(x::ForwardDiffNumber, n::ForwardDiffNumber) = <=(value(x), value(n))
+        <=(x::$T, n::ForwardDiffNumber) = <=(x, value(n))
+        <=(n::ForwardDiffNumber, x::$T) = <=(value(n), x)
     end
 end
 
@@ -127,6 +130,9 @@ isnan(n::ForwardDiffNumber) = isnan(value(n))
 isfinite(n::ForwardDiffNumber) = isfinite(value(n))
 isinf(n::ForwardDiffNumber) = isinf(value(n))
 isreal(n::ForwardDiffNumber) = isconstant(n)
+
+floor{T}(::Type{T}, n::ForwardDiffNumber) = floor(T, value(n))
+ceil{T}(::Type{T}, n::ForwardDiffNumber) = ceil(T, value(n))
 
 ########################
 # Conversion/Promotion #

--- a/src/ForwardDiffNumber.jl
+++ b/src/ForwardDiffNumber.jl
@@ -131,8 +131,10 @@ isfinite(n::ForwardDiffNumber) = isfinite(value(n))
 isinf(n::ForwardDiffNumber) = isinf(value(n))
 isreal(n::ForwardDiffNumber) = isconstant(n)
 
-floor{T}(::Type{T}, n::ForwardDiffNumber) = floor(T, value(n))
-ceil{T}(::Type{T}, n::ForwardDiffNumber) = ceil(T, value(n))
+floor{T<:ExternalReal}(::Type{T}, n::ForwardDiffNumber) = floor(T, value(n))
+ceil{ T<:ExternalReal}(::Type{T}, n::ForwardDiffNumber) = ceil( T, value(n))
+trunc{T<:ExternalReal}(::Type{T}, n::ForwardDiffNumber) = trunc(T, value(n))
+round{T<:ExternalReal}(::Type{T}, n::ForwardDiffNumber) = round(T, value(n))
 
 ########################
 # Conversion/Promotion #

--- a/test/test_gradients.jl
+++ b/test/test_gradients.jl
@@ -106,7 +106,11 @@ for (test_partials, Grad) in ((test_partialstup, ForwardDiff.GradNumTup), (test_
 
     @test isless(test_grad-1, test_grad)
     @test test_grad-1 < test_grad
+    @test !(test_grad < test_val)
+    @test test_grad-1 <= test_grad
+    @test test_grad <= test_val
     @test test_grad > test_grad-1
+    @test test_grad >= test_grad-1
 
     @test isless(test_val-1, test_grad)
     @test test_val-1 < test_grad
@@ -115,6 +119,9 @@ for (test_partials, Grad) in ((test_partialstup, ForwardDiff.GradNumTup), (test_
     @test isless(test_grad, test_val+1)
     @test test_grad < test_val+1
     @test test_val+1 > test_grad
+
+    @test floor(Int, test_grad) == floor(Int, test_val)
+    @test ceil(Int, test_grad) == ceil(Int, test_val)
 
     #######
     # I/O #

--- a/test/test_gradients.jl
+++ b/test/test_gradients.jl
@@ -122,6 +122,8 @@ for (test_partials, Grad) in ((test_partialstup, ForwardDiff.GradNumTup), (test_
 
     @test floor(Int, test_grad) == floor(Int, test_val)
     @test ceil(Int, test_grad) == ceil(Int, test_val)
+    @test trunc(Int, test_grad) == trunc(Int, test_val)
+    @test round(Int, test_grad) == round(Int, test_val)
 
     #######
     # I/O #

--- a/test/test_hessians.jl
+++ b/test/test_hessians.jl
@@ -127,9 +127,18 @@ inf_hess = HessianNumber{N,T,C}(Inf)
 @test test_val-1 < test_hess
 @test test_hess > test_val-1
 
+@test test_hess-1 <= test_hess
+@test test_hess <= test_val
+
 @test isless(test_hess, test_val+1)
 @test test_hess < test_val+1
 @test test_val+1 > test_hess
+
+@test test_hess+1 >= test_hess
+@test test_hess+1 >= test_val
+
+@test floor(Int, test_hess) == floor(Int, test_val)
+@test ceil(Int, test_hess) == ceil(Int, test_val)
 
 #######
 # I/O #

--- a/test/test_hessians.jl
+++ b/test/test_hessians.jl
@@ -139,6 +139,8 @@ inf_hess = HessianNumber{N,T,C}(Inf)
 
 @test floor(Int, test_hess) == floor(Int, test_val)
 @test ceil(Int, test_hess) == ceil(Int, test_val)
+@test trunc(Int, test_hess) == trunc(Int, test_val)
+@test round(Int, test_hess) == round(Int, test_val)
 
 #######
 # I/O #

--- a/test/test_tensors.jl
+++ b/test/test_tensors.jl
@@ -141,9 +141,18 @@ inf_tens = TensorNumber{N,T,C}(Inf)
 @test test_val-1 < test_tens
 @test test_tens > test_val-1
 
+@test test_tens-1 <= test_tens
+@test test_tens <= test_val
+
 @test isless(test_tens, test_val+1)
 @test test_tens < test_val+1
 @test test_val+1 > test_tens
+
+@test test_tens+1 >= test_tens
+@test test_tens+1 >= test_val
+
+@test floor(Int, test_tens) == floor(Int, test_val)
+@test ceil(Int, test_tens) == ceil(Int, test_val)
 
 #######
 # I/O #

--- a/test/test_tensors.jl
+++ b/test/test_tensors.jl
@@ -153,6 +153,8 @@ inf_tens = TensorNumber{N,T,C}(Inf)
 
 @test floor(Int, test_tens) == floor(Int, test_val)
 @test ceil(Int, test_tens) == ceil(Int, test_val)
+@test trunc(Int, test_tens) == trunc(Int, test_val)
+@test round(Int, test_tens) == round(Int, test_val)
 
 #######
 # I/O #


### PR DESCRIPTION
This supports operations used in various packages I use. I'm submitting it for consideration, but I'd suggest these definitions are worth contemplating a bit before you decide to merge this. From a mathematical perspective, since you can think of a GradientNumber similarly to `r+ϵ`, then you'd expect `r+ϵ < r2` if `r < r2`, but it's not obvious that one would want `r+ϵ <= r`. On the other hand, from the standpoint of, e..g., bounds-checking with a GradientNumber (e.g., in Interpolations), it seems that you probably want `<=` defined. `floor` and `ceil` are a bit similar.