### PR TITLE
add missing Partials{0} definitions

### DIFF
--- a/src/partials.jl
+++ b/src/partials.jl
@@ -122,14 +122,22 @@ end
 #-------------------------#
 
 @inline Base.:+(a::Partials{0,A}, b::Partials{0,B}) where {A,B} = Partials{0,promote_type(A,B)}(tuple())
+@inline Base.:+(a::Partials{0,A}, b::Partials{N,B}) where {N,A,B} = convert(Partials{N,promote_type(A,B)}, b)
+@inline Base.:+(a::Partials{N,A}, b::Partials{0,B}) where {N,A,B} = convert(Partials{N,promote_type(A,B)}, a)
+
 @inline Base.:-(a::Partials{0,A}, b::Partials{0,B}) where {A,B} = Partials{0,promote_type(A,B)}(tuple())
+@inline Base.:-(a::Partials{0,A}, b::Partials{N,B}) where {N,A,B} = -(convert(Partials{N,promote_type(A,B)}, b))
+@inline Base.:-(a::Partials{N,A}, b::Partials{0,B}) where {N,A,B} = convert(Partials{N,promote_type(A,B)}, a)
 @inline Base.:-(partials::Partials{0,V}) where {V} = partials
+
 @inline Base.:*(partials::Partials{0,V}, x::Real) where {V} = Partials{0,promote_type(V,typeof(x))}(tuple())
 @inline Base.:*(x::Real, partials::Partials{0,V}) where {V} = Partials{0,promote_type(V,typeof(x))}(tuple())
+
 @inline Base.:/(partials::Partials{0,V}, x::Real) where {V} = Partials{0,promote_type(V,typeof(x))}(tuple())
 
 @inline _mul_partials(a::Partials{0,A}, b::Partials{0,B}, afactor, bfactor) where {A,B} = Partials{0,promote_type(A,B)}(tuple())
-@inline _div_partials(a::Partials{0,A}, b::Partials{0,B}, afactor, bfactor) where {A,B} = Partials{0,promote_type(A,B)}(tuple())
+@inline _mul_partials(a::Partials{0,A}, b::Partials{N,B}, afactor, bfactor) where {N,A,B} = bfactor * b
+@inline _mul_partials(a::Partials{N,A}, b::Partials{0,B}, afactor, bfactor) where {N,A,B} = afactor * a
 
 ##################################
 # Generated Functions on NTuples #

--- a/test/MiscTest.jl
+++ b/test/MiscTest.jl
@@ -131,4 +131,16 @@ end
 
 @test ForwardDiff.partials(NaNMath.pow(ForwardDiff.Dual(-2.0,1.0),ForwardDiff.Dual(2.0,0.0)),1) == -4.0
 
+# Partials{0} #
+#-------------#
+
+x, y = rand(3), rand(3)
+h = ForwardDiff.hessian(y -> sum(hypot.(x, y)), y)
+@test h[1, 1] ≈ (x[1]^2) / (x[1]^2 + y[1]^2)^(3/2)
+@test h[2, 2] ≈ (x[2]^2) / (x[2]^2 + y[2]^2)^(3/2)
+@test h[3, 3] ≈ (x[3]^2) / (x[3]^2 + y[3]^2)^(3/2)
+for i in 1:3, j in 1:3
+    i != j && (@test h[i, j] ≈ 0.0)
+end
+
 end

--- a/test/PartialsTest.jl
+++ b/test/PartialsTest.jl
@@ -97,8 +97,15 @@ for N in (0, 3), T in (Int, Float32, Float64)
     # Arithmetic Functions #
     ########################
 
+    ZERO_PARTIALS = Partials{0,T}(())
+
     @test (PARTIALS + PARTIALS).values == map(v -> v + v, VALUES)
+    @test (PARTIALS + ZERO_PARTIALS) === PARTIALS
+    @test (ZERO_PARTIALS + PARTIALS) === PARTIALS
+
     @test (PARTIALS - PARTIALS).values == map(v -> v - v, VALUES)
+    @test (PARTIALS - ZERO_PARTIALS) === PARTIALS
+    @test (ZERO_PARTIALS - PARTIALS) === -PARTIALS
     @test getfield(-(PARTIALS), :values) == map(-, VALUES)
 
     X = rand()
@@ -109,8 +116,10 @@ for N in (0, 3), T in (Int, Float32, Float64)
     @test (PARTIALS / X).values == map(v -> v / X, VALUES)
 
     if N > 0
-        @test ForwardDiff._mul_partials(PARTIALS, PARTIALS2, X, Y).values == map((a, b) -> (X * a) + (Y * b), VALUES, VALUES2)
         @test ForwardDiff._div_partials(PARTIALS, PARTIALS2, X, Y) == ForwardDiff._mul_partials(PARTIALS, PARTIALS2, inv(Y), -X/(Y^2))
+        @test ForwardDiff._mul_partials(PARTIALS, PARTIALS2, X, Y).values == map((a, b) -> (X * a) + (Y * b), VALUES, VALUES2)
+        @test ForwardDiff._mul_partials(ZERO_PARTIALS, PARTIALS, X, Y) == Y * PARTIALS
+        @test ForwardDiff._mul_partials(PARTIALS, ZERO_PARTIALS, X, Y) == X * PARTIALS
 
         if ForwardDiff.NANSAFE_MODE_ENABLED
             ZEROS = Partials((zeros(T, N)...))


### PR DESCRIPTION
Prompted by the following code, which was failing when `+(::Partials{0}, ::Partials{N})` fell back to the `AbstractVector` method:

```julia
ForwardDiff.hessian(x -> sum(hypot.([1,2,3], x)), [1,2,3])
```

cc @ranjanan