### PR TITLE
Accessing lower order results for StaticArrays methods

### DIFF
--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -40,12 +40,8 @@ end
         return SArray{S}($result)
     end
 end
-@generated function extract_value(y::Real, ::SArray{S,X,D,N}) where {S,X,D,N}
-    result = Expr(:tuple, [:(value(y, $i)) for i in 1:N]...)
-    return quote
-        $(Expr(:meta, :inline))
-        return SArray{S}($result)
-    end
+function extract_value(y::Real, ::SArray{S,X,D,N}) where {S,X,D,N}
+    y.value
 end
 
 function extract_gradient!(out::DiffResult, y::Real)

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -40,8 +40,12 @@ end
         return SArray{S}($result)
     end
 end
-function extract_value(y::Real, ::SArray{S,X,D,N}) where {S,X,D,N}
-   a.value
+@generated function extract_value(y::Real, ::SArray{S,X,D,N}) where {S,X,D,N}
+    result = Expr(:tuple, [:(value(y, $i)) for i in 1:N]...)
+    return quote
+        $(Expr(:meta, :inline))
+        return SArray{S}($result)
+    end
 end
 
 function extract_gradient!(out::DiffResult, y::Real)

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -25,6 +25,7 @@ function gradient!(out, f::F, x, cfg::AllowedGradientConfig{F,H} = GradientConfi
 end
 
 @inline gradient(f::F, x::SArray) where {F} = vector_mode_gradient(f, x)
+@inline gradient_val(f::F, x::SArray) where {F} = vector_mode_gradient_val(f, x)
 
 @inline gradient!(out, f::F, x::SArray) where {F} = vector_mode_gradient!(out, f, x)
 
@@ -38,6 +39,9 @@ end
         $(Expr(:meta, :inline))
         return SArray{S}($result)
     end
+end
+function extract_value(y::Real, ::SArray{S,X,D,N}) where {S,X,D,N}
+   a.value
 end
 
 function extract_gradient!(out::DiffResult, y::Real)
@@ -87,6 +91,11 @@ end
 
 @inline function vector_mode_gradient(f::F, x::SArray) where F
     return extract_gradient(vector_mode_dual_eval(f, x), x)
+end
+
+@inline function vector_mode_gradient_val(f::F, x::SArray) where F
+    a = vector_mode_dual_eval(f, x)
+    return (extract_gradient(a, x), extract_value(a, x))
 end
 
 @inline function vector_mode_gradient!(out, f::F, x::SArray) where F

--- a/src/hessian.jl
+++ b/src/hessian.jl
@@ -31,7 +31,7 @@ function hessian!(out::DiffResult, f::F, x, cfg::AllowedHessianConfig{F,H} = Hes
 end
 
 hessian(f::F, x::SArray) where {F} = jacobian(y -> gradient(f, y), x)
-hessian_vals(f::F, x::SArray) where {F} = jacobian_vals(y -> gradient(f, y), x)
+hessian_grad(f::F, x::SArray) where {F} = jacobian_vals(y -> gradient(f, y), x)
 
 hessian!(out, f::F, x::SArray) where {F} = jacobian!(out, y -> gradient(f, y), x)
 

--- a/src/hessian.jl
+++ b/src/hessian.jl
@@ -31,6 +31,7 @@ function hessian!(out::DiffResult, f::F, x, cfg::AllowedHessianConfig{F,H} = Hes
 end
 
 hessian(f::F, x::SArray) where {F} = jacobian(y -> gradient(f, y), x)
+hessian_vals(f::F, x::SArray) where {F} = jacobian_vals(y -> gradient(f, y), x)
 
 hessian!(out, f::F, x::SArray) where {F} = jacobian!(out, y -> gradient(f, y), x)
 

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -145,7 +145,7 @@ end
 
 @inline function vector_mode_jacobian_vals(f::F, x::SArray) where F
     a = vector_mode_dual_eval(f, x)
-    return (extract_jacobian(a, x), a.val)
+    return (extract_jacobian(a, x), extract_value(a,x))
 end
 
 @inline function vector_mode_jacobian!(out, f::F, x::SArray{S,V,D,N}) where {F,S,V,D,N}

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -132,6 +132,11 @@ end
     return extract_jacobian(vector_mode_dual_eval(f, x), x)
 end
 
+@inline function vector_mode_jacobian_vals(f::F, x::SArray) where F
+    a = vector_mode_dual_eval(f, x)
+    return (extract_jacobian(a, x), a.val)
+end
+
 @inline function vector_mode_jacobian!(out, f::F, x::SArray{S,V,D,N}) where {F,S,V,D,N}
     ydual = vector_mode_dual_eval(f, x)
     extract_jacobian!(out, ydual, N)

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -67,7 +67,7 @@ end
     result = Expr(:tuple, [:(value(ydual[$i])) for i in 1:M]...)
     return quote
         $(Expr(:meta, :inline))
-        return SArray{SX}($result)
+        return SArray{SY}($result)
     end
 end
 

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -62,6 +62,15 @@ end
     end
 end
 
+@generated function extract_value(ydual::SArray{SY,VY,DY,M},
+                                     x::SArray{SX,VX,DX,N}) where {SY,VY,DY,M,SX,VX,DX,N}
+    result = Expr(:tuple, [:(value(ydual[$i])) for i in 1:M]...)
+    return quote
+        $(Expr(:meta, :inline))
+        return SArray{Tuple{M}}($result)
+    end
+end
+
 function extract_jacobian(ydual::AbstractArray, x::SArray{S,V,D,N}) where {S,V,D,N}
     out = similar(ydual, valtype(eltype(ydual)), length(ydual), N)
     return extract_jacobian!(out, ydual, N)

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -44,6 +44,8 @@ function jacobian!(out, f!::F, y, x, cfg::AllowedJacobianConfig{F,H} = JacobianC
 end
 
 @inline jacobian(f::F, x::SArray) where {F} = vector_mode_jacobian(f, x)
+@inline jacobian_vals(f::F, x::SArray) where {F} = vector_mode_jacobian_vals(f, x)
+
 
 @inline jacobian!(out, f::F, x::SArray) where {F} = vector_mode_jacobian!(out, f, x)
 

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -67,7 +67,7 @@ end
     result = Expr(:tuple, [:(value(ydual[$i])) for i in 1:M]...)
     return quote
         $(Expr(:meta, :inline))
-        return SArray{Tuple{M}}($result)
+        return SArray{SX}($result)
     end
 end
 

--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -79,8 +79,10 @@ x = rand(3, 3)
 sx = StaticArrays.SArray{Tuple{3,3}}(x)
 out = similar(x)
 actual = ForwardDiff.gradient(prod, x)
+actual_val = prod(x)
 
 @test ForwardDiff.gradient(prod, sx) == actual
+@test ForwardDiff.gradient_val(prod, sx) == (actual, actual_val)
 
 ForwardDiff.gradient!(out, prod, sx)
 

--- a/test/HessianTest.jl
+++ b/test/HessianTest.jl
@@ -92,8 +92,10 @@ x = rand(3, 3)
 sx = StaticArrays.SArray{Tuple{3,3}}(x)
 out = similar(x, 9, 9)
 actual = ForwardDiff.hessian(prod, x)
+actual_grad = ForwardDiff.gradient(prod, x)
 
 @test ForwardDiff.hessian(prod, sx) == actual
+@test ForwardDiff.hessian_grad(prod, sx) == (actual, actual_grad)
 
 ForwardDiff.hessian!(out, prod, sx)
 

--- a/test/JacobianTest.jl
+++ b/test/JacobianTest.jl
@@ -158,8 +158,10 @@ x = rand(3, 3)
 sx = StaticArrays.SArray{Tuple{3,3}}(x)
 out = similar(x, 6, 9)
 actual = ForwardDiff.jacobian(diff, x)
+actual_vals = diff(x)
 
 @test ForwardDiff.jacobian(diff, sx) == actual
+@test ForwardDiff.jacobian_vals(diff, sx) == (actual, actual_vals)
 
 ForwardDiff.jacobian!(out, diff, sx)
 


### PR DESCRIPTION
I wanted to use the StaticArrays methods for some numerical optimization routines, and I didn't see any way to access the lower order results using the existing methods. This PR adds methods `hessian_grad`, `jacobian_vals`, `gradient_val` to do so.

Example:
```
julia> f(x) = exp(x[1])*x[2]^x[3]
f (generic function with 1 method)

julia> sx = @SVector rand(3)
3-element SVector{3,Float64}:
 0.331614
 0.683379
 0.307809

julia> function test1(sx)
       hess = ForwardDiff.hessian(f, sx)
       grad = ForwardDiff.gradient(f, sx)
       (hess, grad)
       end
test1 (generic function with 1 method)

julia> function test2(sx)
       (hess, grad) = ForwardDiff.hessian_grad(f, sx)
       end
test2 (generic function with 1 method)

julia> @btime test1($sx)
  557.204 ns (0 allocations: 0 bytes)
([1.23916 0.558143 -0.471753; 0.558143 -0.56534 1.60079; -0.471753 1.60079 0.179599], [1.23916, 0.558143, -0.471753])

julia> @btime test2($sx)
  385.565 ns (0 allocations: 0 bytes)
([1.23916 0.558143 -0.471753; 0.558143 -0.56534 1.60079; -0.471753 1.60079 0.179599], [1.23916, 0.558143, -0.471753])
```

I'm very new at this, so apologies if this PR is improperly constructed.