### PR TITLE
bump DiffBase lower bound to 0.3.2

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.6.0-pre
 StaticArrays 0.5.0
-DiffBase 0.3.0 0.4.0
+DiffBase 0.3.2 0.4.0
 NaNMath 0.2.2
 SpecialFunctions 0.1.0
 RealInterface 0.0.2


### PR DESCRIPTION
...so that folks don't lose their hypot/atan derivative definitions in an upgrade following #251.

This relies on https://github.com/JuliaLang/METADATA.jl/pull/11009