### PR TITLE
fix wrong partials multiplied in FMA

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -414,13 +414,13 @@ end
     vx, vy = value(x), value(y)
     result = fma(vx, vy, value(z))
     return Dual(result,
-                _mul_partials(partials(x), partials(y), vx, vy) + partials(z))
+                _mul_partials(partials(x), partials(y), vy, vx) + partials(z))
 end
 
 @inline function Base.fma(x::Dual, y::Dual, z::Real)
     vx, vy = value(x), value(y)
     result = fma(vx, vy, z)
-    return Dual(result, _mul_partials(partials(x), partials(y), vx, vy))
+    return Dual(result, _mul_partials(partials(x), partials(y), vy, vx))
 end
 
 @inline function Base.fma(x::Dual, y::Real, z::Dual)

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -387,20 +387,20 @@ for N in (0,3), M in (0,4), T in (Int, Float32)
 
     @test partials(NaNMath.pow(Dual(-2.0, 1.0), Dual(2.0, 0.0)), 1) == -4.0
 
-    @test fma(FDNUM, FDNUM2, FDNUM3) == Dual(fma(PRIMAL, PRIMAL2, PRIMAL3),
+    test_approx_diffnums(fma(FDNUM, FDNUM2, FDNUM3), Dual(fma(PRIMAL, PRIMAL2, PRIMAL3),
                                              PRIMAL*PARTIALS2 + PRIMAL2*PARTIALS +
-                                             PARTIALS3)
-    @test fma(FDNUM, FDNUM2, PRIMAL3) == Dual(fma(PRIMAL, PRIMAL2, PRIMAL3),
-                                              PRIMAL*PARTIALS2 + PRIMAL2*PARTIALS)
-    @test fma(PRIMAL, FDNUM2, FDNUM3) == Dual(fma(PRIMAL, PRIMAL2, PRIMAL3),
-                                              PRIMAL*PARTIALS2 + PARTIALS3)
-    @test fma(PRIMAL, FDNUM2, PRIMAL3) == Dual(fma(PRIMAL, PRIMAL2, PRIMAL3),
-                                               PRIMAL*PARTIALS2)
-    @test fma(FDNUM, PRIMAL2, FDNUM3) == Dual(fma(PRIMAL, PRIMAL2, PRIMAL3),
-                                              PRIMAL2*PARTIALS + PARTIALS3)
-    @test fma(FDNUM, PRIMAL2, PRIMAL3) == Dual(fma(PRIMAL, PRIMAL2, PRIMAL3),
-                                               PRIMAL2*PARTIALS)
-    @test fma(PRIMAL, PRIMAL2, FDNUM3) == Dual(fma(PRIMAL, PRIMAL2, PRIMAL3), PARTIALS3)
+                                             PARTIALS3))
+    test_approx_diffnums(fma(FDNUM, FDNUM2, PRIMAL3), Dual(fma(PRIMAL, PRIMAL2, PRIMAL3),
+                                              PRIMAL*PARTIALS2 + PRIMAL2*PARTIALS))
+    test_approx_diffnums(fma(PRIMAL, FDNUM2, FDNUM3), Dual(fma(PRIMAL, PRIMAL2, PRIMAL3),
+                                              PRIMAL*PARTIALS2 + PARTIALS3))
+    test_approx_diffnums(fma(PRIMAL, FDNUM2, PRIMAL3), Dual(fma(PRIMAL, PRIMAL2, PRIMAL3),
+                                               PRIMAL*PARTIALS2))
+    test_approx_diffnums(fma(FDNUM, PRIMAL2, FDNUM3), Dual(fma(PRIMAL, PRIMAL2, PRIMAL3),
+                                              PRIMAL2*PARTIALS + PARTIALS3))
+    test_approx_diffnums(fma(FDNUM, PRIMAL2, PRIMAL3), Dual(fma(PRIMAL, PRIMAL2, PRIMAL3),
+                                               PRIMAL2*PARTIALS))
+    test_approx_diffnums(fma(PRIMAL, PRIMAL2, FDNUM3), Dual(fma(PRIMAL, PRIMAL2, PRIMAL3), PARTIALS3))
 
     # Unary Functions #
     #-----------------#


### PR DESCRIPTION
The methods gave the wrong partials but this was not noticed in the tests because `==` only compares the `value` part:

```jl
julia> x, y, z = Dual(1,1,2,3), Dual(2,4,5,6), Dual(3,7,8,9);

julia> x*y + z - fma(x, y, z)
Dual(0,-3,-3,-3)
```

 Fix the bug and introduce a `dualapprox` function to test approximate results of both the value and partial part:

```jl
julia> x, y, z = Dual(1,1,2,3), Dual(2,4,5,6), Dual(3,7,8,9);

julia> x*y + z - fma(x, y, z)
Dual(0,0,0,0)
```

cc @tpapp 