### PR TITLE
Added a method for Base.rtoldefault, fixing #176.

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -173,6 +173,8 @@ Base.isinteger(n::Dual) = isinteger(value(n))
 Base.iseven(n::Dual) = iseven(value(n))
 Base.isodd(n::Dual) = isodd(value(n))
 
+Base.rtoldefault{N, T <: Real}(::Type{Dual{N,T}}) = Base.rtoldefault(T)
+
 ########################
 # Promotion/Conversion #
 ########################

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -100,6 +100,8 @@ Base.copy(n::Dual) = n
 Base.eps(n::Dual) = eps(value(n))
 Base.eps{D<:Dual}(::Type{D}) = eps(valtype(D))
 
+Base.rtoldefault{N, T <: Real}(::Type{Dual{N,T}}) = Base.rtoldefault(T)
+
 Base.floor{T<:Real}(::Type{T}, n::Dual) = floor(T, value(n))
 Base.floor(n::Dual) = floor(value(n))
 
@@ -172,8 +174,6 @@ Base.isreal(n::Dual) = isreal(value(n))
 Base.isinteger(n::Dual) = isinteger(value(n))
 Base.iseven(n::Dual) = iseven(value(n))
 Base.isodd(n::Dual) = isodd(value(n))
-
-Base.rtoldefault{N, T <: Real}(::Type{Dual{N,T}}) = Base.rtoldefault(T)
 
 ########################
 # Promotion/Conversion #

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -134,6 +134,7 @@ for N in (0,3), M in (0,4), T in (Int, Float32)
 
         @test Base.rtoldefault(typeof(FDNUM)) ≡ Base.rtoldefault(typeof(PRIMAL))
         @test Dual(PRIMAL-eps(T), PARTIALS) ≈ FDNUM
+        @test Base.rtoldefault(typeof(NESTED_FDNUM)) ≡ Base.rtoldefault(typeof(PRIMAL))
     end
 
     @test hash(FDNUM) === hash(PRIMAL)

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -131,6 +131,9 @@ for N in (0,3), M in (0,4), T in (Int, Float32)
         @test round(FDNUM) === round(PRIMAL)
         @test round(FDNUM2) === round(PRIMAL2)
         @test round(NESTED_FDNUM) === round(PRIMAL)
+
+        @test Base.rtoldefault(typeof(FDNUM)) ≡ Base.rtoldefault(typeof(PRIMAL))
+        @test Dual(PRIMAL-eps(T), PARTIALS) ≈ FDNUM
     end
 
     @test hash(FDNUM) === hash(PRIMAL)
@@ -432,12 +435,6 @@ for N in (0,3), M in (0,4), T in (Int, Float32)
         @test typeof(sqrt(FDNUM)) === typeof(FDNUM)
         @test typeof(sqrt(NESTED_FDNUM)) === typeof(NESTED_FDNUM)
     end
-end
-
-let p = Partials((0.0,0.0)),
-    d = Dual(1.0, p)
-    @test Base.rtoldefault(typeof(d)) ≡ Base.rtoldefault(typeof(value(d)))
-    @test Dual(1.0-eps(Float64), p) ≈ d
 end
 
 end # module

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -434,4 +434,10 @@ for N in (0,3), M in (0,4), T in (Int, Float32)
     end
 end
 
+let p = Partials((0.0,0.0)),
+    d = Dual(1.0, p)
+    @test Base.rtoldefault(typeof(d)) ≡ Base.rtoldefault(typeof(value(d)))
+    @test Dual(1.0-eps(Float64), p) ≈ d
+end
+
 end # module


### PR DESCRIPTION
Small fix for #176, with tests. Assumes that only `value` is compared by predicated (looks that way from the code), hope this is correct.