### PR TITLE
"ConfigHismatchError" -> "ConfigMismatchError"

### DIFF
--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -4,8 +4,8 @@
 
 const AllowedDerivativeConfig{F,H} = Union{DerivativeConfig{Tag{F,H}}, DerivativeConfig{Tag{Void,H}}}
 
-derivative(f!, y, x, cfg::DerivativeConfig) = throw(ConfigHismatchError(f, cfg))
-derivative!(out, f!, y, x, cfg::DerivativeConfig) = throw(ConfigHismatchError(f, cfg))
+derivative(f!, y, x, cfg::DerivativeConfig) = throw(ConfigMismatchError(f, cfg))
+derivative!(out, f!, y, x, cfg::DerivativeConfig) = throw(ConfigMismatchError(f, cfg))
 
 """
     ForwardDiff.derivative(f, x::Real)

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -4,8 +4,8 @@
 
 const AllowedGradientConfig{F,H} = Union{GradientConfig{Tag{F,H}}, GradientConfig{Tag{Void,H}}}
 
-gradient(f, x::AbstractArray, cfg::GradientConfig) = throw(ConfigHismatchError(f, cfg))
-gradient!(result::Union{AbstractArray,DiffResult}, f, x::AbstractArray, cfg::GradientConfig) = throw(ConfigHismatchError(f, cfg))
+gradient(f, x::AbstractArray, cfg::GradientConfig) = throw(ConfigMismatchError(f, cfg))
+gradient!(result::Union{AbstractArray,DiffResult}, f, x::AbstractArray, cfg::GradientConfig) = throw(ConfigMismatchError(f, cfg))
 
 """
     ForwardDiff.gradient(f, x::AbstractArray, cfg::GradientConfig = GradientConfig(f, x))


### PR DESCRIPTION
Fixed the typo for an error message more informative than "ERROR: UndefVarError: ConfigHismatchError not defined".