### PR TITLE
fix type stability of return function from @derivative

### DIFF
--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -33,15 +33,15 @@ function derivative(f, x::Real, A::DataType)
     return handle_deriv_result(f(DiffNumber(x, one(x))), A)
 end
 
-@generated function derivative{output_mutates}(f, A::DataType, ::Type{Val{output_mutates}})
+@generated function derivative{all_results, output_mutates}(f, ::Type{Val{all_results}}, ::Type{Val{output_mutates}})
     if output_mutates
         return quote
-            d!(output::Array, x::Real) = derivative!(f, output, x, A)
+            d!(output::Array, x::Real) = derivative!(f, output, x, Val{all_results})
             return d!
         end
     else
         return quote
-            d(x::Real) = derivative(f, x, A)
+            d(x::Real) = derivative(f, x, Val{all_results})
             return d
         end
     end


### PR DESCRIPTION
Using:
```jl
using ForwardDiff
f(x) = x
g = ForwardDiff.@derivative(f)
@code_warntype g(1.0)
```

Before:
```
Variables:
  #self#::ForwardDiff.#d#25{#f,DataType}
  x::Float64
  ####partials#8012#8013::Tuple{Float64}

Body:
  begin  # /home/kristoffer/.julia/v0.5/ForwardDiff/src/derivative.jl, line 44:
      return (ForwardDiff.handle_deriv_result)($(Expr(:new, ForwardDiff.DiffNumber{1,Float64}, :(x::Float64), :($(Expr(:new, ForwardDiff.Partials{1,Float64}, :((top(tuple))((Base.box)(Float64,(Base.sitofp)(Float64,1)))::Tuple{Float64})))))),(top(getfield))(#self#::ForwardDiff.#d#25{#f,DataType},:A)::DataType)::Union{Float64,Tuple{Float64,Float64}}
  end::Union{Float64,Tuple{Float64,Float64}}
```

After:
```
Variables:
  #self#::ForwardDiff.#d#25{false,#f}
  x::Float64
  ####partials#8109#8110::Tuple{Float64}

Body:
  begin  # /home/kristoffer/.julia/v0.5/ForwardDiff/src/derivative.jl, line 44:
      return (Base.getfield)((top(getfield))((top(getfield))($(Expr(:new, ForwardDiff.DiffNumber{1,Float64}, :(x::Float64), :($(Expr(:new, ForwardDiff.Partials{1,Float64}, :((top(tuple))((Base.box)(Float64,(Base.sitofp)(Float64,1)))::Tuple{Float64})))))),:partials)::ForwardDiff.Partials{1,Float64},:values)::Tuple{Float64},1)::Float64
  end::Float64
```


