### PR TITLE
Julia v0.6 updates and deprecation fixes

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -308,10 +308,13 @@ for fsym in AUTO_DEFINED_UNARY_FUNCS
     v = :v
     deriv = Calculus.differentiate(:($(fsym)($v)), v)
 
-    @eval begin
-        @inline function Base.$(fsym)(n::Dual)
-            $(v) = value(n)
-            return Dual($(fsym)($v), $(deriv) * partials(n))
+    # exp and sqrt are manually defined below
+    if !(in(fsym, (:exp, :sqrt)))
+        @eval begin
+            @inline function Base.$(fsym)(n::Dual)
+                $(v) = value(n)
+                return Dual($(fsym)($v), $(deriv) * partials(n))
+            end
         end
     end
 

--- a/test/DerivativeTest.jl
+++ b/test/DerivativeTest.jl
@@ -21,8 +21,8 @@ for f in DiffBase.NUMBER_TO_NUMBER_FUNCS
 
     out = DiffBase.DiffResult(zero(v), zero(v))
     ForwardDiff.derivative!(out, f, x)
-    @test_approx_eq DiffBase.value(out) v
-    @test_approx_eq DiffBase.derivative(out) d
+    @test isapprox(DiffBase.value(out), v)
+    @test isapprox(DiffBase.derivative(out), d)
 end
 
 for f in DiffBase.NUMBER_TO_ARRAY_FUNCS
@@ -33,12 +33,12 @@ for f in DiffBase.NUMBER_TO_ARRAY_FUNCS
 
     out = similar(v)
     ForwardDiff.derivative!(out, f, x)
-    @test_approx_eq out d
+    @test isapprox(out, d)
 
     out = DiffBase.DiffResult(zero(v), similar(d))
     ForwardDiff.derivative!(out, f, x)
-    @test_approx_eq DiffBase.value(out) v
-    @test_approx_eq DiffBase.derivative(out) d
+    @test isapprox(DiffBase.value(out), v)
+    @test isapprox(DiffBase.derivative(out), d)
 end
 
 

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -20,7 +20,13 @@ if v"0.4" <= VERSION < v"0.5"
     Base.hypot(x, y, z) = hypot(hypot(x, y), z)
 end
 
-test_approx_diffnums(a::Real, b::Real) = @test isapprox(a, b)
+if VERSION < v"0.5"
+    # isapprox on v0.4 doesn't properly set the tolerance
+    # for mixed-precision inputs, while @test_approx_eq does
+    test_approx_diffnums(a::Real, b::Real) = @test_approx_eq a b
+else
+    test_approx_diffnums(a::Real, b::Real) = @test isapprox(a, b)
+end
 
 function test_approx_diffnums{N}(a::Dual{N}, b::Dual{N})
     test_approx_diffnums(value(a), value(b))

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -20,7 +20,7 @@ if v"0.4" <= VERSION < v"0.5"
     Base.hypot(x, y, z) = hypot(hypot(x, y), z)
 end
 
-test_approx_diffnums(a::Real, b::Real) = @test_approx_eq a b
+test_approx_diffnums(a::Real, b::Real) = @test isapprox(a, b)
 
 function test_approx_diffnums{N}(a::Dual{N}, b::Dual{N})
     test_approx_diffnums(value(a), value(b))

--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -22,42 +22,42 @@ for c in (1, 2, 3)
 
     # single-threaded #
     #-----------------#
-    @test_approx_eq g ForwardDiff.gradient(f, x, cfg)
-    @test_approx_eq g ForwardDiff.gradient(f, x)
+    @test isapprox(g, ForwardDiff.gradient(f, x, cfg))
+    @test isapprox(g, ForwardDiff.gradient(f, x))
 
     out = similar(x)
     ForwardDiff.gradient!(out, f, x, cfg)
-    @test_approx_eq out g
+    @test isapprox(out, g)
 
     out = similar(x)
     ForwardDiff.gradient!(out, f, x)
-    @test_approx_eq out g
+    @test isapprox(out, g)
 
     out = DiffBase.GradientResult(x)
     ForwardDiff.gradient!(out, f, x, cfg)
-    @test_approx_eq DiffBase.value(out) v
-    @test_approx_eq DiffBase.gradient(out) g
+    @test isapprox(DiffBase.value(out), v)
+    @test isapprox(DiffBase.gradient(out), g)
 
     out = DiffBase.GradientResult(x)
     ForwardDiff.gradient!(out, f, x)
