### PR TITLE
tweak tag generation

### DIFF
--- a/src/config.jl
+++ b/src/config.jl
@@ -87,6 +87,7 @@ function DerivativeConfig(f::F,
     return DerivativeConfig{T,typeof(duals)}(duals)
 end
 
+checktag(::DerivativeConfig{T},f,x) where {T} = checktag(T,f,x)
 Base.eltype(::Type{DerivativeConfig{T,D}}) where {T,D} = eltype(D)
 
 ##################
@@ -122,6 +123,7 @@ function GradientConfig(f::F,
     return GradientConfig{T,V,N,typeof(duals)}(seeds, duals)
 end
 
+checktag(::GradientConfig{T},f,x) where {T} = checktag(T,f,x)
 Base.eltype(::Type{GradientConfig{T,V,N,D}}) where {T,V,N,D} = Dual{T,V,N}
 
 ##################
@@ -186,6 +188,7 @@ function JacobianConfig(f::F,
     return JacobianConfig{T,X,N,typeof(duals)}(seeds, duals)
 end
 
+checktag(::JacobianConfig{T},f,x) where {T} = checktag(T,f,x)
 Base.eltype(::Type{JacobianConfig{T,V,N,D}}) where {T,V,N,D} = Dual{T,V,N}
 
 #################
@@ -249,5 +252,6 @@ function HessianConfig(f::F,
     return HessianConfig(jacobian_config, gradient_config)
 end
 
+checktag(::HessianConfig{T},f,x) where {T} = checktag(T,f,x)
 Base.eltype(::Type{HessianConfig{T,V,N,DG,DJ}}) where {T,V,N,DG,DJ} =
     Dual{T,Dual{T,V,N},N}

--- a/src/config.jl
+++ b/src/config.jl
@@ -25,10 +25,14 @@ Tag(::Void, ::Type{V}) where {V} = nothing
     tagcount(Tag{F1,V1}) < tagcount(Tag{F2,V2})
 end
 
+struct InvalidTagException{E,O} <: Exception
+end
 
+Base.showerror(io::IO, e::InvalidTagException{E,O}) where {E,O} =
+    print(io, "Invalid Tag object:\n  Expected $E,\n  Observed $O.")
 
 checktag(::Type{Tag{FT,VT}}, f::F, x::AbstractArray{V}) where {FT,VT,F,V} =
-    error("Invalid Tag object:\n  Expected $(Tag{F,V}),\n  Observed $(Tag{FT,VT}).")
+    throw(InvalidTagException{Tag{F,V},Tag{FT,VT}}())
 
 checktag(::Type{Tag{F,V}}, f::F, x::AbstractArray{V}) where {F,V} = true
 

--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -15,14 +15,16 @@ This method assumes that `isa(f(x), Union{Real,AbstractArray})`.
 end
 
 """
-    ForwardDiff.derivative(f!, y::AbstractArray, x::Real, cfg::DerivativeConfig = DerivativeConfig(f!, y, x))
+    ForwardDiff.derivative(f!, y::AbstractArray, x::Real, cfg::DerivativeConfig = DerivativeConfig(f!, y, x), check=Val{true}())
 
 Return `df!/dx` evaluated at `x`, assuming `f!` is called as `f!(y, x)` where the result is
 stored in `y`.
+
+Set `check` to `Val{false}()` to disable tag checking. This can lead to perturbation confusion, so should be used with care.
 """
 @inline function derivative(f!, y::AbstractArray, x::Real,
-                            cfg::DerivativeConfig{T} = DerivativeConfig(f!, y, x)) where {T}
-    checktag(T, f!, x)
+                            cfg::DerivativeConfig{T} = DerivativeConfig(f!, y, x), ::Val{CHK}=Val{true}()) where {T, CHK}
+    CHK && checktag(T, f, x)
     ydual = cfg.duals
     seed!(ydual, y)
     f!(ydual, Dual{T}(x, one(x)))
@@ -48,15 +50,17 @@ This method assumes that `isa(f(x), Union{Real,AbstractArray})`.
 end
 
 """
-    ForwardDiff.derivative!(result::Union{AbstractArray,DiffResult}, f!, y::AbstractArray, x::Real, cfg::DerivativeConfig = DerivativeConfig(f!, y, x))
+    ForwardDiff.derivative!(result::Union{AbstractArray,DiffResult}, f!, y::AbstractArray, x::Real, cfg::DerivativeConfig = DerivativeConfig(f!, y, x), check=Val{true}())
 
 Compute `df!/dx` evaluated at `x` and store the result(s) in `result`, assuming `f!` is
 called as `f!(y, x)` where the result is stored in `y`.
+
+Set `check` to `Val{false}()` to disable tag checking. This can lead to perturbation confusion, so should be used with care.
 """
 @inline function derivative!(result::Union{AbstractArray,DiffResult},
                              f!, y::AbstractArray, x::Real,
-                             cfg::DerivativeConfig{T} = DerivativeConfig(f!, y, x)) where {T}
-    checktag(T, f!, x)
+                             cfg::DerivativeConfig{T} = DerivativeConfig(f!, y, x), ::Val{CHK}=Val{true}()) where {T, CHK}
+    CHK && checktag(T, f, x)
     ydual = cfg.duals
     seed!(ydual, y)
     f!(ydual, Dual{T}(x, one(x)))

--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -24,7 +24,7 @@ Set `check` to `Val{false}()` to disable tag checking. This can lead to perturba
 """
 @inline function derivative(f!, y::AbstractArray, x::Real,
                             cfg::DerivativeConfig{T} = DerivativeConfig(f!, y, x), ::Val{CHK}=Val{true}()) where {T, CHK}
-    CHK && checktag(T, f, x)
+    CHK && checktag(T, f!, x)
     ydual = cfg.duals
     seed!(ydual, y)
     f!(ydual, Dual{T}(x, one(x)))
@@ -60,7 +60,7 @@ Set `check` to `Val{false}()` to disable tag checking. This can lead to perturba
 @inline function derivative!(result::Union{AbstractArray,DiffResult},
                              f!, y::AbstractArray, x::Real,
                              cfg::DerivativeConfig{T} = DerivativeConfig(f!, y, x), ::Val{CHK}=Val{true}()) where {T, CHK}
-    CHK && checktag(T, f, x)
+    CHK && checktag(T, f!, x)
     ydual = cfg.duals
     seed!(ydual, y)
     f!(ydual, Dual{T}(x, one(x)))

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -3,11 +3,13 @@
 ###############
 
 """
-    ForwardDiff.gradient(f, x::AbstractArray, cfg::GradientConfig = GradientConfig(f, x))
+    ForwardDiff.gradient(f, x::AbstractArray, cfg::GradientConfig = GradientConfig(f, x), check=Val{true}())
 
 Return `∇f` evaluated at `x`, assuming `f` is called as `f(x)`.
 
 This method assumes that `isa(f(x), Real)`.
+
+Set `check` to `Val{false}()` to disable tag checking. This can lead to perturbation confusion, so should be used with care.
 """
 function gradient(f, x::AbstractArray, cfg::GradientConfig{T} = GradientConfig(f, x), ::Val{CHK}=Val{true}()) where {T, CHK}
     CHK && checktag(T, f, x)
@@ -19,12 +21,13 @@ function gradient(f, x::AbstractArray, cfg::GradientConfig{T} = GradientConfig(f
 end
 
 """
-    ForwardDiff.gradient!(result::Union{AbstractArray,DiffResult}, f, x::AbstractArray, cfg::GradientConfig = GradientConfig(f, x))
+    ForwardDiff.gradient!(result::Union{AbstractArray,DiffResult}, f, x::AbstractArray, cfg::GradientConfig = GradientConfig(f, x), check=Val{true}())
 
 Compute `∇f` evaluated at `x` and store the result(s) in `result`, assuming `f` is called as
 `f(x)`.
 
 This method assumes that `isa(f(x), Real)`.
+
 """
 function gradient!(result::Union{AbstractArray,DiffResult}, f, x::AbstractArray, cfg::GradientConfig{T} = GradientConfig(f, x), ::Val{CHK}=Val{true}()) where {T, CHK}
     CHK && checktag(T, f, x)

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -9,8 +9,8 @@ Return `∇f` evaluated at `x`, assuming `f` is called as `f(x)`.
 
 This method assumes that `isa(f(x), Real)`.
 """
-function gradient(f, x::AbstractArray, cfg::GradientConfig{T} = GradientConfig(f, x)) where {T}
-    checktag(T, f, x)
+function gradient(f, x::AbstractArray, cfg::GradientConfig{T} = GradientConfig(f, x), ::Val{CHK}=Val{true}()) where {T, CHK}
+    CHK && checktag(T, f, x)
     if chunksize(cfg) == length(x)
         return vector_mode_gradient(f, x, cfg)
     else
@@ -26,8 +26,8 @@ Compute `∇f` evaluated at `x` and store the result(s) in `result`, assuming `f
 
 This method assumes that `isa(f(x), Real)`.
 """
-function gradient!(result::Union{AbstractArray,DiffResult}, f, x::AbstractArray, cfg::GradientConfig{T} = GradientConfig(f, x)) where {T}
-    checktag(T, f, x)
+function gradient!(result::Union{AbstractArray,DiffResult}, f, x::AbstractArray, cfg::GradientConfig{T} = GradientConfig(f, x), ::Val{CHK}=Val{true}()) where {T, CHK}
+    CHK && checktag(T, f, x)
     if chunksize(cfg) == length(x)
         vector_mode_gradient!(result, f, x, cfg)
     else

--- a/src/hessian.jl
+++ b/src/hessian.jl
@@ -3,11 +3,13 @@
 ###############
 
 """
-    ForwardDiff.hessian(f, x::AbstractArray, cfg::HessianConfig = HessianConfig(f, x))
+    ForwardDiff.hessian(f, x::AbstractArray, cfg::HessianConfig = HessianConfig(f, x), check=Val{true}())
 
 Return `H(f)` (i.e. `J(∇(f))`) evaluated at `x`, assuming `f` is called as `f(x)`.
 
 This method assumes that `isa(f(x), Real)`.
+
+Set `check` to `Val{false}()` to disable tag checking. This can lead to perturbation confusion, so should be used with care.
 """
 function hessian(f, x::AbstractArray, cfg::HessianConfig{T} = HessianConfig(f, x), ::Val{CHK}=Val{true}()) where {T,CHK}
     CHK && checktag(T, f, x)
@@ -16,12 +18,14 @@ function hessian(f, x::AbstractArray, cfg::HessianConfig{T} = HessianConfig(f, x
 end
 
 """
-    ForwardDiff.hessian!(result::AbstractArray, f, x::AbstractArray, cfg::HessianConfig = HessianConfig(f, x))
+    ForwardDiff.hessian!(result::AbstractArray, f, x::AbstractArray, cfg::HessianConfig = HessianConfig(f, x), check=Val{true}())
 
 Compute `H(f)` (i.e. `J(∇(f))`) evaluated at `x` and store the result(s) in `result`,
 assuming `f` is called as `f(x)`.
 
 This method assumes that `isa(f(x), Real)`.
+
+Set `check` to `Val{false}()` to disable tag checking. This can lead to perturbation confusion, so should be used with care.
 """
 function hessian!(result::AbstractArray, f, x::AbstractArray, cfg::HessianConfig{T} = HessianConfig(f, x), ::Val{CHK}=Val{true}()) where {T,CHK}
     CHK && checktag(T, f, x)
@@ -31,11 +35,13 @@ function hessian!(result::AbstractArray, f, x::AbstractArray, cfg::HessianConfig
 end
 
 """
-    ForwardDiff.hessian!(result::DiffResult, f, x::AbstractArray, cfg::HessianConfig = HessianConfig(f, result, x))
+    ForwardDiff.hessian!(result::DiffResult, f, x::AbstractArray, cfg::HessianConfig = HessianConfig(f, result, x), check=Val{true}())
 
 Exactly like `ForwardDiff.hessian!(result::AbstractArray, f, x::AbstractArray, cfg::HessianConfig)`, but
 because `isa(result, DiffResult)`, `cfg` is constructed as `HessianConfig(f, result, x)` instead of
 `HessianConfig(f, x)`.
+
+Set `check` to `Val{false}()` to disable tag checking. This can lead to perturbation confusion, so should be used with care.
 """
 function hessian!(result::DiffResult, f, x::AbstractArray, cfg::HessianConfig{T} = HessianConfig(f, result, x), ::Val{CHK}=Val{true}()) where {T,CHK}
     CHK && checktag(T, f, x)

--- a/src/hessian.jl
+++ b/src/hessian.jl
@@ -9,9 +9,10 @@ Return `H(f)` (i.e. `J(∇(f))`) evaluated at `x`, assuming `f` is called as `f(
 
 This method assumes that `isa(f(x), Real)`.
 """
-function hessian(f, x::AbstractArray, cfg::HessianConfig = HessianConfig(f, x))
-    ∇f = y -> gradient(f, y, cfg.gradient_config)
-    return jacobian(∇f, x, cfg.jacobian_config)
+function hessian(f, x::AbstractArray, cfg::HessianConfig{T} = HessianConfig(f, x), ::Val{CHK}=Val{true}()) where {T,CHK}
+    CHK && checktag(T, f, x)
+    ∇f = y -> gradient(f, y, cfg.gradient_config, Val{false}())
+    return jacobian(∇f, x, cfg.jacobian_config, Val{false}())
 end
 
 """
@@ -22,9 +23,10 @@ assuming `f` is called as `f(x)`.
 
 This method assumes that `isa(f(x), Real)`.
 """
-function hessian!(result::AbstractArray, f, x::AbstractArray, cfg::HessianConfig = HessianConfig(f, x))
-    ∇f = y -> gradient(f, y, cfg.gradient_config)
-    jacobian!(result, ∇f, x, cfg.jacobian_config)
+function hessian!(result::AbstractArray, f, x::AbstractArray, cfg::HessianConfig{T} = HessianConfig(f, x), ::Val{CHK}=Val{true}()) where {T,CHK}
+    CHK && checktag(T, f, x)
+    ∇f = y -> gradient(f, y, cfg.gradient_config, Val{false}())
+    jacobian!(result, ∇f, x, cfg.jacobian_config, Val{false}())
     return result
 end
 
@@ -35,14 +37,15 @@ Exactly like `ForwardDiff.hessian!(result::AbstractArray, f, x::AbstractArray, c
 because `isa(result, DiffResult)`, `cfg` is constructed as `HessianConfig(f, result, x)` instead of
 `HessianConfig(f, x)`.
 """
-function hessian!(result::DiffResult, f, x::AbstractArray, cfg::HessianConfig = HessianConfig(f, result, x))
+function hessian!(result::DiffResult, f, x::AbstractArray, cfg::HessianConfig{T} = HessianConfig(f, result, x), ::Val{CHK}=Val{true}()) where {T,CHK}
+    CHK && checktag(T, f, x)
     ∇f! = (y, z) -> begin
         inner_result = DiffResult(zero(eltype(y)), y)
-        gradient!(inner_result, f, z, cfg.gradient_config)
+        gradient!(inner_result, f, z, cfg.gradient_config, Val{false}())
         result = DiffResults.value!(result, value(DiffResults.value(inner_result)))
         return y
     end
-    jacobian!(DiffResults.hessian(result), ∇f!, DiffResults.gradient(result), x, cfg.jacobian_config)
+    jacobian!(DiffResults.hessian(result), ∇f!, DiffResults.gradient(result), x, cfg.jacobian_config, Val{false}())
     return result
 end
 
@@ -57,14 +60,13 @@ hessian!(result::MutableDiffResult, f, x::SArray) = hessian!(result, f, x, Hessi
 hessian!(result::ImmutableDiffResult, f, x::SArray, cfg::HessianConfig) = hessian!(result, f, x)
 
 function hessian!(result::ImmutableDiffResult, f::F, x::SArray{S,V}) where {F,S,V}
-    TJ = typeof(Tag((f,gradient),V))
-    d1 = dualize(TJ, x)
-    TG = typeof(Tag(f, eltype(d1)))
-    d2 = dualize(TG, d1)
+    T = typeof(Tag(f,V))
+    d1 = dualize(T, x)
+    d2 = dualize(T, d1)
     fd2 = f(d2)
-    val = value(TJ,value(TG,fd2))
-    grad = extract_gradient(TJ,value(TG,fd2), x)
-    hess = extract_jacobian(TJ,partials(TG,fd2), x)
+    val = value(T,value(T,fd2))
+    grad = extract_gradient(T,value(T,fd2), x)
+    hess = extract_jacobian(T,partials(T,fd2), x)
     result = DiffResults.hessian!(result, hess)
     result = DiffResults.gradient!(result, grad)
     result = DiffResults.value!(result, val)

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -3,11 +3,13 @@
 ###############
 
 """
-    ForwardDiff.jacobian(f, x::AbstractArray, cfg::JacobianConfig = JacobianConfig(f, x))
+    ForwardDiff.jacobian(f, x::AbstractArray, cfg::JacobianConfig = JacobianConfig(f, x), check=Val{true}())
 
 Return `J(f)` evaluated at `x`, assuming `f` is called as `f(x)`.
 
 This method assumes that `isa(f(x), AbstractArray)`.
+
+Set `check` to `Val{false}()` to disable tag checking. This can lead to perturbation confusion, so should be used with care.
 """
 function jacobian(f, x::AbstractArray, cfg::JacobianConfig{T} = JacobianConfig(f, x), ::Val{CHK}=Val{true}()) where {T,CHK}
     CHK && checktag(T, f, x)
@@ -19,10 +21,12 @@ function jacobian(f, x::AbstractArray, cfg::JacobianConfig{T} = JacobianConfig(f
 end
 
 """
-    ForwardDiff.jacobian(f!, y::AbstractArray, x::AbstractArray, cfg::JacobianConfig = JacobianConfig(f!, y, x))
+    ForwardDiff.jacobian(f!, y::AbstractArray, x::AbstractArray, cfg::JacobianConfig = JacobianConfig(f!, y, x), check=Val{true}())
 
 Return `J(f!)` evaluated at `x`,  assuming `f!` is called as `f!(y, x)` where the result is
 stored in `y`.
+
+Set `check` to `Val{false}()` to disable tag checking. This can lead to perturbation confusion, so should be used with care.
 """
 function jacobian(f!, y::AbstractArray, x::AbstractArray, cfg::JacobianConfig{T} = JacobianConfig(f!, y, x), ::Val{CHK}=Val{true}()) where {T, CHK}
     CHK && checktag(T, f!, x)    
@@ -35,12 +39,14 @@ end
 
 
 """
-    ForwardDiff.jacobian!(result::Union{AbstractArray,DiffResult}, f, x::AbstractArray, cfg::JacobianConfig = JacobianConfig(f, x))
+    ForwardDiff.jacobian!(result::Union{AbstractArray,DiffResult}, f, x::AbstractArray, cfg::JacobianConfig = JacobianConfig(f, x), check=Val{true}())
 
 Compute `J(f)` evaluated at `x` and store the result(s) in `result`, assuming `f` is called
 as `f(x)`.
 
 This method assumes that `isa(f(x), AbstractArray)`.
+
+Set `check` to `Val{false}()` to disable tag checking. This can lead to perturbation confusion, so should be used with care.
 """
 function jacobian!(result::Union{AbstractArray,DiffResult}, f, x::AbstractArray, cfg::JacobianConfig{T} = JacobianConfig(f, x), ::Val{CHK}=Val{true}()) where {T, CHK}
     CHK && checktag(T, f, x)
@@ -53,12 +59,14 @@ function jacobian!(result::Union{AbstractArray,DiffResult}, f, x::AbstractArray,
 end
 
 """
-    ForwardDiff.jacobian!(result::Union{AbstractArray,DiffResult}, f!, y::AbstractArray, x::AbstractArray, cfg::JacobianConfig = JacobianConfig(f!, y, x))
+    ForwardDiff.jacobian!(result::Union{AbstractArray,DiffResult}, f!, y::AbstractArray, x::AbstractArray, cfg::JacobianConfig = JacobianConfig(f!, y, x), check=Val{true}())
 
 Compute `J(f!)` evaluated at `x` and store the result(s) in `result`, assuming `f!` is
 called as `f!(y, x)` where the result is stored in `y`.
 
 This method assumes that `isa(f(x), AbstractArray)`.
+
+Set `check` to `Val{false}()` to disable tag checking. This can lead to perturbation confusion, so should be used with care.
 """
 function jacobian!(result::Union{AbstractArray,DiffResult}, f!, y::AbstractArray, x::AbstractArray, cfg::JacobianConfig{T} = JacobianConfig(f!, y, x), ::Val{CHK}=Val{true}()) where {T,CHK}
     CHK && checktag(T, f!, x)

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -9,8 +9,8 @@ Return `J(f)` evaluated at `x`, assuming `f` is called as `f(x)`.
 
 This method assumes that `isa(f(x), AbstractArray)`.
 """
-function jacobian(f, x::AbstractArray, cfg::JacobianConfig{T} = JacobianConfig(f, x)) where {T}
-    checktag(T, f, x)
+function jacobian(f, x::AbstractArray, cfg::JacobianConfig{T} = JacobianConfig(f, x), ::Val{CHK}=Val{true}()) where {T,CHK}
+    CHK && checktag(T, f, x)
     if chunksize(cfg) == length(x)
         return vector_mode_jacobian(f, x, cfg)
     else
@@ -24,8 +24,8 @@ end
 Return `J(f!)` evaluated at `x`,  assuming `f!` is called as `f!(y, x)` where the result is
 stored in `y`.
 """
-function jacobian(f!, y::AbstractArray, x::AbstractArray, cfg::JacobianConfig{T} = JacobianConfig(f!, y, x)) where {T}
-    checktag(T, f!, x)    
+function jacobian(f!, y::AbstractArray, x::AbstractArray, cfg::JacobianConfig{T} = JacobianConfig(f!, y, x), ::Val{CHK}=Val{true}()) where {T, CHK}
+    CHK && checktag(T, f!, x)    
     if chunksize(cfg) == length(x)
         return vector_mode_jacobian(f!, y, x, cfg)
     else
@@ -42,8 +42,8 @@ as `f(x)`.
 
 This method assumes that `isa(f(x), AbstractArray)`.
 """
-function jacobian!(result::Union{AbstractArray,DiffResult}, f, x::AbstractArray, cfg::JacobianConfig{T} = JacobianConfig(f, x)) where {T}
-    checktag(T, f, x)
+function jacobian!(result::Union{AbstractArray,DiffResult}, f, x::AbstractArray, cfg::JacobianConfig{T} = JacobianConfig(f, x), ::Val{CHK}=Val{true}()) where {T, CHK}
+    CHK && checktag(T, f, x)
     if chunksize(cfg) == length(x)
         vector_mode_jacobian!(result, f, x, cfg)
     else
@@ -60,8 +60,8 @@ called as `f!(y, x)` where the result is stored in `y`.
 
 This method assumes that `isa(f(x), AbstractArray)`.
 """
-function jacobian!(result::Union{AbstractArray,DiffResult}, f!, y::AbstractArray, x::AbstractArray, cfg::JacobianConfig{T} = JacobianConfig(f!, y, x)) where {T}
-    checktag(T, f!, x)
+function jacobian!(result::Union{AbstractArray,DiffResult}, f!, y::AbstractArray, x::AbstractArray, cfg::JacobianConfig{T} = JacobianConfig(f!, y, x), ::Val{CHK}=Val{true}()) where {T,CHK}
+    CHK && checktag(T, f!, x)
     if chunksize(cfg) == length(x)
         vector_mode_jacobian!(result, f!, y, x, cfg)
     else

--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -46,6 +46,11 @@ for c in (1, 2, 3), tag in (nothing, Tag(f, eltype(x)))
     @test isapprox(DiffResults.value(out), v)
 end
 
+cfgx = ForwardDiff.GradientConfig(sin, x)
+@test_throws ForwardDiff.InvalidTagException ForwardDiff.gradient(f, x, cfgx)
+@test ForwardDiff.gradient(f, x, cfgx, Val{false}()) == ForwardDiff.gradient(f,x)
+
+
 ########################
 # test vs. Calculus.jl #
 ########################
@@ -129,5 +134,6 @@ sresult3 = ForwardDiff.gradient!(sresult3, prod, sx, scfg)
 @test DiffResults.gradient(sresult1) == DiffResults.gradient(result)
 @test DiffResults.gradient(sresult2) == DiffResults.gradient(result)
 @test DiffResults.gradient(sresult3) == DiffResults.gradient(result)
+
 
 end # module

--- a/test/HessianTest.jl
+++ b/test/HessianTest.jl
@@ -53,6 +53,11 @@ for c in (1, 2, 3), tag in (nothing, Tag((f,gradient), eltype(x)))
     @test isapprox(DiffResults.hessian(out), h)
 end
 
+cfgx = ForwardDiff.HessianConfig(sin, x)
+@test_throws ForwardDiff.InvalidTagException ForwardDiff.hessian(f, x, cfgx)
+@test ForwardDiff.hessian(f, x, cfgx, Val{false}()) == ForwardDiff.hessian(f,x)
+
+
 ########################
 # test vs. Calculus.jl #
 ########################

--- a/test/JacobianTest.jl
+++ b/test/JacobianTest.jl
@@ -90,6 +90,11 @@ for c in (1, 2, 3), tags in ((nothing, nothing),
     @test isapprox(DiffResults.jacobian(out), j)
 end
 
+cfgx = ForwardDiff.JacobianConfig(sin, x)
+@test_throws ForwardDiff.InvalidTagException ForwardDiff.jacobian(f, x, cfgx)
+@test ForwardDiff.jacobian(f, x, cfgx, Val{false}()) == ForwardDiff.jacobian(f,x)
+
+
 ########################
 # test vs. Calculus.jl #
 ########################


### PR DESCRIPTION
This does 3 related things
1. Re-enables void tags by providing `nothing` as function argument
2. Allows opt out of tag checking via `Val{false}()` argument.
3. Simplifies the Hessian to use the same tag (which is useful for my own purposes of computing Riemannian metrics, but also makes the code a bit cleaner).