### PR TITLE
fix domain error in pow

### DIFF
--- a/src/GradientNumber.jl
+++ b/src/GradientNumber.jl
@@ -110,7 +110,10 @@ end
 #----------------#
 for f in (:^, :(NaNMath.pow))
     @eval begin
-        @inline function ($f){N}(g1::GradientNumber{N}, g2::GradientNumber{N})
+        @inline function ($f){N,T,C}(g1::GradientNumber{N}, g2::GradientNumber{N,T,C})
+            if partials(g2) == zero_partials(C,N)
+                return $f(g1,value(g2))
+            end
             a1, a2 = value(g1), value(g2)
             exp_a = ($f)(a1, a2)
             powval = a2 * ($f)(a1, a2 - 1)

--- a/test/test_behaviors.jl
+++ b/test/test_behaviors.jl
@@ -107,3 +107,9 @@ for op in (-, +, .-, .+, ./, .*)
     tens = ForwardDiff.tensor(f, a)
     @test reduce(&, -tens + zeros(N, N, N) .== 0)
 end
+
+######################
+# DomainError Issues #
+######################
+
+@test ForwardDiff.grad(NaNMath.pow(ForwardDiff.GradientNumber(-2.0,(1.0,)),ForwardDiff.GradientNumber(2.0,(0.0,))),1) == -4.0


### PR DESCRIPTION
This ports https://github.com/JuliaDiff/DualNumbers.jl/pull/34 to ForwardDiff. It fixes the domain errors in the cases that affect JuMP (all partials are zero), but doesn't fully address the issue, since there will still be issues if some of the partials are zero and some are not.