-    @test_approx_eq DiffBase.value(out) v
-    @test_approx_eq DiffBase.gradient(out) g
+    @test isapprox(DiffBase.value(out), v)
+    @test isapprox(DiffBase.gradient(out), g)
 
     # multithreaded #
     #---------------#
     if ForwardDiff.IS_MULTITHREADED_JULIA
         multi_cfg = ForwardDiff.MultithreadConfig(cfg)
 
-        @test_approx_eq g ForwardDiff.gradient(f, x, multi_cfg)
+        @test isapprox(g, ForwardDiff.gradient(f, x, multi_cfg))
 
         out = similar(x)
         ForwardDiff.gradient!(out, f, x, multi_cfg)
-        @test_approx_eq out g
+        @test isapprox(out, g)
 
         out = DiffBase.GradientResult(x)
         ForwardDiff.gradient!(out, f, x, multi_cfg)
-        @test_approx_eq DiffBase.value(out) v
-        @test_approx_eq DiffBase.gradient(out) g
+        @test isapprox(DiffBase.value(out), v)
+        @test isapprox(DiffBase.gradient(out), g)
     end
 end
 
@@ -76,16 +76,16 @@ for f in DiffBase.VECTOR_TO_NUMBER_FUNCS
         # single-threaded #
         #-----------------#
         out = ForwardDiff.gradient(f, X, cfg)
-        @test_approx_eq out g
+        @test isapprox(out, g)
 
         out = similar(X)
         ForwardDiff.gradient!(out, f, X, cfg)
-        @test_approx_eq out g
+        @test isapprox(out, g)
 
         out = DiffBase.GradientResult(X)
         ForwardDiff.gradient!(out, f, X, cfg)
-        @test_approx_eq DiffBase.value(out) v
-        @test_approx_eq DiffBase.gradient(out) g
+        @test isapprox(DiffBase.value(out), v)
+        @test isapprox(DiffBase.gradient(out), g)
 
         # multithreaded #
         #---------------#
@@ -93,16 +93,16 @@ for f in DiffBase.VECTOR_TO_NUMBER_FUNCS
             multi_cfg = ForwardDiff.MultithreadConfig(cfg)
 
             out = ForwardDiff.gradient(f, X, multi_cfg)
-            @test_approx_eq out g
+            @test isapprox(out, g)
 
             out = similar(X)
             ForwardDiff.gradient!(out, f, X, multi_cfg)
-            @test_approx_eq out g
+            @test isapprox(out, g)
 
             out = DiffBase.GradientResult(X)
             ForwardDiff.gradient!(out, f, X, multi_cfg)
-            @test_approx_eq DiffBase.value(out) v
-            @test_approx_eq DiffBase.gradient(out) g
+            @test isapprox(DiffBase.value(out), v)
+            @test isapprox(DiffBase.gradient(out), g)
         end
     end
 end

--- a/test/HessianTest.jl
+++ b/test/HessianTest.jl
@@ -26,28 +26,28 @@ for c in (1, 2, 3)
 
     # single-threaded #
     #-----------------#
-    @test_approx_eq h ForwardDiff.hessian(f, x)
-    @test_approx_eq h ForwardDiff.hessian(f, x, cfg)
+    @test isapprox(h, ForwardDiff.hessian(f, x))
+    @test isapprox(h, ForwardDiff.hessian(f, x, cfg))
 
     out = similar(x, 3, 3)
     ForwardDiff.hessian!(out, f, x)
-    @test_approx_eq out h
+    @test isapprox(out, h)
 
     out = similar(x, 3, 3)
     ForwardDiff.hessian!(out, f, x, cfg)
-    @test_approx_eq out h
+    @test isapprox(out, h)
 
     out = DiffBase.HessianResult(x)
     ForwardDiff.hessian!(out, f, x)
-    @test_approx_eq DiffBase.value(out) v
-    @test_approx_eq DiffBase.gradient(out) g
-    @test_approx_eq DiffBase.hessian(out) h
+    @test isapprox(DiffBase.value(out), v)
+    @test isapprox(DiffBase.gradient(out), g)
+    @test isapprox(DiffBase.hessian(out), h)
 
     out = DiffBase.HessianResult(x)
     ForwardDiff.hessian!(out, f, x, resultcfg)
