### PR TITLE
revert removal of special case division rule

### DIFF
--- a/src/partials.jl
+++ b/src/partials.jl
@@ -55,7 +55,7 @@ Base.hash(partials::Partials, hsh::UInt64) = hash(hash(partials), hsh)
 
 @inline Base.copy(partials::Partials) = partials
 
-Base.read(io::IO, ::Type{Partials{N,V}}) where {N,V} = Partials{N,V}(ntuple(i->read(io, V), Val(N)))
+Base.read(io::IO, ::Type{Partials{N,V}}) where {N,V} = Partials{N,V}(ntuple(i->read(io, V), N))
 
 function Base.write(io::IO, partials::Partials)
     for p in partials

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -397,7 +397,7 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
 
     if V != Int
         for (M, f, arity) in DiffRules.diffrules()
-            in(f, (:hankelh1, :hankelh1x, :hankelh2, :hankelh2x)) && continue
+            in(f, (:hankelh1, :hankelh1x, :hankelh2, :hankelh2x, :/)) && continue
             println("       ...auto-testing $(M).$(f) with $arity arguments")
             if arity == 1
                 deriv = DiffRules.diffrule(M, f, :x)

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -22,23 +22,23 @@ dual_isapprox(a::Dual, b::Dual) = isapprox(value(a), value(b)) && isapprox(parti
 for N in (0,3), M in (0,4), V in (Int, Float32)
     println("  ...testing Dual{Void,$V,$N} and Dual{Void,Dual{Void,$V,$M},$N}")
 
-    PARTIALS = Partials{N,V}(ntuple(n -> intrand(V), Val(N)))
+    PARTIALS = Partials{N,V}(ntuple(n -> intrand(V), N))
     PRIMAL = intrand(V)
     FDNUM = Dual(PRIMAL, PARTIALS)
 
-    PARTIALS2 = Partials{N,V}(ntuple(n -> intrand(V), Val(N)))
+    PARTIALS2 = Partials{N,V}(ntuple(n -> intrand(V), N))
     PRIMAL2 = intrand(V)
     FDNUM2 = Dual(PRIMAL2, PARTIALS2)
 
-    PARTIALS3 = Partials{N,V}(ntuple(n -> intrand(V), Val(N)))
+    PARTIALS3 = Partials{N,V}(ntuple(n -> intrand(V), N))
     PRIMAL3 = intrand(V)
     FDNUM3 = Dual(PRIMAL3, PARTIALS3)
 
-    M_PARTIALS = Partials{M,V}(ntuple(m -> intrand(V), Val(M)))
+    M_PARTIALS = Partials{M,V}(ntuple(m -> intrand(V), M))
     NESTED_PARTIALS = convert(Partials{N,Dual{Void,V,M}}, PARTIALS)
     NESTED_FDNUM = Dual(Dual(PRIMAL, M_PARTIALS), NESTED_PARTIALS)
 
-    M_PARTIALS2 = Partials{M,V}(ntuple(m -> intrand(V), Val(M)))
+    M_PARTIALS2 = Partials{M,V}(ntuple(m -> intrand(V), M))
     NESTED_PARTIALS2 = convert(Partials{N,Dual{Void,V,M}}, PARTIALS2)
     NESTED_FDNUM2 = Dual(Dual(PRIMAL2, M_PARTIALS2), NESTED_PARTIALS2)
 
@@ -398,6 +398,7 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
     if V != Int
         for (M, f, arity) in DiffRules.diffrules()
             in(f, (:hankelh1, :hankelh1x, :hankelh2, :hankelh2x)) && continue
+            println("       ...auto-testing $(M).$(f) with $arity arguments")
             if arity == 1
                 deriv = DiffRules.diffrule(M, f, :x)
                 modifier = in(f, (:asec, :acsc, :asecd, :acscd, :acosh, :acoth)) ? one(V) : zero(V)


### PR DESCRIPTION
fixes #264 

Funny story: I special-cased this rule a longggg time ago exactly because of #264-like issues due to floating point quirks. However, when I was working on #262, I couldn't for the life of me remember why it was special-cased, figured it must be cruft, and removed the special-cased rule. 

There are three lessons we can learn from this: 

1. don't fix what isn't broken
2. past Jarrett has your back
3. future Jarrett can't be trusted