### PR TITLE
Add specialized StaticArrays-based methods

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6-
-StaticArrays 0.4
+StaticArrays 0.5.0
 DiffBase 0.0.3
 Calculus 0.2.0
 NaNMath 0.2.2

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.6-
+StaticArrays 0.4
 DiffBase 0.0.3
 Calculus 0.2.0
 NaNMath 0.2.2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:

--- a/src/ForwardDiff.jl
+++ b/src/ForwardDiff.jl
@@ -4,6 +4,7 @@ module ForwardDiff
 
 using DiffBase
 using DiffBase: DiffResult
+using StaticArrays
 
 import Calculus
 import NaNMath
@@ -40,6 +41,29 @@ const REAL_TYPES = (AbstractFloat, Irrational, Integer, Rational, Real)
 #----------------#
 
 const DEFAULT_CHUNK_THRESHOLD = 10
+
+struct Chunk{N} end
+
+function Chunk(input_length::Integer, threshold::Integer = DEFAULT_CHUNK_THRESHOLD)
+    N = pickchunksize(input_length, threshold)
+    return Chunk{N}()
+end
+
+function Chunk(x::AbstractArray, threshold::Integer = DEFAULT_CHUNK_THRESHOLD)
+    return Chunk(length(x), threshold)
+end
+
+# Constrained to `N <= threshold`, minimize (in order of priority):
+#   1. the number of chunks that need to be computed
+#   2. the number of "left over" perturbations in the final chunk
+function pickchunksize(input_length, threshold = DEFAULT_CHUNK_THRESHOLD)
+    if input_length <= threshold
+        return input_length
+    else
+        nchunks = round(Int, input_length / DEFAULT_CHUNK_THRESHOLD, RoundUp)
+        return round(Int, input_length / nchunks, RoundUp)
+    end
+end
 
 ############
 # includes #

--- a/src/config.jl
+++ b/src/config.jl
@@ -18,33 +18,6 @@ struct Tag{F,H} end
     end
 end
 
-#########
-# Chunk #
-#########
-
-struct Chunk{N} end
-
-function Chunk(input_length::Integer, threshold::Integer = DEFAULT_CHUNK_THRESHOLD)
-    N = pickchunksize(input_length, threshold)
-    return Chunk{N}()
-end
-
-function Chunk(x::AbstractArray, threshold::Integer = DEFAULT_CHUNK_THRESHOLD)
-    return Chunk(length(x), threshold)
-end
-
-# Constrained to `N <= threshold`, minimize (in order of priority):
-#   1. the number of chunks that need to be computed
-#   2. the number of "left over" perturbations in the final chunk
-function pickchunksize(input_length, threshold = DEFAULT_CHUNK_THRESHOLD)
-    if input_length <= threshold
-        return input_length
-    else
-        nchunks = round(Int, input_length / DEFAULT_CHUNK_THRESHOLD, RoundUp)
-        return round(Int, input_length / nchunks, RoundUp)
-    end
-end
-
 ##################
 # AbstractConfig #
 ##################

--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -22,7 +22,7 @@ end
 
 @inline extract_derivative(y::Dual{T,V,1}) where {T,V} = partials(y, 1)
 @inline extract_derivative(y::Real) = zero(y)
-@inline extract_derivative(y::AbstractArray) = extract_derivative!(similar(y, valtype(eltype(y))), y)
+@inline extract_derivative(y::AbstractArray) = map(extract_derivative, y)
 
 # mutating #
 #----------#

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -21,7 +21,7 @@ end
 @inline (::Type{Dual{T}})(value::Real, partials::Tuple) where {T} = Dual{T}(value, Partials(partials))
 @inline (::Type{Dual{T}})(value::Real, partials::Tuple{}) where {T} = Dual{T}(value, Partials{0,typeof(value)}(partials))
 @inline (::Type{Dual{T}})(value::Real, partials::Real...) where {T} = Dual{T}(value, partials)
