### PR TITLE
whitespace fixes

### DIFF
--- a/benchmarks/py/benchmarks.py
+++ b/benchmarks/py/benchmarks.py
@@ -89,10 +89,10 @@ def get_benchmarks(*fs):
 ##################
 default_fs = (ackley, rosenbrock, self_weighted_logit)
 
-def run_default_benchmarks(): 
+def run_default_benchmarks():
     return run_benchmarks(*default_fs)
 
-def get_default_benchmarks(): 
+def get_default_benchmarks():
     return get_benchmarks(*default_fs)
 
 if __name__ == '__main__':

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,7 +7,7 @@ ForwardDiff.jl implements methods to take **derivatives**, **gradients**, **Jaco
 
 While performance can vary depending on the functions you evaluate, the algorithms implemented by ForwardDiff.jl **generally outperform non-AD algorithms in both speed and accuracy.**
 
-This `wikipedia page`_ on automatic differentiation is a useful resource for learning about the advantages of AD techniques over other common differentiation methods (such as `finite differencing`_). 
+This `wikipedia page`_ on automatic differentiation is a useful resource for learning about the advantages of AD techniques over other common differentiation methods (such as `finite differencing`_).
 
 .. toctree::
    :maxdepth: 2

--- a/src/api/api.jl
+++ b/src/api/api.jl
@@ -1,7 +1,7 @@
-# Note for the files in this folder: 
-# Following convention, methods whose names are prefixed 
-# with an underscore are unsafe to use outside of a strictly 
-# controlled context - such methods assume that all 
+# Note for the files in this folder:
+# Following convention, methods whose names are prefixed
+# with an underscore are unsafe to use outside of a strictly
+# controlled context - such methods assume that all
 # boundary-checking is done by the caller.
 
 const tuple_usage_threshold = 10
@@ -9,7 +9,7 @@ const default_chunk_size = 0
 
 abstract AllResults
 
-function check_chunk_size(xlen::Int, chunk_size::Int)        
+function check_chunk_size(xlen::Int, chunk_size::Int)
     if chunk_size != default_chunk_size
         @assert chunk_size > 0 "Invalid chunk_size: $chunk_size. chunk_size cannot be negative."
         @assert xlen % chunk_size == 0 "Length of input vector is indivisible by chunk size (length(x) = $xlen, chunk size = $chunk_size)"

--- a/src/api/deprecated.jl
+++ b/src/api/deprecated.jl
@@ -22,12 +22,12 @@ Base.@deprecate forwarddiff_jacobian!(f::Function, T::DataType; fadtype::Symbol=
 Base.@deprecate forwarddiff_hessian!(f::Function, T::DataType; fadtype::Symbol=:dual, args...) depr_inplace_fad(ForwardDiff.hessian, f)
 Base.@deprecate forwarddiff_tensor!(f::Function, T::DataType; fadtype::Symbol=:dual, args...) depr_inplace_fad(ForwardDiff.tensor, f)
 
-export forwarddiff_gradient, 
+export forwarddiff_gradient,
     forwarddiff_gradient!,
-    forwarddiff_jacobian, 
+    forwarddiff_jacobian,
     forwarddiff_jacobian!,
-    forwarddiff_hessian, 
+    forwarddiff_hessian,
     forwarddiff_hessian!,
-    forwarddiff_tensor, 
+    forwarddiff_tensor,
     forwarddiff_tensor!,
     deprecated_inplace_fad


### PR DESCRIPTION
This just fixes the trailing whitespaces so that future diffs will be clean.

It is commited on top of the closure refactor branch since my guess is that it will be merged and I wanted to avoid merge conflicts.