### PR TITLE
use SpecialFunctions package due to function deprecations in Julia v0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ DiffBase 0.0.3
 Compat 0.17.0
 Calculus 0.2.0
 NaNMath 0.2.2
+SpecialFunctions 0.1.0

--- a/src/ForwardDiff.jl
+++ b/src/ForwardDiff.jl
@@ -8,6 +8,7 @@ using DiffBase: DiffResult
 
 import Calculus
 import NaNMath
+import SpecialFunctions
 
 #############################
 # types/functions/constants #
@@ -35,8 +36,16 @@ end
 #---------------------#
 
 const AUTO_DEFINED_UNARY_FUNCS = map(first, Calculus.symbolic_derivatives_1arg())
+
 const NANMATH_FUNCS = (:sin, :cos, :tan, :asin, :acos, :acosh,
                        :atanh, :log, :log2, :log10, :lgamma, :log1p)
+
+const SPECIAL_FUNCS = (:erf, :erfc, :erfinv, :erfcinv, :erfi, :erfcx,
+                       :dawson, :digamma, :eta, :zeta, :airyai, :airyaiprime,
+                       :airybi, :airybiprime, :airyaix, :besselj, :besselj0,
+                       :besselj1, :besseljx, :bessely, :bessely0, :bessely1,
+                       :besselyx, :besselh, :hankelh1, :hankelh1x, :hankelh2,
+                       :hankelh2x, :besseli, :besselix, :besselk, :besselkx)
 
 # chunk settings #
 #----------------#

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -310,10 +310,21 @@ for fsym in AUTO_DEFINED_UNARY_FUNCS
 
     # exp and sqrt are manually defined below
     if !(in(fsym, (:exp, :sqrt)))
-        @eval begin
-            @inline function Base.$(fsym)(n::Dual)
-                $(v) = value(n)
-                return Dual($(fsym)($v), $(deriv) * partials(n))
+        is_special_function = in(fsym, SPECIAL_FUNCS)
+        if is_special_function
+            @eval begin
+                @inline function SpecialFunctions.$(fsym)(n::Dual)
+                    $(v) = value(n)
+                    return Dual(SpecialFunctions.$(fsym)($v), $(deriv) * partials(n))
+                end
+            end
+        end
+        if !(is_special_function) || VERSION < v"0.6.0-dev.2767"
+            @eval begin
+                @inline function Base.$(fsym)(n::Dual)
+                    $(v) = value(n)
+                    return Dual(Base.$(fsym)($v), $(deriv) * partials(n))
+                end
             end
         end
     end


### PR DESCRIPTION
Supercedes #192 - we should actually overload SpecialFunctions functions instead of Base functions on v0.6.

For example, on v0.5, this PR will overload both `Base.erf` and `SpecialFuntions.erf` with `Dual` definitions. If `VERSION >= v"0.6.0-dev.2767"`, only `SpecialFuntions.erf` is overloaded with a `Dual` definition.