-@inline (::Type{Dual{T}})(value::V, ::Type{Val{N}}, ::Type{Val{i}}) where {T,V<:Real,N,i} = Dual{T}(value, single_seed(Partials{N,V}, Val{i}))
+@inline (::Type{Dual{T}})(value::V, ::Chunk{N}, p::Val{i}) where {T,V<:Real,N,i} = Dual{T}(value, single_seed(Partials{N,V}, p))
 
 @inline Dual(args...) = Dual{Void}(args...)
 

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -24,13 +24,9 @@ function gradient!(out, f::F, x, cfg::AllowedGradientConfig{F,H} = GradientConfi
     return out
 end
 
-@inline function gradient(f::F, x::SArray) where F
-    return extract_gradient(vector_mode_dual_eval(f, x), x)
-end
+@inline gradient(f::F, x::SArray) where {F} = vector_mode_gradient(f, x)
 
-@inline function gradient!(out, f::F, x::SArray) where F
-    return extract_gradient!(out, vector_mode_dual_eval(f, x))
-end
+@inline gradient!(out, f::F, x::SArray) where {F} = vector_mode_gradient!(out, f, x)
 
 #####################
 # result extraction #
@@ -87,6 +83,14 @@ function vector_mode_gradient!(out, f::F, x, cfg) where {F}
     ydual = vector_mode_dual_eval(f, x, cfg)
     extract_gradient!(out, ydual)
     return out
+end
+
+@inline function vector_mode_gradient(f::F, x::SArray) where F
+    return extract_gradient(vector_mode_dual_eval(f, x), x)
+end
+
+@inline function vector_mode_gradient!(out, f::F, x::SArray) where F
+    return extract_gradient!(out, vector_mode_dual_eval(f, x))
 end
 
 ##############

--- a/src/hessian.jl
+++ b/src/hessian.jl
@@ -29,3 +29,9 @@ function hessian!(out::DiffResult, f::F, x, cfg::AllowedHessianConfig{F,H} = Hes
     jacobian!(DiffBase.hessian(out), ∇f!, DiffBase.gradient(out), x, cfg.jacobian_config)
     return out
 end
+
+hessian(f::F, x::SArray) where {F} = jacobian(y -> gradient(f, y), x)
+
+hessian!(out, f::F, x::SArray) where {F} = jacobian!(out, y -> gradient(f, y), x)
+
+hessian!(out::DiffResult, f::F, x::SArray) where {F} = hessian!(out, f, x, HessianConfig(f, out, x))

--- a/src/partials.jl
+++ b/src/partials.jl
@@ -6,7 +6,7 @@ end
 # Utility/Accessor Functions #
 ##############################
 
-@generated function single_seed(::Type{Partials{N,V}}, ::Type{Val{i}}) where {N,V,i}
+@generated function single_seed(::Type{Partials{N,V}}, ::Val{i}) where {N,V,i}
     ex = Expr(:tuple, [ifelse(i === j, :(one(V)), :(zero(V))) for j in 1:N]...)
     return :(Partials($(ex)))
 end


### PR DESCRIPTION
Adds StaticArrays as dependency, and uses it to support a low-dimensional, stack-allocated differentiation API.

```julia
julia> using BenchmarkTools, ForwardDiff, StaticArrays

julia> x = rand(3, 3, 3);

julia> sx = SArray{Tuple{3,3,3}}(x);

julia> out = similar(x);

julia> cfg = ForwardDiff.GradientConfig(sum, x);

# naive old method
julia> @btime ForwardDiff.gradient(sum, $x);
  6.585 μs (3 allocations: 3.23 KiB)

# non-allocating old method
julia> @btime ForwardDiff.gradient!($out, sum, $x, $cfg);
  666.856 ns (0 allocations: 0 bytes)

# stack-allocated new method
julia> @btime ForwardDiff.gradient(sum, $sx);
  9.394 ns (0 allocations: 0 bytes)
```

Currently, I've only added support for gradients and Jacobians. EDIT: Added special cases for Hessians as well, see below. ~~I still need to add back in the tests I originally used in #213.~~ Done.