### PR TITLE
Propagate inbounds information.

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -65,9 +65,9 @@ end
 @inline partials(x::Real) = Partials{0,typeof(x)}(tuple())
 @inline partials(d::Dual) = d.partials
 @inline partials(x::Real, i...) = zero(x)
-@inline partials(d::Dual, i) = d.partials[i]
-@inline partials(d::Dual, i, j) = partials(d, i).partials[j]
-@inline partials(d::Dual, i, j, k...) = partials(partials(d, i, j), k...)
+@inline Base.@propagate_inbounds partials(d::Dual, i) = d.partials[i]
+@inline Base.@propagate_inbounds partials(d::Dual, i, j) = partials(d, i).partials[j]
+@inline Base.@propagate_inbounds partials(d::Dual, i, j, k...) = partials(partials(d, i, j), k...)
 
 @inline partials(::Type{T}, x::Real, i...) where T = partials(x, i...)
 @inline partials(::Type{T}, d::Dual{T}, i...) where T = partials(d, i...)

--- a/src/partials.jl
+++ b/src/partials.jl
@@ -20,7 +20,7 @@ end
 @inline Base.length(::Partials{N}) where {N} = N
 @inline Base.size(::Partials{N}) where {N} = (N,)
 
-@inline Base.getindex(partials::Partials, i::Int) = partials.values[i]
+@inline Base.@propagate_inbounds Base.getindex(partials::Partials, i::Int) = partials.values[i]
 
 Base.start(partials::Partials) = start(partials.values)
 Base.next(partials::Partials, i) = next(partials.values, i)


### PR DESCRIPTION
For GPU compatibility. Still needs `@inbounds` on the outer call to `partials`, of course.