### PR TITLE
add eltype for AbstractConfig

### DIFF
--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -22,7 +22,7 @@ for c in (1, 2, 3), tag in (nothing, f)
     println("  ...running hardcoded test with chunk size = $c and tag = $tag")
     cfg = ForwardDiff.GradientConfig(tag, x, ForwardDiff.Chunk{c}())
 
-    @test eltype(cfg) == Dual{Tag(tag, eltype(x)), eltype(x), c}
+    @test eltype(cfg) == Dual{Tag(typeof(tag), eltype(x)), eltype(x), c}
 
     @test isapprox(g, ForwardDiff.gradient(f, x, cfg))
     @test isapprox(g, ForwardDiff.gradient(f, x))

--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -22,7 +22,7 @@ for c in (1, 2, 3), tag in (nothing, f)
     println("  ...running hardcoded test with chunk size = $c and tag = $tag")
     cfg = ForwardDiff.GradientConfig(tag, x, ForwardDiff.Chunk{c}())
 
-    @test eltype(cfg) == Dual{Tag(typeof(tag), eltype(x)), eltype(x), c}
+    @test eltype(cfg) == Dual{typeof(Tag(typeof(tag), eltype(x))), eltype(x), c}
 
     @test isapprox(g, ForwardDiff.gradient(f, x, cfg))
     @test isapprox(g, ForwardDiff.gradient(f, x))

--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -4,6 +4,7 @@ import Calculus
 
 using Base.Test
 using ForwardDiff
+using ForwardDiff: Dual, Tag
 using StaticArrays
 
 include(joinpath(dirname(@__FILE__), "utils.jl"))
@@ -20,6 +21,8 @@ g = [-9.4, 15.6, 52.0]
 for c in (1, 2, 3), tag in (nothing, f)
     println("  ...running hardcoded test with chunk size = $c and tag = $tag")
     cfg = ForwardDiff.GradientConfig(tag, x, ForwardDiff.Chunk{c}())
+
+    @test eltype(cfg) == Dual{Tag(tag, eltype(x)), eltype(x), c}
 
     @test isapprox(g, ForwardDiff.gradient(f, x, cfg))
     @test isapprox(g, ForwardDiff.gradient(f, x))

--- a/test/HessianTest.jl
+++ b/test/HessianTest.jl
@@ -26,8 +26,8 @@ for c in (1, 2, 3), tag in (nothing, f)
     cfg = ForwardDiff.HessianConfig(tag, x, ForwardDiff.Chunk{c}())
     resultcfg = ForwardDiff.HessianConfig(tag, DiffBase.HessianResult(x), x, ForwardDiff.Chunk{c}())
 
-    D = Dual{Tag(tag, eltype(x)), eltype(x), c}
-    @test eltype(cfg) == Dual{Tag(tag, D), D, c}
+    D = Dual{Tag(typeof(tag), eltype(x)), eltype(x), c}
+    @test eltype(cfg) == Dual{Tag(typeof(tag), D), D, c}
     @test eltype(resultcfg) == eltype(cfg)
 
     @test isapprox(h, ForwardDiff.hessian(f, x))

--- a/test/HessianTest.jl
+++ b/test/HessianTest.jl
@@ -4,6 +4,7 @@ import Calculus
 
 using Base.Test
 using ForwardDiff
+using ForwardDiff: Dual, Tag
 using StaticArrays
 
 include(joinpath(dirname(@__FILE__), "utils.jl"))
@@ -24,6 +25,10 @@ for c in (1, 2, 3), tag in (nothing, f)
     println("  ...running hardcoded test with chunk size = $c and tag = $tag")
     cfg = ForwardDiff.HessianConfig(tag, x, ForwardDiff.Chunk{c}())
     resultcfg = ForwardDiff.HessianConfig(tag, DiffBase.HessianResult(x), x, ForwardDiff.Chunk{c}())
+
+    D = Dual{Tag(tag, eltype(x)), eltype(x), c}
+    @test eltype(cfg) == Dual{Tag(tag, D), D, c}
+    @test eltype(resultcfg) == eltype(cfg)
 
     @test isapprox(h, ForwardDiff.hessian(f, x))
     @test isapprox(h, ForwardDiff.hessian(f, x, cfg))

