### PR TITLE
Update stale multithreading code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: julia
 julia:
     - 0.4
+    - 0.5
     - nightly
 notifications:
     email: false

--- a/src/ForwardDiff.jl
+++ b/src/ForwardDiff.jl
@@ -14,7 +14,7 @@ import NaNMath
 # multithreading #
 #----------------#
 
-const IS_MULTITHREADED_JULIA = VERSION >= v"0.5.0-dev+923" && Base.Threads.nthreads() > 1
+const IS_MULTITHREADED_JULIA = VERSION >= v"0.5.0-dev+923"
 
 if IS_MULTITHREADED_JULIA
     const NTHREADS = Base.Threads.nthreads()

--- a/test/HessianTest.jl
+++ b/test/HessianTest.jl
@@ -39,7 +39,7 @@ for c in (Chunk{1}(), Chunk{2}(), Chunk{3}())
     if ForwardDiff.IS_MULTITHREADED_JULIA
         @test_approx_eq h ForwardDiff.hessian(rosenbrock, x, c; multithread = true)
 
-        out = similar(x)
+        out = similar(x, 3, 3)
         ForwardDiff.hessian!(out, rosenbrock, x, c; multithread = true)
         @test_approx_eq out h
 


### PR DESCRIPTION
The multithreaded gradient implementation went stale at some point, and wasn't being tested on Travis because the `IS_MULTITHREADED_JULIA` conditional depended on `nthreads() > 1`. 

This updates the code and removes the `nthreads() > 1` condition (since it doesn't really help anything).