### PR TITLE
don't accidentally widen input type in sqrt calculation

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -339,7 +339,7 @@ end
 
 @inline function Base.sqrt{N}(n::Dual{N})
     sqrtv = sqrt(value(n))
-    deriv = 0.5 / sqrtv
+    deriv = inv(sqrtv + sqrtv)
     return Dual(sqrtv, deriv * partials(n))
 end
 

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -428,6 +428,10 @@ for N in (0,3), M in (0,4), T in (Int, Float32)
     test_approx_diffnums(hypot(FDNUM, FDNUM2, FDNUM), sqrt(2*(FDNUM^2) + FDNUM2^2))
     map(test_approx_diffnums, ForwardDiff.sincos(FDNUM), (sin(FDNUM), cos(FDNUM)))
 
+    if T === Float32
+        @test typeof(sqrt(FDNUM)) === typeof(FDNUM)
+        @test typeof(sqrt(NESTED_FDNUM)) === typeof(NESTED_FDNUM)
+    end
 end
 
 end # module


### PR DESCRIPTION
fixes #169 

This doesn't seem to introduce any significant performance difference. On master (`d` is a `Dual{3,Float64}`):

```julia
julia> @benchmark sqrt($d)
BenchmarkTools.Trial:
  memory estimate:  0.00 bytes
  allocs estimate:  0
  --------------
  minimum time:     9.078 ns (0.00% GC)
  median time:      9.113 ns (0.00% GC)
  mean time:        9.119 ns (0.00% GC)
  maximum time:     17.372 ns (0.00% GC)
```

with this PR:

```julia
julia> @benchmark sqrt($d)
BenchmarkTools.Trial:
  memory estimate:  0.00 bytes
  allocs estimate:  0
  --------------
  minimum time:     9.087 ns (0.00% GC)
  median time:      9.098 ns (0.00% GC)
  mean time:        9.165 ns (0.00% GC)
  maximum time:     62.783 ns (0.00% GC)
```