-    @test_approx_eq DiffBase.value(out) v
-    @test_approx_eq DiffBase.gradient(out) g
-    @test_approx_eq DiffBase.hessian(out) h
+    @test isapprox(DiffBase.value(out), v)
+    @test isapprox(DiffBase.gradient(out), g)
+    @test isapprox(DiffBase.hessian(out), h)
 
     # multithreaded #
     #---------------#
@@ -55,17 +55,17 @@ for c in (1, 2, 3)
         multi_cfg = ForwardDiff.MultithreadConfig(cfg)
         multi_resultcfg = ForwardDiff.MultithreadConfig(resultcfg)
 
-        @test_approx_eq h ForwardDiff.hessian(f, x, multi_cfg)
+        @test isapprox(h, ForwardDiff.hessian(f, x, multi_cfg))
 
         out = similar(x, 3, 3)
         ForwardDiff.hessian!(out, f, x, multi_cfg)
-        @test_approx_eq out h
+        @test isapprox(out, h)
 
         out = DiffBase.HessianResult(x)
         ForwardDiff.hessian!(out, f, x, multi_resultcfg)
-        @test_approx_eq DiffBase.value(out) v
-        @test_approx_eq DiffBase.gradient(out) g
-        @test_approx_eq DiffBase.hessian(out) h
+        @test isapprox(DiffBase.value(out), v)
+        @test isapprox(DiffBase.gradient(out), g)
+        @test isapprox(DiffBase.hessian(out), h)
     end
 end
 
@@ -87,17 +87,17 @@ for f in DiffBase.VECTOR_TO_NUMBER_FUNCS
         # single-threaded #
         #-----------------#
         out = ForwardDiff.hessian(f, X, cfg)
-        @test_approx_eq out h
+        @test isapprox(out, h)
 
         out = similar(X, length(X), length(X))
         ForwardDiff.hessian!(out, f, X, cfg)
-        @test_approx_eq out h
+        @test isapprox(out, h)
 
         out = DiffBase.HessianResult(X)
         ForwardDiff.hessian!(out, f, X, resultcfg)
-        @test_approx_eq DiffBase.value(out) v
-        @test_approx_eq DiffBase.gradient(out) g
-        @test_approx_eq DiffBase.hessian(out) h
+        @test isapprox(DiffBase.value(out), v)
+        @test isapprox(DiffBase.gradient(out), g)
+        @test isapprox(DiffBase.hessian(out), h)
 
         # multithreaded #
         #---------------#
@@ -106,17 +106,17 @@ for f in DiffBase.VECTOR_TO_NUMBER_FUNCS
             multi_resultcfg = ForwardDiff.MultithreadConfig(resultcfg)
 
             out = ForwardDiff.hessian(f, X, multi_cfg)
-            @test_approx_eq out h
+            @test isapprox(out, h)
 
             out = similar(X, length(X), length(X))
             ForwardDiff.hessian!(out, f, X, multi_cfg)
-            @test_approx_eq out h
+            @test isapprox(out, h)
 
             out = DiffBase.HessianResult(X)
             ForwardDiff.hessian!(out, f, X, multi_resultcfg)
-            @test_approx_eq DiffBase.value(out) v
-            @test_approx_eq DiffBase.gradient(out) g
-            @test_approx_eq DiffBase.hessian(out) h
+            @test isapprox(DiffBase.value(out), v)
+            @test isapprox(DiffBase.gradient(out), g)
+            @test isapprox(DiffBase.hessian(out), h)
         end
     end
 end

--- a/test/JacobianTest.jl
+++ b/test/JacobianTest.jl
@@ -34,54 +34,54 @@ for c in (1, 2, 3)
     ycfg = JacobianConfig{c}(zeros(4), x)
 
     # testing f(x)
-    @test_approx_eq j ForwardDiff.jacobian(f, x, cfg)
-    @test_approx_eq j ForwardDiff.jacobian(f, x)
+    @test isapprox(j, ForwardDiff.jacobian(f, x, cfg))
+    @test isapprox(j, ForwardDiff.jacobian(f, x))
 
     out = zeros(4, 3)
     ForwardDiff.jacobian!(out, f, x, cfg)
-    @test_approx_eq out j
+    @test isapprox(out, j)
 
     out = zeros(4, 3)
     ForwardDiff.jacobian!(out, f, x)
-    @test_approx_eq out j
+    @test isapprox(out, j)
 
     out = DiffBase.JacobianResult(zeros(4), zeros(3))
     ForwardDiff.jacobian!(out, f, x, JacobianConfig(x))
