### PR TITLE
bump version requirements for Calculus, DiffBase, and NaNMath to include v0.6 fixes

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.4
-DiffBase 0.0.1
+DiffBase 0.0.3
 Compat 0.8.6
-Calculus 0.1.15
-NaNMath 0.2.1
+Calculus 0.2.0
+NaNMath 0.2.2

--- a/src/ForwardDiff.jl
+++ b/src/ForwardDiff.jl
@@ -1,4 +1,4 @@
-isdefined(Base, :__precompile__) && __precompile__()
+__precompile__()
 
 module ForwardDiff
 


### PR DESCRIPTION
This PR depends on https://github.com/JuliaLang/METADATA.jl/pull/7645 getting merged. I plan on tagging a new patch release of ForwardDiff once this is merged.

