### PR TITLE
Use similar in cache construction

### DIFF
--- a/src/cache.jl
+++ b/src/cache.jl
@@ -16,17 +16,23 @@ function eltype_param_number{T<:AbstractArray}(::Type{T})
     end
 end
 
-@inline @generated function replace_eltype{T,S}(x::AbstractArray{T}, ::Type{S})
+@generated function replace_eltype{T,S}(x::AbstractArray{T}, ::Type{S})
     if x.mutable
         pnum = eltype_param_number(x.name.primary)
         tname = x.name.primary
         tparams = collect(x.parameters)
         tparams[pnum] = S
-        newtype = :($(tname){$(tparams...)})
-        return newtype
+        newtype = quote
+            $(Expr(:meta, :inline))
+            $(tname){$(tparams...)}
+        end
     else
-        return :(typeof(similar(x, S, size(x))))
+        newtype = quote
+            $(Expr(:meta, :inline))
+            typeof(similar(x, S, size(x)))
+        end
     end
+    return newtype
 end
 
 #######################################

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -16,7 +16,7 @@ function eltype_param_number{T<:AbstractArray}(::Type{T})
     end
 end
 
-@inline Base.@pure @generated function replace_eltype{T,S}(x::AbstractArray{T}, ::Type{S})
+@inline @generated function replace_eltype{T,S}(x::AbstractArray{T}, ::Type{S})
     if x.mutable
         pnum = eltype_param_number(x.name.primary)
         tname = x.name.primary

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -11,13 +11,13 @@ end
 
 function JacobianCache{N}(x, chunk::Chunk{N})
     T = eltype(x)
-    duals = Array{Dual{N,T}}(size(x))
+    duals = similar(x, Dual{N,T}, size(x))
     seeds = construct_seeds(T, chunk)
     return JacobianCache{N,T,typeof(duals)}(duals, seeds)
 end
 
-@inline jacobian_dual_type{N}(arr, ::Chunk{N}) = Array{Dual{N,eltype(arr)},ndims(arr)}
-@inline jacobian_dual_type{T,M,N}(::AbstractArray{T,M}, ::Chunk{N}) = Array{Dual{N,T},M}
+@inline jacobian_dual_type{N}(arr, ::Chunk{N}) = typeof(similar(arr, Dual{N,eltype(arr)},size(arr)))
+@inline jacobian_dual_type{T,M,N}(arr::AbstractArray{T,M}, ::Chunk{N}) = typeof(similar(arr, Dual{N,T}, size(arr)))
 
 Base.copy(cache::JacobianCache) = JacobianCache(copy(cache.duals), cache.seeds)
 
@@ -51,14 +51,14 @@ end
 
 function HessianCache{N}(x, chunk::Chunk{N})
     T = eltype(x)
-    duals = Array{Dual{N,Dual{N,T}}}(size(x))
+    duals = similar(x, Dual{N,Dual{N,T}}, size(x))
     inseeds = construct_seeds(T, chunk)
     outseeds = construct_seeds(Dual{N,T}, chunk)
     return HessianCache{N,T,typeof(duals)}(duals, inseeds, outseeds)
 end
 
-@inline hessian_dual_type{N}(arr, ::Chunk{N}) = Array{Dual{Dual{N,eltype(arr)}},ndims(arr)}
-@inline hessian_dual_type{T,M,N}(::AbstractArray{T,M}, ::Chunk{N}) = Array{Dual{N,Dual{N,T}},M}
+@inline hessian_dual_type{N}(arr, ::Chunk{N}) = typeof(similar(arr, Dual{Dual{N,eltype(arr)}}, size(arr)))
+@inline hessian_dual_type{T,M,N}(arr::AbstractArray{T,M}, ::Chunk{N}) = typeof(similar(arr, Dual{N,Dual{N,T}}, size(arr)))
 
 Base.copy(cache::HessianCache) = HessianCache(copy(cache.duals), cache.inseeds, cache.outseeds)
 

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -18,7 +18,7 @@ end
 
 @inline Base.@pure @generated function replace_eltype{T,S}(x::AbstractArray{T}, ::Type{S})
     pnum = eltype_param_number(x.name.primary)
-    tname = x.name.name
+    tname = x.name.primary
     tparams = collect(x.parameters)
     tparams[pnum] = S
     newtype = :($(tname){$(tparams...)})

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -29,9 +29,6 @@ end
     end
 end
 
-# Fallback method
-@inline replace_eltype{T}(x, ::Type{T}) = typeof(similar(x, T, size(x)))
-
 #######################################
 # caching for Jacobians and gradients #
 #######################################

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -25,6 +25,9 @@ end
     return newtype
 end
 
