### PR TITLE
Fix 0.6 abstract type declaration depwarn

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.4
 DiffBase 0.0.3
-Compat 0.8.6
+Compat 0.17.0
 Calculus 0.2.0
 NaNMath 0.2.2

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,4 +1,4 @@
-abstract AbstractConfig
+@compat abstract type AbstractConfig end
 
 ###########
 # Config #


### PR DESCRIPTION
Local tests pass on 0.4 and 0.5. I'm assuming @ararslan [will have `a branch that should fix it` on 0.6](https://github.com/JuliaStats/StatsBase.jl/pull/235#issuecomment-279183388).