-    @test_approx_eq DiffBase.value(out) v
-    @test_approx_eq DiffBase.jacobian(out) j
+    @test isapprox(DiffBase.value(out), v)
+    @test isapprox(DiffBase.jacobian(out), j)
 
     # testing f!(y, x)
     y = zeros(4)
-    @test_approx_eq j ForwardDiff.jacobian(f!, y, x, ycfg)
-    @test_approx_eq v y
+    @test isapprox(j, ForwardDiff.jacobian(f!, y, x, ycfg))
+    @test isapprox(v, y)
 
     y = zeros(4)
-    @test_approx_eq j ForwardDiff.jacobian(f!, y, x)
-    @test_approx_eq v y
+    @test isapprox(j, ForwardDiff.jacobian(f!, y, x))
+    @test isapprox(v, y)
 
     out, y = zeros(4, 3), zeros(4)
     ForwardDiff.jacobian!(out, f!, y, x, ycfg)
-    @test_approx_eq out j
-    @test_approx_eq y v
+    @test isapprox(out, j)
+    @test isapprox(y, v)
 
     out, y = zeros(4, 3), zeros(4)
     ForwardDiff.jacobian!(out, f!, y, x)
-    @test_approx_eq out j
-    @test_approx_eq y v
+    @test isapprox(out, j)
+    @test isapprox(y, v)
 
     out = DiffBase.JacobianResult(zeros(4), zeros(3))
     y = zeros(4)
     ForwardDiff.jacobian!(out, f!, y, x, ycfg)
     @test DiffBase.value(out) == y
-    @test_approx_eq y v
-    @test_approx_eq DiffBase.jacobian(out) j
+    @test isapprox(y, v)
+    @test isapprox(DiffBase.jacobian(out), j)
 
     out = DiffBase.JacobianResult(zeros(4), zeros(3))
     y = zeros(4)
     ForwardDiff.jacobian!(out, f!, y, x)
     @test DiffBase.value(out) == y
-    @test_approx_eq y v
-    @test_approx_eq DiffBase.jacobian(out) j
+    @test isapprox(y, v)
+    @test isapprox(DiffBase.jacobian(out), j)
 end
 
 ########################
@@ -97,16 +97,16 @@ for f in DiffBase.ARRAY_TO_ARRAY_FUNCS
 
         println("  ...testing $f with chunk size = $c")
         out = ForwardDiff.jacobian(f, X, cfg)
-        @test_approx_eq out j
+        @test isapprox(out, j)
 
         out = similar(X, length(v), length(X))
         ForwardDiff.jacobian!(out, f, X, cfg)
-        @test_approx_eq out j
+        @test isapprox(out, j)
 
         out = DiffBase.DiffResult(similar(v, length(v)), similar(v, length(v), length(X)))
         ForwardDiff.jacobian!(out, f, X, cfg)
-        @test_approx_eq DiffBase.value(out) v
-        @test_approx_eq DiffBase.jacobian(out) j
+        @test isapprox(DiffBase.value(out), v)
+        @test isapprox(DiffBase.jacobian(out), j)
     end
 end
 
@@ -122,28 +122,28 @@ for f! in DiffBase.INPLACE_ARRAY_TO_ARRAY_FUNCS
         println("  ...testing $(f!) with chunk size = $c")
         y = zeros(Y)
         out = ForwardDiff.jacobian(f!, y, X, ycfg)
-        @test_approx_eq y v
-        @test_approx_eq out j
+        @test isapprox(y, v)
+        @test isapprox(out, j)
 
         y = zeros(Y)
         out = similar(Y, length(Y), length(X))
         ForwardDiff.jacobian!(out, f!, y, X)
-        @test_approx_eq y v
-        @test_approx_eq out j
+        @test isapprox(y, v)
+        @test isapprox(out, j)
 
         y = zeros(Y)
         out = DiffBase.JacobianResult(y, X)
         ForwardDiff.jacobian!(out, f!, y, X)
         @test DiffBase.value(out) == y
-        @test_approx_eq y v
-        @test_approx_eq DiffBase.jacobian(out) j
+        @test isapprox(y, v)
+        @test isapprox(DiffBase.jacobian(out), j)
 
         y = zeros(Y)
         out = DiffBase.JacobianResult(y, X)
         ForwardDiff.jacobian!(out, f!, y, X, ycfg)
         @test DiffBase.value(out) == y
