### PR TITLE
enable one-sided nested differentiation for binary Dual functions

### DIFF
--- a/src/config.jl
+++ b/src/config.jl
@@ -4,6 +4,8 @@ abstract AbstractConfig
 # Config #
 ###########
 
+@inline chunksize(::Tuple{}) = error("empty tuple passed to `chunksize`")
+
 # Define a few different AbstractConfig types. All these types share the same structure,
 # but feature different constructors and dispatch restrictions in downstream code.
 for Config in (:GradientConfig, :JacobianConfig)
@@ -33,8 +35,8 @@ for Config in (:GradientConfig, :JacobianConfig)
         Base.copy{N,T,D}(cfg::$Config{N,T,D}) = $Config{N,T,D}(cfg.seeds, copy(cfg.duals))
         Base.copy{N,T,D<:Tuple}(cfg::$Config{N,T,D}) = $Config{N,T,D}(cfg.seeds, map(copy, cfg.duals))
 
-        chunksize{N}(::$Config{N}) = N
-        chunksize{N}(::Tuple{Vararg{$Config{N}}}) = N
+        @inline chunksize{N}(::$Config{N}) = N
+        @inline chunksize{N}(::Tuple{Vararg{$Config{N}}}) = N
     end
 end
 

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -1,3 +1,5 @@
+const ExternalReal = Union{subtypes(Real)...}
+
 ########
 # Dual #
 ########
@@ -54,7 +56,26 @@ degree{N,T}(::Type{Dual{N,T}}) = 1 + degree(T)
 
 macro ambiguous(ex)
     def = ex.head == :macrocall ? ex.args[2] : ex
-    f = def.args[1].args[1].args[1]
+    sig = def.args[1]
+    body = def.args[2]
+    f = isa(sig.args[1], Expr) && sig.args[1].head == :curly ? sig.args[1].args[1] : sig.args[1]
+    a, b = sig.args[2].args[1], sig.args[3].args[1]
+    Ta, Tb = sig.args[2].args[2], sig.args[3].args[2]
+    if isa(a, Symbol) && isa(b, Symbol) && isa(Ta, Symbol) && isa(Tb, Symbol)
+        if Ta == :Real && Tb == :Dual
+            return quote
+                $(f){N,M,A<:ExternalReal,B<:Dual}($(a)::Dual{N,A}, $(b)::Dual{M,B}) = $(body)
+                $(esc(ex))
+            end
+        elseif Ta == :Dual && Tb == :Real
+            return quote
+                $(f){N,M,A<:Dual,B<:ExternalReal}($(a)::Dual{N,A}, $(b)::Dual{M,B}) = $(body)
+                $(esc(ex))
+            end
+        else
+            return esc(ex)
+        end
+    end
     return quote
         $(f)(a::Dual, b::Dual) = error("npartials($(typeof(a))) != npartials($(typeof(b)))")
         if !(in($f, (isequal, ==, isless, <, <=, <)))
