### PR TITLE
Replace operator macro with compat macro, bump required Compat version

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.4
-Compat
+Compat 0.8.6
 Calculus
 NaNMath

--- a/src/ForwardDiff.jl
+++ b/src/ForwardDiff.jl
@@ -7,23 +7,6 @@ using Compat
 import Calculus
 import NaNMath
 
-#######################
-# compatibility patch #
-#######################
-
-if v"0.4" <= VERSION < v"0.5-"
-    # e.g. @operator Base.:op -> Base.(:op)
-    macro operator(qualified_name)
-        func_name = qualified_name.args[2].args[1]
-        qualified_name.args[2] = func_name
-        return qualified_name
-    end
-else
-    macro operator(qualified_name)
-        return qualified_name
-    end
-end
-
 #############################
 # types/functions/constants #
 #############################

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -108,26 +108,26 @@ end
 isconstant(n::Dual) = iszero(partials(n))
 
 @ambiguous Base.isequal{N}(a::Dual{N}, b::Dual{N}) = isequal(value(a), value(b))
-@ambiguous @operator(Base.:(==)){N}(a::Dual{N}, b::Dual{N}) = value(a) == value(b)
+@ambiguous @compat(Base.:(==)){N}(a::Dual{N}, b::Dual{N}) = value(a) == value(b)
 @ambiguous Base.isless{N}(a::Dual{N}, b::Dual{N}) = value(a) < value(b)
-@ambiguous @operator(Base.:<){N}(a::Dual{N}, b::Dual{N}) = isless(a, b)
-@ambiguous @operator(Base.:(<=)){N}(a::Dual{N}, b::Dual{N}) = <=(value(a), value(b))
+@ambiguous @compat(Base.:<){N}(a::Dual{N}, b::Dual{N}) = isless(a, b)
+@ambiguous @compat(Base.:(<=)){N}(a::Dual{N}, b::Dual{N}) = <=(value(a), value(b))
 
 for T in (AbstractFloat, Irrational, Real)
     Base.isequal(n::Dual, x::T) = isequal(value(n), x)
     Base.isequal(x::T, n::Dual) = isequal(n, x)
 
-    @operator(Base.:(==))(n::Dual, x::T) = (value(n) == x)
-    @operator(Base.:(==))(x::T, n::Dual) = ==(n, x)
+    @compat(Base.:(==))(n::Dual, x::T) = (value(n) == x)
+    @compat(Base.:(==))(x::T, n::Dual) = ==(n, x)
 
     Base.isless(n::Dual, x::T) = value(n) < x
     Base.isless(x::T, n::Dual) = x < value(n)
 
-    @operator(Base.:<)(n::Dual, x::T) = isless(n, x)
-    @operator(Base.:<)(x::T, n::Dual) = isless(x, n)
+    @compat(Base.:<)(n::Dual, x::T) = isless(n, x)
+    @compat(Base.:<)(x::T, n::Dual) = isless(x, n)
 
-    @operator(Base.:(<=))(n::Dual, x::T) = <=(value(n), x)
-    @operator(Base.:(<=))(x::T, n::Dual) = <=(x, value(n))
+    @compat(Base.:(<=))(n::Dual, x::T) = <=(value(n), x)
+    @compat(Base.:(<=))(x::T, n::Dual) = <=(x, value(n))
 end
 
 Base.isnan(n::Dual) = isnan(value(n))
@@ -174,49 +174,49 @@ Base.float{N,T}(n::Dual{N,T}) = Dual{N,promote_type(T, Float16)}(n)
 # Addition/Subtraction #
 #----------------------#
 
-@ambiguous @inline @operator(Base.:+){N}(n1::Dual{N}, n2::Dual{N}) = Dual(value(n1) + value(n2), partials(n1) + partials(n2))
-@inline @operator(Base.:+)(n::Dual, x::Real) = Dual(value(n) + x, partials(n))
-@inline @operator(Base.:+)(x::Real, n::Dual) = n + x
+@ambiguous @inline @compat(Base.:+){N}(n1::Dual{N}, n2::Dual{N}) = Dual(value(n1) + value(n2), partials(n1) + partials(n2))
+@inline @compat(Base.:+)(n::Dual, x::Real) = Dual(value(n) + x, partials(n))
+@inline @compat(Base.:+)(x::Real, n::Dual) = n + x
 