-        @test_approx_eq y v
-        @test_approx_eq DiffBase.jacobian(out) j
+        @test isapprox(y, v)
+        @test isapprox(DiffBase.jacobian(out), j)
     end
 end
 

--- a/test/MiscTest.jl
+++ b/test/MiscTest.jl
@@ -21,7 +21,7 @@ f = x -> sum(sin, x) + prod(tan, x) * sum(sqrt, x)
 g = x -> ForwardDiff.gradient(f, x)
 j = x -> ForwardDiff.jacobian(g, x)
 
-@test_approx_eq ForwardDiff.hessian(f, x) j(x)
+@test isapprox(ForwardDiff.hessian(f, x), j(x))
 
 # higher-order derivatives #
 #--------------------------#
@@ -42,7 +42,7 @@ test_tensor_output = reshape([240.0  -400.0     0.0;
                                 0.0  -400.0     0.0;
                                 0.0     0.0     0.0], 3, 3, 3)
 
-@test_approx_eq tensor(DiffBase.rosenbrock_1, [0.1, 0.2, 0.3]) test_tensor_output
+@test isapprox(tensor(DiffBase.rosenbrock_1, [0.1, 0.2, 0.3]), test_tensor_output)
 
 test_nested_jacobian_output = [-sin(1)  0.0     0.0;
                                -0.0    -0.0    -0.0;
@@ -56,7 +56,7 @@ test_nested_jacobian_output = [-sin(1)  0.0     0.0;
 
 sin_jacobian = x -> ForwardDiff.jacobian(y -> broadcast(sin, y), x)
 
-@test_approx_eq ForwardDiff.jacobian(sin_jacobian, [1., 2., 3.]) test_nested_jacobian_output
+@test isapprox(ForwardDiff.jacobian(sin_jacobian, [1., 2., 3.]), test_nested_jacobian_output)
 
 # Issue #59 example #
 #-------------------#
@@ -69,7 +69,7 @@ testdf = x -> (((cos(x)^2)/3) - (sin(x)^2)/3) / 2
 f2 = x -> df(x[1]) * f(x[2])
 testf2 = x -> testdf(x[1]) * f(x[2])
 
-@test_approx_eq ForwardDiff.gradient(f2, x) ForwardDiff.gradient(testf2, x)
+@test isapprox(ForwardDiff.gradient(f2, x), ForwardDiff.gradient(testf2, x))
 
 ######################################
 # Higher-Dimensional Differentiation #
@@ -77,7 +77,7 @@ testf2 = x -> testdf(x[1]) * f(x[2])
 
 x = rand(5, 5)
 
-@test_approx_eq ForwardDiff.jacobian(inv, x) -kron(inv(x'), inv(x))
+@test isapprox(ForwardDiff.jacobian(inv, x), -kron(inv(x'), inv(x)))
 
 #########################################
 # Differentiation with non-Array inputs #
@@ -88,11 +88,11 @@ x = rand(5,5)
 # Sparse
 f = x -> sum(sin, x) + prod(tan, x) * sum(sqrt, x)
 gfx = ForwardDiff.gradient(f, x)
-@test_approx_eq gfx ForwardDiff.gradient(f, sparse(x))
+@test isapprox(gfx, ForwardDiff.gradient(f, sparse(x)))
 
 # Views
 jinvx = ForwardDiff.jacobian(inv, x)
-@test_approx_eq jinvx ForwardDiff.jacobian(inv, Compat.view(x, 1:5, 1:5))
+@test isapprox(jinvx, ForwardDiff.jacobian(inv, Compat.view(x, 1:5, 1:5)))
 
 ########################
 # Conversion/Promotion #
@@ -116,7 +116,7 @@ jac0 = reshape(vcat([[zeros(N*(i-1)); a; zeros(N^2-N*i)] for i = 1:N]...), N^2, 
 for op in (-, +, .-, .+, ./, .*)
     f = x -> [op(x[1], a); op(x[2], a); op(x[3], a); op(x[4], a)]
     jac = ForwardDiff.jacobian(f, a)
-    @test_approx_eq jac0 jac
+    @test isapprox(jac0, jac)
 end
 
 # NaNs #


### PR DESCRIPTION
Julia v0.6 tests here will depend on https://github.com/JuliaDiff/DiffBase.jl/pull/1. ForwardDiff users will still see a bunch of depwarns from Calculus.jl, so I'm working on fixing those as well.