@@ -160,7 +181,6 @@ Base.promote_rule{N,A<:Real,B<:Real}(::Type{Dual{N,A}}, ::Type{B}) = Dual{N,prom
 Base.promote_rule{N,A<:Real,B<:Real}(::Type{A}, ::Type{Dual{N,B}}) = Dual{N,promote_type(A, B)}
 
 Base.convert(::Type{Dual}, n::Dual) = n
-Base.convert{N1,N2,T<:Real}(D::Type{Dual{N1,T}}, n::Dual{N2}) = error("can't convert $(typeof(n)) to $(D)")
 Base.convert{N,T<:Real}(::Type{Dual{N,T}}, n::Dual{N}) = Dual(convert(T, value(n)), convert(Partials{N,T}, partials(n)))
 Base.convert{D<:Dual}(::Type{D}, n::D) = n
 Base.convert{N,T<:Real}(::Type{Dual{N,T}}, x::Real) = Dual(convert(T, x), zero(Partials{N,T}))
@@ -181,12 +201,12 @@ Base.float{N,T}(n::Dual{N,T}) = Dual{N,promote_type(T, Float16)}(n)
 #----------------------#
 
 @ambiguous @inline @compat(Base.:+){N}(n1::Dual{N}, n2::Dual{N}) = Dual(value(n1) + value(n2), partials(n1) + partials(n2))
-@inline @compat(Base.:+)(n::Dual, x::Real) = Dual(value(n) + x, partials(n))
-@inline @compat(Base.:+)(x::Real, n::Dual) = n + x
+@ambiguous @inline @compat(Base.:+)(n::Dual, x::Real) = Dual(value(n) + x, partials(n))
+@ambiguous @inline @compat(Base.:+)(x::Real, n::Dual) = n + x
 
 @ambiguous @inline @compat(Base.:-){N}(n1::Dual{N}, n2::Dual{N}) = Dual(value(n1) - value(n2), partials(n1) - partials(n2))
-@inline @compat(Base.:-)(n::Dual, x::Real) = Dual(value(n) - x, partials(n))
-@inline @compat(Base.:-)(x::Real, n::Dual) = Dual(x - value(n), -(partials(n)))
+@ambiguous @inline @compat(Base.:-)(n::Dual, x::Real) = Dual(value(n) - x, partials(n))
+@ambiguous @inline @compat(Base.:-)(x::Real, n::Dual) = Dual(x - value(n), -(partials(n)))
 @inline @compat(Base.:-)(n::Dual) = Dual(-(value(n)), -(partials(n)))
 
 # Multiplication #
@@ -200,8 +220,8 @@ Base.float{N,T}(n::Dual{N,T}) = Dual{N,promote_type(T, Float16)}(n)
     return Dual(v1 * v2, _mul_partials(partials(n1), partials(n2), v2, v1))
 end
 
-@inline @compat(Base.:*)(n::Dual, x::Real) = Dual(value(n) * x, partials(n) * x)
-@inline @compat(Base.:*)(x::Real, n::Dual) = n * x
+@ambiguous @inline @compat(Base.:*)(n::Dual, x::Real) = Dual(value(n) * x, partials(n) * x)
+@ambiguous @inline @compat(Base.:*)(x::Real, n::Dual) = n * x
 
 # Division #
 #----------#
@@ -211,13 +231,13 @@ end
     return Dual(v1 / v2, _div_partials(partials(n1), partials(n2), v1, v2))
 end
 
-@inline function @compat(Base.:/)(x::Real, n::Dual)
+@ambiguous @inline function @compat(Base.:/)(x::Real, n::Dual)
     v = value(n)
     divv = x / v
     return Dual(divv, -(divv / v) * partials(n))
 end
 
-@inline @compat(Base.:/)(n::Dual, x::Real) = Dual(value(n) / x, partials(n) / x)
+@ambiguous @inline @compat(Base.:/)(n::Dual, x::Real) = Dual(value(n) / x, partials(n) / x)
 
 # Exponentiation #
 #----------------#
@@ -242,14 +262,14 @@ for f in (macroexpand(:(@compat(Base.:^))), :(NaNMath.pow))
 
     for T in (:Integer, :Rational, :Real)
         @eval begin
-            @inline function ($f)(n::Dual, x::$(T))
+            @ambiguous @inline function ($f)(n::Dual, x::$(T))
                 v = value(n)
                 expv = ($f)(v, x)
                 deriv = x * ($f)(v, x - 1)
                 return Dual(expv, deriv * partials(n))
             end
 
-            @inline function ($f)(x::$(T), n::Dual)
+            @ambiguous @inline function ($f)(x::$(T), n::Dual)
                 v = value(n)
                 expv = ($f)(x, v)
                 deriv = expv*log(x)
@@ -334,9 +354,9 @@ end
     return Dual(h, (vx/h) * partials(x) + (vy/h) * partials(y) + (vz/h) * partials(z))
 end
 
-@inline Base.hypot{N}(x::Dual{N}, y::Dual{N}) = calc_hypot(x, y)
-@inline Base.hypot(x::Dual, y::Real) = calc_hypot(x, y)
-@inline Base.hypot(x::Real, y::Dual) = calc_hypot(x, y)
+@ambiguous @inline Base.hypot{N}(x::Dual{N}, y::Dual{N}) = calc_hypot(x, y)
+@ambiguous @inline Base.hypot(x::Dual, y::Real) = calc_hypot(x, y)
+@ambiguous @inline Base.hypot(x::Real, y::Dual) = calc_hypot(x, y)
 
 for A in (:(Dual{N}), :Real), B in (:(Dual{N}), :Real), C in (:(Dual{N}), :Real)
     (A == B == C == :Real) && continue
@@ -362,8 +382,8 @@ end
 end
 
 @ambiguous @inline Base.atan2{N}(y::Dual{N}, x::Dual{N}) = calc_atan2(y, x)
-@inline Base.atan2(y::Real, x::Dual) = calc_atan2(y, x)
-@inline Base.atan2(y::Dual, x::Real) = calc_atan2(y, x)
+@ambiguous @inline Base.atan2(y::Real, x::Dual) = calc_atan2(y, x)
+@ambiguous @inline Base.atan2(y::Dual, x::Real) = calc_atan2(y, x)
 
 ###################
 # Pretty Printing #

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -65,11 +65,17 @@ macro ambiguous(ex)
         if Ta == :Real && Tb == :Dual
             return quote
                 @inline $(f){N,M,A<:ExternalReal,B<:Dual}($(a)::Dual{N,A}, $(b)::Dual{M,B}) = $(body)
+                @inline $(f){A<:ExternalReal,B<:Dual}($(a)::Dual{0,A}, $(b)::Dual{0,B}) = Dual($(f)(value(a), value(b)))
+                @inline $(f){M,A<:ExternalReal,B<:Dual}($(a)::Dual{0,A}, $(b)::Dual{M,B}) = $(f)(value(a), b)
+                @inline $(f){N,A<:ExternalReal,B<:Dual}($(a)::Dual{N,A}, $(b)::Dual{0,B}) = $(f)(a, value(b))
                 $(esc(ex))
             end
         elseif Ta == :Dual && Tb == :Real
             return quote
                 @inline $(f){N,M,A<:Dual,B<:ExternalReal}($(a)::Dual{N,A}, $(b)::Dual{M,B}) = $(body)
+                @inline $(f){A<:Dual,B<:ExternalReal}($(a)::Dual{0,A}, $(b)::Dual{0,B}) = Dual($(f)(value(a), value(b)))
+                @inline $(f){M,A<:Dual,B<:ExternalReal}($(a)::Dual{0,A}, $(b)::Dual{M,B}) = $(f)(value(a), b)
+                @inline $(f){N,A<:Dual,B<:ExternalReal}($(a)::Dual{N,A}, $(b)::Dual{0,B}) = $(f)(a, value(b))
                 $(esc(ex))
             end
         else

--- a/test/MiscTest.jl
+++ b/test/MiscTest.jl
@@ -54,7 +54,9 @@ test_nested_jacobian_output = [-sin(1)  0.0     0.0;
                                -0.0    -0.0    -0.0;
                                -0.0    -0.0    -sin(3)]
 
-@test_approx_eq ForwardDiff.jacobian(x -> ForwardDiff.jacobian(sin, x), [1, 2, 3]) test_nested_jacobian_output
+sin_jacobian = x -> ForwardDiff.jacobian(y -> broadcast(sin, y), x)
+
+@test_approx_eq ForwardDiff.jacobian(sin_jacobian, [1., 2., 3.]) test_nested_jacobian_output
 
 # Issue #59 example #
 #-------------------#


### PR DESCRIPTION
This makes it possible to do mixed-mode nested AD using ReverseDiff's pre-compiled tapes, which can be faster and more memory efficient than using `ForwardDiff.hessian` or `ReverseDiff.hessian`.

This change intends to be equivalent to adding the following definitions to binary Dual functions:

```julia
f{N,M,A<:Real,B<:Dual}(a::Dual{N,A}, b::Dual{M,B}) = invoke(f, (Real, Dual), a, b)
f{N,M,A<:Dual,B<:Real}(a::Dual{N,A}, b::Dual{M,B}) = invoke(f, (Dual, Real), a, b)
```

...but instead of the above, it does a bit of gymnastics to avoid `invoke`. 
