### PR TITLE
allow AbstractVector input for gradients

### DIFF
--- a/src/api/gradient.jl
+++ b/src/api/gradient.jl
@@ -4,13 +4,13 @@
 
 # Exposed API methods #
 #---------------------#
-@generated function gradient!{T,A}(output::Vector{T}, f, x::Vector, ::Type{A}=Void;
+@generated function gradient!{T,A}(output::AbstractVector{T}, f, x::AbstractVector, ::Type{A}=Void;
                                    chunk_size::Int=default_chunk_size,
                                    cache::ForwardDiffCache=dummy_cache)
     if A <: Void
-        return_stmt = :(gradient!(output, result)::Vector{T})
+        return_stmt = :(gradient!(output, result)::typeof(output))
     elseif A <: AllResults
-        return_stmt = :(gradient!(output, result)::Vector{T}, result)
+        return_stmt = :(gradient!(output, result)::typeof(output), result)
     else
         error("invalid argument $A passed to FowardDiff.gradient")
     end
@@ -21,7 +21,7 @@
     end
 end
 
-@generated function gradient{T,A}(f, x::Vector{T}, ::Type{A}=Void;
+@generated function gradient{T,A}(f, x::AbstractVector{T}, ::Type{A}=Void;
                                   chunk_size::Int=default_chunk_size,
                                   cache::ForwardDiffCache=dummy_cache)
     if A <: Void
@@ -43,14 +43,14 @@ function gradient{A}(f, ::Type{A}=Void;
                      chunk_size::Int=default_chunk_size,
                      cache::ForwardDiffCache=ForwardDiffCache())
     if mutates
-        function g!(output::Vector, x::Vector)
+        function g!(output::AbstractVector, x::AbstractVector)
             return ForwardDiff.gradient!(output, f, x, A;
                                          chunk_size=chunk_size,
                                          cache=cache)
         end
         return g!
     else
-        function g(x::Vector)
+        function g(x::AbstractVector)
             return ForwardDiff.gradient(f, x, A;
                                         chunk_size=chunk_size,
                                         cache=cache)
@@ -61,7 +61,7 @@ end
 
 # Calculate gradient of a given function #
 #----------------------------------------#
-function _calc_gradient{S}(f, x::Vector, ::Type{S},
+function _calc_gradient{S}(f, x::AbstractVector, ::Type{S},
                            chunk_size::Int,
                            cache::ForwardDiffCache)
     X = Val{length(x)}
@@ -69,7 +69,7 @@ function _calc_gradient{S}(f, x::Vector, ::Type{S},
     return _calc_gradient(f, x, S, X, C, cache)
 end
 
-@generated function _calc_gradient{T,S,xlen,chunk_size}(f, x::Vector{T}, ::Type{S},
+@generated function _calc_gradient{T,S,xlen,chunk_size}(f, x::AbstractVector{T}, ::Type{S},
                                                         X::Type{Val{xlen}},
                                                         C::Type{Val{chunk_size}},
                                                         cache::ForwardDiffCache)


### PR DESCRIPTION
I don't mean to create unnecessary merge conflicts for https://github.com/JuliaDiff/ForwardDiff.jl/pull/102 (so I didn't add tests), but in JuMP we need to pass around subarrays instead of proper Arrays. I don't see why ForwardDiff should insist on the type of the vector inputs so long as it's indexable.