### PR TITLE
remove redundant abs definition post-DiffRules v0.0.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,7 +2,7 @@ julia 0.6.0
 Compat 0.47.0
 StaticArrays 0.5.0
 DiffResults 0.0.1
-DiffRules 0.0.3
+DiffRules 0.0.4
 NaNMath 0.2.2
 SpecialFunctions 0.1.0
 CommonSubexpressions 0.0.1

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -318,8 +318,6 @@ Base.AbstractFloat(d::Dual{T,V,N}) where {T,V,N} = convert(Dual{T,promote_type(V
 
 @inline Base.conj(d::Dual) = d
 
-@inline Base.abs(d::Dual) = signbit(value(d)) ? -d : d
-
 for (M, f, arity) in DiffRules.diffrules()
     in((M, f), ((:Base, :^), (:NaNMath, :pow), (:Base, :/), (:Base, :+), (:Base, :-))) && continue
     if arity == 1


### PR DESCRIPTION
to be merged after https://github.com/JuliaLang/METADATA.jl/pull/13985

resolves #310 