+# Fallback method
+@inline replace_eltype{T}(x, ::Type{S}) = typeof(similar(x, S, size(x)))
+
 #######################################
 # caching for Jacobians and gradients #
 #######################################

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -47,9 +47,9 @@ end
 
 Base.copy(cache::JacobianCache) = JacobianCache(copy(cache.duals), cache.seeds)
 
-@eval function multithread_jacobian_cachefetch!{N}(x, chunk::Chunk{N}, usecache::Bool,
+@eval function multithread_jacobian_cachefetch!{T<:AbstractArray, N}(x::T, chunk::Chunk{N}, usecache::Bool,
                                                    alt::Bool = false)
-    T, xlen = eltype(x), length(x)
+    S, xlen = eltype(x), length(x)
     if usecache
         result = get!(JACOBIAN_CACHE, (xlen, N, T, alt)) do
             construct_jacobian_caches(x, chunk)
@@ -57,7 +57,7 @@ Base.copy(cache::JacobianCache) = JacobianCache(copy(cache.duals), cache.seeds)
     else
         result = construct_jacobian_caches(x, chunk)
     end
-    return result::NTuple{$NTHREADS,JacobianCache{N,T,jacobian_dual_type(x, chunk)}}
+    return result::NTuple{$NTHREADS,JacobianCache{N,S,jacobian_dual_type(x, chunk)}}
 end
 
 jacobian_cachefetch!(args...) = multithread_jacobian_cachefetch!(args...)[compat_threadid()]
@@ -87,8 +87,8 @@ end
 
 Base.copy(cache::HessianCache) = HessianCache(copy(cache.duals), cache.inseeds, cache.outseeds)
 
-@eval function multithread_hessian_cachefetch!{N}(x, chunk::Chunk{N}, usecache::Bool)
-    T = eltype(x)
+@eval function multithread_hessian_cachefetch!{T<:AbstractArray,N}(x::T, chunk::Chunk{N}, usecache::Bool)
+    S = eltype(x)
     if usecache
         result = get!(HESSIAN_CACHE, (N, T)) do
             construct_hessian_caches(x, chunk)
@@ -96,7 +96,7 @@ Base.copy(cache::HessianCache) = HessianCache(copy(cache.duals), cache.inseeds, 
     else
         result = construct_hessian_caches(x, chunk)
     end
-    return result::NTuple{$NTHREADS,HessianCache{N,T,hessian_dual_type(x, chunk)}}
+    return result::NTuple{$NTHREADS,HessianCache{N,S,hessian_dual_type(x, chunk)}}
 end
 
 hessian_cachefetch!(args...) = multithread_hessian_cachefetch!(args...)[compat_threadid()]

--- a/test/MiscTest.jl
+++ b/test/MiscTest.jl
@@ -81,10 +81,15 @@ x = rand(5, 5)
 # Differentiation with non-Array inputs #
 #########################################
 
-x = rand(5, 5)
-jinvx = ForwardDiff.jacobian(inv, x)
+x = rand(5,5)
 
-@test_approx_eq jinvx ForwardDiff.jacobian(inv, sparse(x))
+# Sparse
+f = x -> sum(sin, x) + prod(tan, x) * sum(sqrt, x)
+gfx = ForwardDiff.gradient(f, x)
+@test_approx_eq gfx ForwardDiff.gradient(f, sparse(x))
+
+# Views
+jinvx = ForwardDiff.jacobian(inv, x)
 @test_approx_eq jinvx ForwardDiff.jacobian(inv, Compat.view(x, 1:5, 1:5))
 
 ########################


### PR DESCRIPTION
I have been writing a [vector calculus package](https://github.com/lstagner/VectorCalculus.jl) that uses ForwardDiff

With this package you can do things like

```julia
grad(phi::Function, x::Coordinate) #Calculate gradient of scalar field phi
laplacian(phi, x::Coordinate) #Calculate laplacian of of scalar field phi
div(A::Function, x::Coordinate) #Calculate divergence of vector field A
curl(A::Function, x::Coordinate) #Calculate curl (Doesn't work yet)
```
These routines (should) work in any arbitrary coordinate system, even non-orthogonal curvilinear systems. 
This is possible because of the `Coordinate` type carries around a transformation function.

```julia
type Coordinate{T,F<:Function} <: AbstractArray{T,1}
    u::Vector{T} #Coordinates
    R::F         #Transformation (x,y,z,...) = R(u₁,u₂,u₃,...)
end
```
So when you creates co/contravariant vectors it also calculates the correct metric.

The way the Jacobian/Hessian cache was constructed in ForwardDiff was preventing me from using the `Coordinate` type. Changing the cache constructors to use `similar` allows me to use the `Coordinate` type with some caveats.

I have been unable to resolve an issue when `usecache=true` is set. It hits the type assertion in `multithread_(jacobian/hessian)_cachefetch!`. As far as I can tell this shouldn't happen. This also cause the "miscellaneous" tests to fail.

For now I have been setting `usecache=false` and everything works as expected.