### PR TITLE
Added Functionality for FieldVectors (from StaticArrays)

### DIFF
--- a/src/apiutils.jl
+++ b/src/apiutils.jl
@@ -29,6 +29,18 @@ end
 
 @inline static_dual_eval(::Type{T}, f, x::SArray) where {T} = f(dualize(T, x))
 
+########### FieldVectors ###########
+@generated function dualize(::Type{T}, x::FieldVector{N,V}) where {T,V,N}
+    dx = Expr(:tuple, [:(Dual{T}(x[$i], chunk, Val{$i}())) for i in 1:N]...)
+    return quote
+        chunk = Chunk{N}()
+        $(Expr(:meta, :inline))
+        return similar_type($x, Dual{T,V,N})($(dx))
+    end
+end
+@inline static_dual_eval(::Type{T}, f, x::FieldVector) where {T} = f(dualize(T, x))
+####################################
+
 function vector_mode_dual_eval(f, x, cfg::Union{JacobianConfig,GradientConfig})
     xdual = cfg.duals
     seed!(xdual, x, cfg.seeds)

--- a/src/apiutils.jl
+++ b/src/apiutils.jl
@@ -17,29 +17,19 @@ end
 ###################################
 # vector mode function evaluation #
 ###################################
-
-@generated function dualize(::Type{T}, x::SArray{S,V,D,N}) where {T,S,V,D,N}
+@generated function dualize(::Type{T}, x::Union{FieldVector, SArray}) where {T}
+    N = length(x)
+    V = eltype(x)
     dx = Expr(:tuple, [:(Dual{T}(x[$i], chunk, Val{$i}())) for i in 1:N]...)
     return quote
-        chunk = Chunk{N}()
+        chunk = Chunk{$N}()
         $(Expr(:meta, :inline))
-        return SArray{S}($(dx))
+        # return SArray{S}($(dx))
+        similar_type($x,Dual{T,$V,$N})($(dx))
     end
 end
 
-@inline static_dual_eval(::Type{T}, f, x::SArray) where {T} = f(dualize(T, x))
-
-########### FieldVectors ###########
-@generated function dualize(::Type{T}, x::FieldVector{N,V}) where {T,V,N}
-    dx = Expr(:tuple, [:(Dual{T}(x[$i], chunk, Val{$i}())) for i in 1:N]...)
-    return quote
-        chunk = Chunk{N}()
-        $(Expr(:meta, :inline))
-        return similar_type($x, Dual{T,V,N})($(dx))
-    end
-end
-@inline static_dual_eval(::Type{T}, f, x::FieldVector) where {T} = f(dualize(T, x))
-####################################
+@inline static_dual_eval(::Type{T}, f, x::Union{FieldVector, SArray}) where {T} = f(dualize(T, x))
 
 function vector_mode_dual_eval(f, x, cfg::Union{JacobianConfig,GradientConfig})
     xdual = cfg.duals

