### PR TITLE
fix seed-reset order for no-op cases where input === the output

### DIFF
--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -94,17 +94,17 @@ function chunk_mode_gradient_expr(out_definition::Expr)
         # do first chunk manually to calculate output type
         seed!(xdual, x, 1, seeds)
         ydual = f(xdual)
-        seed!(xdual, x, 1)
         $(out_definition)
         extract_gradient_chunk!(out, ydual, 1, N)
+        seed!(xdual, x, 1)
 
         # do middle chunks
         for c in middlechunks
             i = ((c - 1) * N + 1)
             seed!(xdual, x, i, seeds)
             ydual = f(xdual)
-            seed!(xdual, x, i)
             extract_gradient_chunk!(out, ydual, i, N)
+            seed!(xdual, x, i)
         end
 
         # do final chunk
@@ -156,9 +156,9 @@ if IS_MULTITHREADED_JULIA
             # do first chunk manually to calculate output type
             seed!(current_xdual, x, 1, current_seeds)
             current_ydual = f(current_xdual)
-            seed!(current_xdual, x, 1)
             $(out_definition)
             extract_gradient_chunk!(out, current_ydual, 1, N)
+            seed!(current_xdual, x, 1)
 
             # do middle chunks
             Base.Threads.@threads for c in middlechunks
@@ -169,8 +169,8 @@ if IS_MULTITHREADED_JULIA
                 local chunk_index = ((c - 1) * N + 1)
                 seed!(chunk_xdual, x, chunk_index, chunk_seeds)
                 local chunk_dual = f(chunk_xdual)
-                seed!(chunk_xdual, x, chunk_index)
                 extract_gradient_chunk!(out, chunk_dual, chunk_index, N)
+                seed!(chunk_xdual, x, chunk_index)
             end
 
             # do final chunk

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -125,18 +125,18 @@ function jacobian_chunk_mode_expr(work_array_definition::Expr, compute_ydual::Ex
         # do first chunk manually to calculate output type
         seed!(xdual, x, 1, seeds)
         $(compute_ydual)
-        seed!(xdual, x, 1)
         $(out_definition)
         out_reshaped = reshape_jacobian(out, ydual, xdual)
         extract_jacobian_chunk!(out_reshaped, ydual, 1, N)
+        seed!(xdual, x, 1)
 
         # do middle chunks
         for c in middlechunks
             i = ((c - 1) * N + 1)
             seed!(xdual, x, i, seeds)
             $(compute_ydual)
-            seed!(xdual, x, i)
             extract_jacobian_chunk!(out_reshaped, ydual, i, N)
+            seed!(xdual, x, i)
         end
 
         # do final chunk


### PR DESCRIPTION
See https://github.com/JuliaDiff/ReverseDiff.jl/pull/60.

Before this PR:

```julia
julia> ForwardDiff.jacobian(identity, rand(11))
11×11 Array{Float64,2}:
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  1.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  1.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  1.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  1.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  1.0
```

After this PR:

```julia
julia> ForwardDiff.jacobian(identity, rand(11))
11×11 Array{Float64,2}:
 1.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  1.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  1.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  1.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  1.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  1.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  1.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  1.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  1.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  1.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  1.0
```

Test added in DiffBase [here](https://github.com/JuliaDiff/DiffBase.jl/pull/3). Note tests will fail once https://github.com/JuliaDiff/DiffBase.jl/pull/3 is merged and tagged, because ForwardDiff is testing against Calculus and Calculus appears to be getting this wrong as well:

```julia
julia> Calculus.jacobian(identity, rand(11), :forward)
11×11 Array{Float64,2}:
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
```