-@ambiguous @inline @operator(Base.:-){N}(n1::Dual{N}, n2::Dual{N}) = Dual(value(n1) - value(n2), partials(n1) - partials(n2))
-@inline @operator(Base.:-)(n::Dual, x::Real) = Dual(value(n) - x, partials(n))
-@inline @operator(Base.:-)(x::Real, n::Dual) = Dual(x - value(n), -(partials(n)))
-@inline @operator(Base.:-)(n::Dual) = Dual(-(value(n)), -(partials(n)))
+@ambiguous @inline @compat(Base.:-){N}(n1::Dual{N}, n2::Dual{N}) = Dual(value(n1) - value(n2), partials(n1) - partials(n2))
+@inline @compat(Base.:-)(n::Dual, x::Real) = Dual(value(n) - x, partials(n))
+@inline @compat(Base.:-)(x::Real, n::Dual) = Dual(x - value(n), -(partials(n)))
+@inline @compat(Base.:-)(n::Dual) = Dual(-(value(n)), -(partials(n)))
 
 # Multiplication #
 #----------------#
 
-@inline @operator(Base.:*)(n::Dual, x::Bool) = x ? n : (signbit(value(n))==0 ? zero(n) : -zero(n))
-@inline @operator(Base.:*)(x::Bool, n::Dual) = n * x
+@inline @compat(Base.:*)(n::Dual, x::Bool) = x ? n : (signbit(value(n))==0 ? zero(n) : -zero(n))
+@inline @compat(Base.:*)(x::Bool, n::Dual) = n * x
 
-@ambiguous @inline function @operator(Base.:*){N}(n1::Dual{N}, n2::Dual{N})
+@ambiguous @inline function @compat(Base.:*){N}(n1::Dual{N}, n2::Dual{N})
     v1, v2 = value(n1), value(n2)
     return Dual(v1 * v2, _mul_partials(partials(n1), partials(n2), v2, v1))
 end
 
-@inline @operator(Base.:*)(n::Dual, x::Real) = Dual(value(n) * x, partials(n) * x)
-@inline @operator(Base.:*)(x::Real, n::Dual) = n * x
+@inline @compat(Base.:*)(n::Dual, x::Real) = Dual(value(n) * x, partials(n) * x)
+@inline @compat(Base.:*)(x::Real, n::Dual) = n * x
 
 # Division #
 #----------#
 
-@ambiguous @inline function @operator(Base.:/){N}(n1::Dual{N}, n2::Dual{N})
+@ambiguous @inline function @compat(Base.:/){N}(n1::Dual{N}, n2::Dual{N})
     v1, v2 = value(n1), value(n2)
     return Dual(v1 / v2, _div_partials(partials(n1), partials(n2), v1, v2))
 end
 
-@inline function @operator(Base.:/)(x::Real, n::Dual)
+@inline function @compat(Base.:/)(x::Real, n::Dual)
     v = value(n)
     divv = x / v
     return Dual(divv, -(divv / v) * partials(n))
 end
 
-@inline @operator(Base.:/)(n::Dual, x::Real) = Dual(value(n) / x, partials(n) / x)
+@inline @compat(Base.:/)(n::Dual, x::Real) = Dual(value(n) / x, partials(n) / x)
 
 # Exponentiation #
 #----------------#
 
-for f in (macroexpand(:(@operator(Base.:^))), :(NaNMath.pow))
+for f in (macroexpand(:(@compat(Base.:^))), :(NaNMath.pow))
     @eval begin
         @ambiguous @inline function ($f){N}(n1::Dual{N}, n2::Dual{N})
             if isconstant(n2)

--- a/src/partials.jl
+++ b/src/partials.jl
@@ -39,7 +39,7 @@ Base.done(partials::Partials, i) = done(partials.values, i)
 @inline Base.rand{N,T}(rng::AbstractRNG, ::Type{Partials{N,T}}) = Partials{N,T}(rand_tuple(rng, NTuple{N,T}))
 
 Base.isequal{N}(a::Partials{N}, b::Partials{N}) = isequal(a.values, b.values)
-@operator(Base.:(==)){N}(a::Partials{N}, b::Partials{N}) = a.values == b.values
+@compat(Base.:(==)){N}(a::Partials{N}, b::Partials{N}) = a.values == b.values
 
 const PARTIALS_HASH = hash(Partials)
 
