### PR TITLE
temporarily disable nested simd_sum test

### DIFF
--- a/test/SIMDTest.jl
+++ b/test/SIMDTest.jl
@@ -36,10 +36,11 @@ for D in map(typeof, DUALS)
     if !(valtype(D) <: Dual)
         # see https://github.com/JuliaDiff/ForwardDiff.jl/issues/167
         @test ismatch(r"fmul \<.*?x double\>", exp_bitcode)
-    end
 
-    sum_bitcode = sprint(io -> code_llvm(io, simd_sum, (Vector{D},)))
-    @test ismatch(r"fadd \<.*?x double\>", sum_bitcode)
+        # see https://github.com/JuliaDiff/ForwardDiff.jl/pull/201
+        sum_bitcode = sprint(io -> code_llvm(io, simd_sum, (Vector{D},)))
+        @test ismatch(r"fadd \<.*?x double\>", sum_bitcode)
+    end
 end
 
 end # module


### PR DESCRIPTION
`code_llvm(simd_sum, (Vector{ForwardDiff.Dual{1,ForwardDiff.Dual{1,Float64}}},))` no longer seems to contain vector instructions on the v0.6. I suspect this is a Julia v0.6 regression, and not a ForwardDiff regression, so I'm just going to disable the test for now.

Somebody more LLVM IR-literate than me might want to follow up on this (remember to test with `-O3` enabled).

