### PR TITLE
Fix most depwarn on 0.6

### DIFF
--- a/src/config.jl
+++ b/src/config.jl
@@ -10,11 +10,11 @@ abstract AbstractConfig
 # but feature different constructors and dispatch restrictions in downstream code.
 for Config in (:GradientConfig, :JacobianConfig)
     @eval begin
-        immutable $Config{N,T,D} <: AbstractConfig
+        @compat immutable $Config{N,T,D} <: AbstractConfig
             seeds::NTuple{N,Partials{N,T}}
             duals::D
             # disable default outer constructor
-            $Config(seeds, duals) = new(seeds, duals)
+            (::Type{$Config{N,T,D}}){N,T,D}(seeds, duals) = new{N,T,D}(seeds, duals)
         end
 
         # This is type-unstable, which is why our docs advise users to manually enter a chunk size

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -14,10 +14,10 @@ Base.@deprecate JacobianResult(x) DiffBase.JacobianResult(x)
 Base.@deprecate HessianResult(x, y, z) DiffBase.DiffResult(x, y, z)
 Base.@deprecate HessianResult(x) DiffBase.HessianResult(x)
 
-immutable Chunk{N}
-    function Chunk()
+@compat immutable Chunk{N}
+    function (::Type{Chunk{N}}){N}()
         Base.depwarn("Chunk{N}() is deprecated, use the ForwardDiff.AbstractConfig API instead.", :Chunk)
-        return new()
+        return new{N}()
     end
 end
 

--- a/test/DerivativeTest.jl
+++ b/test/DerivativeTest.jl
@@ -17,7 +17,7 @@ for f in DiffBase.NUMBER_TO_NUMBER_FUNCS
     println("  ...testing $f")
     v = f(x)
     d = ForwardDiff.derivative(f, x)
-    @test_approx_eq_eps d Calculus.derivative(f, x) FINITEDIFF_ERROR
+    @test isapprox(d, Calculus.derivative(f, x), atol=FINITEDIFF_ERROR)
 
     out = DiffBase.DiffResult(zero(v), zero(v))
     ForwardDiff.derivative!(out, f, x)
@@ -29,7 +29,7 @@ for f in DiffBase.NUMBER_TO_ARRAY_FUNCS
     println("  ...testing $f")
     v = f(x)
     d = ForwardDiff.derivative(f, x)
-    @test_approx_eq_eps d Calculus.derivative(f, x) FINITEDIFF_ERROR
+    @test isapprox(d, Calculus.derivative(f, x), atol=FINITEDIFF_ERROR)
 
     out = similar(v)
     ForwardDiff.derivative!(out, f, x)

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -23,7 +23,8 @@ end
 if VERSION < v"0.5"
     # isapprox on v0.4 doesn't properly set the tolerance
     # for mixed-precision inputs, while @test_approx_eq does
-    test_approx_diffnums(a::Real, b::Real) = @test_approx_eq a b
+    # Use @eval to avoid expanding @test_approx_eq on 0.6 where it's deprecated
+    @eval test_approx_diffnums(a::Real, b::Real) = @test_approx_eq a b
 else
     test_approx_diffnums(a::Real, b::Real) = @test isapprox(a, b)
 end

--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -68,7 +68,7 @@ end
 for f in DiffBase.VECTOR_TO_NUMBER_FUNCS
     v = f(X)
     g = ForwardDiff.gradient(f, X)
-    @test_approx_eq_eps g Calculus.gradient(f, X) FINITEDIFF_ERROR
+    @test isapprox(g, Calculus.gradient(f, X), atol=FINITEDIFF_ERROR)
     for c in CHUNK_SIZES
         println("  ...testing $f with chunk size = $c")
         cfg = ForwardDiff.GradientConfig{c}(X)

--- a/test/MiscTest.jl
+++ b/test/MiscTest.jl
@@ -113,9 +113,9 @@ N = 4
 a = ones(N)
 jac0 = reshape(vcat([[zeros(N*(i-1)); a; zeros(N^2-N*i)] for i = 1:N]...), N^2, N)
 
-for op in (-, +, .-, .+, ./, .*)
-    f = x -> [op(x[1], a); op(x[2], a); op(x[3], a); op(x[4], a)]
-    jac = ForwardDiff.jacobian(f, a)
+for op in (:-, :+, :.-, :.+, :./, :.*)
+    f = @eval x -> [$op(x[1], a); $op(x[2], a); $op(x[3], a); $op(x[4], a)]
+    jac = @eval ForwardDiff.jacobian(f, a)
     @test isapprox(jac0, jac)
 end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -11,6 +11,3 @@ const YLEN = div(CHUNK_THRESHOLD, 2) + 1
 const X, Y = rand(XLEN), rand(YLEN)
 const CHUNK_SIZES = (1, div(CHUNK_THRESHOLD, 3), div(CHUNK_THRESHOLD, 2), CHUNK_THRESHOLD, CHUNK_THRESHOLD + 1)
 const FINITEDIFF_ERROR = 1.5e-5
-
-# used to test against results calculated via finite difference
-test_approx_eps(a::Array, b::Array) = @test_approx_eq_eps a b EPS


### PR DESCRIPTION
There are 3 `@test_approx_eq_eps` that are not fixed. Naively replacing them causes the tests to fail. Not sure which corner case they are hitting yet.