@@ -69,12 +69,12 @@ Base.convert{N,T}(::Type{Partials{N,T}}, partials::Partials{N,T}) = partials
 # Arithmetic Functions #
 ########################
 
-@inline @operator(Base.:+){N}(a::Partials{N}, b::Partials{N}) = Partials(add_tuples(a.values, b.values))
-@inline @operator(Base.:-){N}(a::Partials{N}, b::Partials{N}) = Partials(sub_tuples(a.values, b.values))
-@inline @operator(Base.:-)(partials::Partials) = Partials(minus_tuple(partials.values))
-@inline @operator(Base.:*)(partials::Partials, x::Real) = Partials(scale_tuple(partials.values, x))
-@inline @operator(Base.:*)(x::Real, partials::Partials) = partials*x
-@inline @operator(Base.:/)(partials::Partials, x::Real) = Partials(div_tuple_by_scalar(partials.values, x))
+@inline @compat(Base.:+){N}(a::Partials{N}, b::Partials{N}) = Partials(add_tuples(a.values, b.values))
+@inline @compat(Base.:-){N}(a::Partials{N}, b::Partials{N}) = Partials(sub_tuples(a.values, b.values))
+@inline @compat(Base.:-)(partials::Partials) = Partials(minus_tuple(partials.values))
+@inline @compat(Base.:*)(partials::Partials, x::Real) = Partials(scale_tuple(partials.values, x))
+@inline @compat(Base.:*)(x::Real, partials::Partials) = partials*x
+@inline @compat(Base.:/)(partials::Partials, x::Real) = Partials(div_tuple_by_scalar(partials.values, x))
 
 @inline function _mul_partials{N}(a::Partials{N}, b::Partials{N}, afactor, bfactor)
     return Partials(mul_tuples(a.values, b.values, afactor, bfactor))
@@ -89,12 +89,12 @@ end
 # edge cases where N == 0 #
 #-------------------------#
 
-@inline @operator(Base.:+){A,B}(a::Partials{0,A}, b::Partials{0,B}) = Partials{0,promote_type(A,B)}(tuple())
-@inline @operator(Base.:-){A,B}(a::Partials{0,A}, b::Partials{0,B}) = Partials{0,promote_type(A,B)}(tuple())
-@inline @operator(Base.:-){T}(partials::Partials{0,T}) = partials
-@inline @operator(Base.:*){T}(partials::Partials{0,T}, x::Real) = Partials{0,promote_type(T,typeof(x))}(tuple())
-@inline @operator(Base.:*){T}(x::Real, partials::Partials{0,T}) = Partials{0,promote_type(T,typeof(x))}(tuple())
-@inline @operator(Base.:/){T}(partials::Partials{0,T}, x::Real) = Partials{0,promote_type(T,typeof(x))}(tuple())
+@inline @compat(Base.:+){A,B}(a::Partials{0,A}, b::Partials{0,B}) = Partials{0,promote_type(A,B)}(tuple())
+@inline @compat(Base.:-){A,B}(a::Partials{0,A}, b::Partials{0,B}) = Partials{0,promote_type(A,B)}(tuple())
+@inline @compat(Base.:-){T}(partials::Partials{0,T}) = partials
+@inline @compat(Base.:*){T}(partials::Partials{0,T}, x::Real) = Partials{0,promote_type(T,typeof(x))}(tuple())
+@inline @compat(Base.:*){T}(x::Real, partials::Partials{0,T}) = Partials{0,promote_type(T,typeof(x))}(tuple())
+@inline @compat(Base.:/){T}(partials::Partials{0,T}, x::Real) = Partials{0,promote_type(T,typeof(x))}(tuple())
 
 @inline _mul_partials{A,B}(a::Partials{0,A}, b::Partials{0,B}, afactor, bfactor) = Partials{0,promote_type(A,B)}(tuple())
 @inline _div_partials{A,B}(a::Partials{0,A}, b::Partials{0,B}, afactor, bfactor) = Partials{0,promote_type(A,B)}(tuple())


### PR DESCRIPTION
Prompted by @tkelman's comment [here](https://github.com/JuliaDiff/ForwardDiff.jl/pull/102#discussion_r71973527).
