### PR TITLE
Dual specializations for trig-related functions

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -318,6 +318,42 @@ end
     return Dual(sqrtv, deriv * partials(n))
 end
 
+@inline Base.hypot{N}(x::Dual{N}, y::Dual{N}) = calc_hypot(x, y)
+@inline Base.hypot(x::Dual, y::Real) = calc_hypot(x, y)
+@inline Base.hypot(x::Real, y::Dual) = calc_hypot(x, y)
+
+@inline function calc_hypot(x, y)
+    vx = value(x)
+    vy = value(y)
+    h = hypot(vx, vy)
+    return Dual(h, (vx/h) * partials(x) + (vy/h) * partials(y))
+end
+
+# define hypot(x,y,z) for combinations of {Dual,Real}
+DualReal = (:Dual, :Real)
+for A in DualReal, B in DualReal, C in DualReal
+    (A === :Real && B === :Real && C === :Real) && continue
+    @eval(@inline Base.hypot(x::$A, y::$B, z::$C) = calc_hypot(x, y, z))
+end
+
+@inline function calc_hypot(x, y, z)
+    vx = value(x)
+    vy = value(y)
+    vz = value(z)
+    h = hypot(vx, vy, vz)
+    return Dual(h, (vx/h) * partials(x) + (vy/h) * partials(y) + (vz/h) * partials(z))
+end
+
+@inline sincos(n) = (sin(n), cos(n))
+
+@inline function sincos(n::Dual)
+    sn, cn = sincos(value(n))
+    return (
+        Dual(sn, cn * partials(n)),
+        Dual(cn, -sn * partials(n)),
+    )
+end
+
 # Other Functions #
 #-----------------#
 

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -14,6 +14,12 @@ samerng() = MersenneTwister(1)
 # exponent by one
 intrand(T) = T == Int ? rand(2:10) : rand(T)
 
+# fix testing issue with Base.hypot(::Int...) undefined in 0.4
+if v"0.4" <= VERSION < v"0.5"
+    Base.hypot(x::Int, y::Int) = Base.hypot(Float64(x), Float64(y))
+    Base.hypot(x, y, z) = hypot(hypot(x, y), z)
+end
+
 for N in (0,3), M in (0,4), T in (Int, Float32)
     println("  ...testing Dual{$N,$T} and Dual{$N,Dual{$M,$T}}")
 
@@ -405,6 +411,20 @@ for N in (0,3), M in (0,4), T in (Int, Float32)
             end
         end
     end
+
+    # Manually Optimized Functions #
+    # ---------------------------- #
+
+    let
+        x = FDNUM
+        y = FDNUM2
+
+        @test isapprox(hypot(x, y), sqrt(x*x + y*y), rtol=1e-6)
+        @test isapprox(hypot(x, y, x), sqrt(x*x + y*y + x*x), rtol=1e-6)
+        @test isapprox(collect(ForwardDiff.sincos(x)), [sin(x), cos(x)], rtol=1e-6)
+
+    end
+
 end
 
 end # module


### PR DESCRIPTION
Added Dual specializations for:
  - hypot(x, y)
  - hypot(x, y, z)
  - sincos(x) = (sin(x), cos(x))

Fixes #148 