### PR TITLE
Cherry-pick #204 to a new release-0.3 branch that supports Julia 0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: julia
 julia:
     - 0.4
     - 0.5
-    - nightly
 notifications:
     email: false
 sudo: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
-julia 0.4
-DiffBase 0.0.3
+julia 0.4 0.6
+DiffBase 0.0.1
 Compat 0.8.6
-Calculus 0.2.0
-NaNMath 0.2.2
+Calculus 0.1.15
+NaNMath 0.2.1

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -94,17 +94,17 @@ function chunk_mode_gradient_expr(out_definition::Expr)
         # do first chunk manually to calculate output type
         seed!(xdual, x, 1, seeds)
         ydual = f(xdual)
-        seed!(xdual, x, 1)
         $(out_definition)
         extract_gradient_chunk!(out, ydual, 1, N)
+        seed!(xdual, x, 1)
 
         # do middle chunks
         for c in middlechunks
             i = ((c - 1) * N + 1)
             seed!(xdual, x, i, seeds)
             ydual = f(xdual)
-            seed!(xdual, x, i)
             extract_gradient_chunk!(out, ydual, i, N)
+            seed!(xdual, x, i)
         end
 
         # do final chunk
@@ -156,9 +156,9 @@ if IS_MULTITHREADED_JULIA
             # do first chunk manually to calculate output type
             seed!(current_xdual, x, 1, current_seeds)
             current_ydual = f(current_xdual)
-            seed!(current_xdual, x, 1)
             $(out_definition)
             extract_gradient_chunk!(out, current_ydual, 1, N)
+            seed!(current_xdual, x, 1)
 
             # do middle chunks
             Base.Threads.@threads for c in middlechunks
@@ -169,8 +169,8 @@ if IS_MULTITHREADED_JULIA
                 local chunk_index = ((c - 1) * N + 1)
                 seed!(chunk_xdual, x, chunk_index, chunk_seeds)
                 local chunk_dual = f(chunk_xdual)
-                seed!(chunk_xdual, x, chunk_index)
                 extract_gradient_chunk!(out, chunk_dual, chunk_index, N)
+                seed!(chunk_xdual, x, chunk_index)
             end
 
             # do final chunk

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -125,18 +125,18 @@ function jacobian_chunk_mode_expr(work_array_definition::Expr, compute_ydual::Ex
         # do first chunk manually to calculate output type
         seed!(xdual, x, 1, seeds)
         $(compute_ydual)
-        seed!(xdual, x, 1)
         $(out_definition)
         out_reshaped = reshape_jacobian(out, ydual, xdual)
         extract_jacobian_chunk!(out_reshaped, ydual, 1, N)
+        seed!(xdual, x, 1)
 
         # do middle chunks
         for c in middlechunks
             i = ((c - 1) * N + 1)
             seed!(xdual, x, i, seeds)
             $(compute_ydual)
-            seed!(xdual, x, i)
             extract_jacobian_chunk!(out_reshaped, ydual, i, N)
+            seed!(xdual, x, i)
         end
 
         # do final chunk


### PR DESCRIPTION
Ref https://github.com/JuliaDiff/ForwardDiff.jl/pull/185#issuecomment-287239945, would like to change the target branch to that once it's created. DiffBase 0.0.5 still supports Julia 0.4 and caused ForwardDiff 0.3.4, the last tag here that supported 0.4, to now fail its tests - https://github.com/JuliaCI/pkg.julialang.org/blob/69282b38ea4ea43a5b300862eac40d89bbf03b7a/logs/ForwardDiff_0.4.log

In local testing, this fixes it.