### PR TITLE
loosen restriction on input array for cache type assertion

### DIFF
--- a/src/cache.jl
+++ b/src/cache.jl
@@ -16,7 +16,8 @@ function JacobianCache{N}(x, chunk::Chunk{N})
     return JacobianCache{N,T,typeof(duals)}(duals, seeds)
 end
 
-@inline jacobian_dual_type{T,M,N}(::Array{T,M}, ::Chunk{N}) = Array{Dual{N,T},M}
+@inline jacobian_dual_type{N}(arr, ::Chunk{N}) = Array{Dual{N,eltype(arr)},ndims(arr)}
+@inline jacobian_dual_type{T,M,N}(::AbstractArray{T,M}, ::Chunk{N}) = Array{Dual{N,T},M}
 
 Base.copy(cache::JacobianCache) = JacobianCache(copy(cache.duals), cache.seeds)
 
@@ -56,7 +57,8 @@ function HessianCache{N}(x, chunk::Chunk{N})
     return HessianCache{N,T,typeof(duals)}(duals, inseeds, outseeds)
 end
 
-@inline hessian_dual_type{T,M,N}(::Array{T,M}, ::Chunk{N}) = Array{Dual{N,Dual{N,T}},M}
+@inline hessian_dual_type{N}(arr, ::Chunk{N}) = Array{Dual{Dual{N,eltype(arr)}},ndims(arr)}
+@inline hessian_dual_type{T,M,N}(::AbstractArray{T,M}, ::Chunk{N}) = Array{Dual{N,Dual{N,T}},M}
 
 Base.copy(cache::HessianCache) = HessianCache(copy(cache.duals), cache.inseeds, cache.outseeds)
 

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -212,7 +212,7 @@ function jacobian_chunk_mode_expr(out_definition::Expr, cache_definition::Expr,
 
         $(y_definition)
 
-        return out
+        return reshape(out_reshaped, size(out))
     end
 end
 

--- a/test/MiscTest.jl
+++ b/test/MiscTest.jl
@@ -2,6 +2,7 @@ module MiscTest
 
 import NaNMath
 
+using Compat
 using Base.Test
 using ForwardDiff
 
@@ -72,18 +73,19 @@ testf2 = x -> testdf(x[1]) * f(x[2])
 # Higher-Dimensional Differentiation #
 ######################################
 
-x = rand(3, 3)
+x = rand(5, 5)
 
 @test_approx_eq ForwardDiff.jacobian(inv, x) -kron(inv(x'), inv(x))
 
-x = [1, 2, 3]
+#########################################
+# Differentiation with non-Array inputs #
+#########################################
 
-function vector_hessian(f, x)
-   n = length(x)
-   out = ForwardDiff.jacobian(x -> ForwardDiff.jacobian(f, x), x)
-   return reshape(out, n, n)
-end
+x = rand(5, 5)
+jinvx = ForwardDiff.jacobian(inv, x)
 
+@test_approx_eq jinvx ForwardDiff.jacobian(inv, sparse(x))
+@test_approx_eq jinvx ForwardDiff.jacobian(inv, Compat.view(x, 1:5, 1:5))
 
 ########################
 # Conversion/Promotion #


### PR DESCRIPTION
This fixes an accidental regression in our support of non-`Array` ForwardDiff inputs ([thanks for pointing this out](https://github.com/JuliaLang/METADATA.jl/pull/6092#issuecomment-241776757), @tkelman).

I'm a tad concerned that this might damage performance for non-`AbstractArray` inputs, since the fallback here uses the result of `ndims` in a type parameter.

It would be nice if there were something like `similar_type` we could call on array-likes, which would allow us to generalize the array types used by the cache types.