--- a/test/HessianTest.jl
+++ b/test/HessianTest.jl
@@ -26,8 +26,8 @@ for c in (1, 2, 3), tag in (nothing, f)
     cfg = ForwardDiff.HessianConfig(tag, x, ForwardDiff.Chunk{c}())
     resultcfg = ForwardDiff.HessianConfig(tag, DiffBase.HessianResult(x), x, ForwardDiff.Chunk{c}())
 
-    D = Dual{Tag(typeof(tag), eltype(x)), eltype(x), c}
-    @test eltype(cfg) == Dual{Tag(typeof(tag), D), D, c}
+    D = Dual{typeof(Tag(Void, eltype(x))), eltype(x), c}
+    @test eltype(cfg) == Dual{typeof(Tag(typeof(tag), Dual{Void,eltype(x),0})), D, c}
     @test eltype(resultcfg) == eltype(cfg)
 
     @test isapprox(h, ForwardDiff.hessian(f, x))

--- a/test/JacobianTest.jl
+++ b/test/JacobianTest.jl
@@ -34,8 +34,8 @@ for c in (1, 2, 3), tags in ((nothing, nothing), (f, f!))
     cfg = JacobianConfig(tags[1], x, ForwardDiff.Chunk{c}())
     ycfg = JacobianConfig(tags[2], zeros(4), x, ForwardDiff.Chunk{c}())
 
-    @test eltype(cfg)  == Dual{Tag(tags[1], eltype(x)), eltype(x), c}
-    @test eltype(ycfg) == Dual{Tag(tags[2], eltype(x)), eltype(x), c}
+    @test eltype(cfg)  == Dual{Tag(typeof(tags[1]), eltype(x)), eltype(x), c}
+    @test eltype(ycfg) == Dual{Tag(typeof(tags[2]), eltype(x)), eltype(x), c}
 
     # testing f(x)
     @test isapprox(j, ForwardDiff.jacobian(f, x, cfg))

--- a/test/JacobianTest.jl
+++ b/test/JacobianTest.jl
@@ -34,8 +34,8 @@ for c in (1, 2, 3), tags in ((nothing, nothing), (f, f!))
     cfg = JacobianConfig(tags[1], x, ForwardDiff.Chunk{c}())
     ycfg = JacobianConfig(tags[2], zeros(4), x, ForwardDiff.Chunk{c}())
 
-    @test eltype(cfg)  == Dual{Tag(typeof(tags[1]), eltype(x)), eltype(x), c}
-    @test eltype(ycfg) == Dual{Tag(typeof(tags[2]), eltype(x)), eltype(x), c}
+    @test eltype(cfg)  == Dual{typeof(Tag(typeof(tags[1]), eltype(x))), eltype(x), c}
+    @test eltype(ycfg) == Dual{typeof(Tag(typeof(tags[2]), eltype(x))), eltype(x), c}
 
     # testing f(x)
     @test isapprox(j, ForwardDiff.jacobian(f, x, cfg))

--- a/test/JacobianTest.jl
+++ b/test/JacobianTest.jl
@@ -4,7 +4,7 @@ import Calculus
 
 using Base.Test
 using ForwardDiff
-using ForwardDiff: JacobianConfig
+using ForwardDiff: Dual, Tag, JacobianConfig
 using StaticArrays
 
 include(joinpath(dirname(@__FILE__), "utils.jl"))
@@ -33,6 +33,9 @@ for c in (1, 2, 3), tags in ((nothing, nothing), (f, f!))
     println("  ...running hardcoded test with chunk size = $c and tag = $tags")
     cfg = JacobianConfig(tags[1], x, ForwardDiff.Chunk{c}())
     ycfg = JacobianConfig(tags[2], zeros(4), x, ForwardDiff.Chunk{c}())
+
+    @test eltype(cfg)  == Dual{Tag(tags[1], eltype(x)), eltype(x), c}
+    @test eltype(ycfg) == Dual{Tag(tags[2], eltype(x)), eltype(x), c}
 
     # testing f(x)
     @test isapprox(j, ForwardDiff.jacobian(f, x, cfg))


### PR DESCRIPTION
This allows users to easily extract the types of the `Dual` instances that will be injected into their code:

```julia
julia> cfg = ForwardDiff.GradientConfig(prod, rand(20));

julia> eltype(cfg)
ForwardDiff.Dual{ForwardDiff.Tag{Base.#prod,0xb046287d533b082d},Float64,10}
```

cc @tkoolen