### PR TITLE
Tighten signature on manually overloaded unary ops so they actually get called

### DIFF
--- a/src/HessianNumber.jl
+++ b/src/HessianNumber.jl
@@ -250,13 +250,14 @@ end
 
 # Manually Optimized Functions #
 #------------------------------#
-@inline function exp(h::HessianNumber)
+@inline function exp{N}(h::HessianNumber{N})
     exp_a = exp(value(h))
     return hessnum_from_deriv(h, exp_a, exp_a, exp_a)
 end
 
-@inline function sqrt(h::HessianNumber)
-    sqrt_a = sqrt(value(h))
+@inline function sqrt{N}(h::HessianNumber{N})
+    a = value(h)
+    sqrt_a = sqrt(a)
     deriv1 = 0.5 / sqrt_a
     deriv2 = -0.25 / (a * sqrt_a)
     return hessnum_from_deriv(h, sqrt_a, deriv1, deriv2)

--- a/src/TensorNumber.jl
+++ b/src/TensorNumber.jl
@@ -312,13 +312,14 @@ end
 
 # Manually Optimized Functions #
 #------------------------------#
-@inline function exp(t::TensorNumber)
+@inline function exp{N}(t::TensorNumber{N})
     exp_a = exp(value(t))
     return tensnum_from_deriv(t, exp_a, exp_a, exp_a, exp_a)
 end
 
-function sqrt(t::TensorNumber)
-    sqrt_a = sqrt(value(t))
+function sqrt{N}(t::TensorNumber{N})
+    a = value(t)
+    sqrt_a = sqrt(a)
     deriv1 = 0.5 / sqrt_a
     sqrt_a_cb = a * sqrt_a
     deriv2 = -0.25 / sqrt_a_cb


### PR DESCRIPTION
I noticed a bug in the manually overloaded functions for hessian numbers:

```jl
@inline function sqrt(h::HessianNumber)
    sqrt_a = sqrt(value(h))
    deriv1 = 0.5 / sqrt_a
    deriv2 = -0.25 / (a * sqrt_a)
    return hessnum_from_deriv(h, sqrt_a, deriv1, deriv2)
end
````

Here, `a` is not defined. I then tried to explicitly call sqrt with a Hessian Number which seemed to work which means that this function is actually not called.

I looked at where the function for `sqrt` and `exp` (which both are manually optimized) are defined:
```jl
julia> @which sqrt(hess_num)
sqrt{N}(h::ForwardDiff.HessianNumber{N,T,C}) at C:\Users\kcarl\.julia\v0.4\ForwardDiff\src\HessianNumber.jl:239

julia> @which exp(hess_num)
exp{N}(h::ForwardDiff.HessianNumber{N,T,C}) at C:\Users\kcarl\.julia\v0.4\ForwardDiff\src\HessianNumber.jl:239
```

This confirms that the general fallback function is used and not the manually optimized one. The reason is that the manual optimization function lacks the `{N}` parameterisation that the general functions have. The general functions are then seen as more specific by julia.

This PR adds the `{N}` to the manually optimized function and fixes bugs where `a` was not defined in two of the functions.

After PR:
```jl
julia> @which sqrt(hess_num)
sqrt{N}(h::ForwardDiff.HessianNumber{N,T,C}) at C:\Users\kcarl\.julia\v0.4\ForwardDiff\src\HessianNumber.jl:259

julia> @which exp(hess_num)
exp{N}(h::ForwardDiff.HessianNumber{N,T,C}) at C:\Users\kcarl\.julia\v0.4\ForwardDiff\src\HessianNumber.jl:254
```