--- a/src/hessian.jl
+++ b/src/hessian.jl
@@ -55,41 +55,18 @@ function hessian!(result::DiffResult, f, x::AbstractArray, cfg::HessianConfig{T}
     return result
 end
 
-hessian(f, x::SArray) = jacobian(y -> gradient(f, y), x)
+hessian(f, x::Union{FieldVector, SArray}) = jacobian(y -> gradient(f, y), x)
 
-hessian(f, x::SArray, cfg::HessianConfig) = hessian(f, x)
+hessian(f, x::Union{FieldVector, SArray}, cfg::HessianConfig) = hessian(f, x)
 
-hessian!(result::AbstractArray, f, x::SArray) = jacobian!(result, y -> gradient(f, y), x)
+hessian!(result::AbstractArray, f, x::Union{FieldVector, SArray}) = jacobian!(result, y -> gradient(f, y), x)
 
-hessian!(result::MutableDiffResult, f, x::SArray) = hessian!(result, f, x, HessianConfig(f, result, x))
+hessian!(result::MutableDiffResult, f, x::Union{FieldVector, SArray}) = hessian!(result, f, x, HessianConfig(f, result, x))
 
-hessian!(result::ImmutableDiffResult, f, x::SArray, cfg::HessianConfig) = hessian!(result, f, x)
+hessian!(result::ImmutableDiffResult, f, x::Union{FieldVector, SArray}, cfg::HessianConfig) = hessian!(result, f, x)
 
-function hessian!(result::ImmutableDiffResult, f::F, x::SArray{S,V}) where {F,S,V}
-    T = typeof(Tag(f,V))
-    d1 = dualize(T, x)
-    d2 = dualize(T, d1)
-    fd2 = f(d2)
-    val = value(T,value(T,fd2))
-    grad = extract_gradient(T,value(T,fd2), x)
-    hess = extract_jacobian(T,partials(T,fd2), x)
-    result = DiffResults.hessian!(result, hess)
-    result = DiffResults.gradient!(result, grad)
-    result = DiffResults.value!(result, val)
-    return result
-end
-
-hessian(f, x::FieldVector) = jacobian(y -> gradient(f, y), x)
-
-hessian(f, x::FieldVector, cfg::HessianConfig) = hessian(f, x)
-
-hessian!(result::AbstractArray, f, x::FieldVector) = jacobian!(result, y -> gradient(f, y), x)
-
-hessian!(result::MutableDiffResult, f, x::FieldVector) = hessian!(result, f, x, HessianConfig(f, result, x))
-
-hessian!(result::ImmutableDiffResult, f, x::FieldVector, cfg::HessianConfig) = hessian!(result, f, x)
-
-function hessian!(result::ImmutableDiffResult, f::F, x::FieldVector{N,V}) where {F,N,V}
+function hessian!(result::ImmutableDiffResult, f::F, x::Union{FieldVector, SArray}) where {F}
+    V = eltype(x)
     T = typeof(Tag(f,V))
     d1 = dualize(T, x)
     d2 = dualize(T, d1)

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -29,7 +29,7 @@ stored in `y`.
 Set `check` to `Val{false}()` to disable tag checking. This can lead to perturbation confusion, so should be used with care.
 """
 function jacobian(f!, y::AbstractArray, x::AbstractArray, cfg::JacobianConfig{T} = JacobianConfig(f!, y, x), ::Val{CHK}=Val{true}()) where {T, CHK}
-    CHK && checktag(T, f!, x)    
+    CHK && checktag(T, f!, x)
     if chunksize(cfg) == length(x)
         return vector_mode_jacobian(f!, y, x, cfg)
     else
@@ -84,6 +84,12 @@ end
 @inline jacobian!(result::Union{AbstractArray,DiffResult}, f, x::SArray) = vector_mode_jacobian!(result, f, x)
 @inline jacobian!(result::Union{AbstractArray,DiffResult}, f, x::SArray, cfg::JacobianConfig) = jacobian!(result, f, x)
 
+@inline jacobian(f, x::FieldVector) = vector_mode_jacobian(f, x)
+@inline jacobian(f, x::FieldVector, cfg::JacobianConfig) = jacobian(f, x)
+
+@inline jacobian!(result::Union{AbstractArray,DiffResult}, f, x::FieldVector) = vector_mode_jacobian!(result, f, x)
+@inline jacobian!(result::Union{AbstractArray,DiffResult}, f, x::FieldVector, cfg::JacobianConfig) = jacobian!(result, f, x)
+
 #####################
 # result extraction #
 #####################
@@ -98,6 +104,20 @@ end
 end
 
 function extract_jacobian(::Type{T}, ydual::AbstractArray, x::SArray{S,V,D,N}) where {T,S,V,D,N}
+    result = similar(ydual, valtype(eltype(ydual)), length(ydual), N)
+    return extract_jacobian!(T, result, ydual, N)
+end
+
+@generated function extract_jacobian(::Type{T}, ydual::FieldVector{M,VY},
+                                     x::FieldVector{N,VX}) where {T,M,VY,N,VX}
+    result = Expr(:tuple, [:(partials(T, ydual[$i], $j)) for i in 1:M, j in 1:N]...)
+    return quote
+        $(Expr(:meta, :inline))
+        return SArray{Tuple{M,N}}($result)
+    end
+end
+
+function extract_jacobian(::Type{T}, ydual::AbstractArray, x::FieldVector{N,VX}) where {T,N,VX}
     result = similar(ydual, valtype(eltype(ydual)), length(ydual), N)
     return extract_jacobian!(T, result, ydual, N)
 end
@@ -186,6 +206,26 @@ end
     return result
 end
 
+@inline function vector_mode_jacobian(f::F, x::FieldVector{N,V}) where {F,N,V}
+    T = typeof(Tag(f,V))
+    return extract_jacobian(T, static_dual_eval(T, f, x), x)
+end
+
+@inline function vector_mode_jacobian!(result, f::F, x::FieldVector{N,V}) where {F,N,V}
+    T = typeof(Tag(f,V))
+    ydual = static_dual_eval(T, f, x)
+    result = extract_jacobian!(T, result, ydual, N)
+    result = extract_value!(T, result, ydual)
+    return result
+end
+
+@inline function vector_mode_jacobian!(result::ImmutableDiffResult, f::F, x::FieldVector{N,V}) where {F,N,V}
+    T = typeof(Tag(f,V))
+    ydual = static_dual_eval(T, f, x)
+    result = DiffResults.jacobian!(result, extract_jacobian(T, ydual, x))
+    result = DiffResults.value!(d -> value(T,d), result, ydual)
+    return result
+end
 # chunk mode #
 #------------#
 


### PR DESCRIPTION
Hi Team,

This is my attempt to extend all `SArray` functionality to `FieldVectors`. This resolves issue #305. The basic approach mostly involves replacing `SArray` with `Union{FieldVector, SArray}` in method definitions.  I have included tests to mirror those used for testing `SArray` codepaths for Gradients, Hessians and Jacobians.