### PR TITLE
Special case x^0

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -408,8 +408,12 @@ for f in (:(Base.:^), :(NaNMath.pow))
             begin
                 v = value(x)
                 expv = ($f)(v, y)
-                deriv = y * ($f)(v, y - 1)
-                return Dual{Tx}(expv, deriv * partials(x))
+                if y == zero(y)
+                    new_partials = zero(partials(x))
+                else
+                    new_partials = partials(x) * y * ($f)(v, y - 1)
+                end
+                return Dual{Tx}(expv, new_partials)
             end,
             begin
                 v = value(y)

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -455,4 +455,14 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
     end
 end
 
+@testset "Exponentiation of zero" begin
+    x0 = 0.0
+    x1 = Dual{:t1}(x0, 1.0)
+    x2 = Dual{:t2}(x1, 1.0)
+    x3 = Dual{:t3}(x2, 1.0)
+    @test x3^2 === x3 * x3
+    @test x2^1 === x2
+    @test x1^0 === Dual{:t1}(1.0, 0.0)
+end
+
 end # module


### PR DESCRIPTION
In current released (and master; 3f62885ecf2523c7e0707863a2c11ccf93fccc5f) ForwardDiff.jl, `n+1`-th derivative of `x^n` at `x = 0` is `NaN`:

```julia
julia> Pkg.installed("ForwardDiff")
v"0.7.5"

julia> using ForwardDiff

julia> ForwardDiff.NANSAFE_MODE_ENABLED
true

julia> nthderiv(f, n, x = 0.0) =
           if n == 1
               ForwardDiff.derivative(f, x)
           else
               ForwardDiff.derivative(z -> nthderiv(f, n - 1, z), x)
           end
nthderiv (generic function with 2 methods)

julia> @assert all(nthderiv(x -> x^n, n) == factorial(n) for n in 1:5)

julia> nthderiv(x -> x^0, 1)
NaN

julia> nthderiv(x -> x^1, 2)
NaN

julia> nthderiv(x -> x^2, 3)
NaN

julia> nthderiv(x -> x^3, 4)
NaN
```

This issue can be observed more directly in nested dual number.  Namely, if I have "`n`-th order" dual number (is it the right word?) with the `.value` component being 0, its `n - 1`-th power produces `NaN` in the `.partials` component:

```julia
julia> using ForwardDiff: Dual

julia> x0 = 0.0
0.0

julia> x1 = Dual{:t1}(x0, 1.0)
Dual{:t1}(0.0,1.0)

julia> x2 = Dual{:t2}(x1, 1.0)
Dual{:t2}(Dual{:t1}(0.0,1.0),Dual{:t1}(1.0,0.0))

julia> x3 = Dual{:t3}(x2, 1.0)
Dual{:t3}(Dual{:t2}(Dual{:t1}(0.0,1.0),Dual{:t1}(1.0,0.0)),
          Dual{:t2}(Dual{:t1}(1.0,0.0),Dual{:t1}(0.0,0.0)))

julia> x3 * x3  # OK
Dual{:t3}(Dual{:t2}(Dual{:t1}(0.0,0.0),Dual{:t1}(0.0,2.0)),
          Dual{:t2}(Dual{:t1}(0.0,2.0),Dual{:t1}(2.0,0.0)))

julia> x3^2
Dual{:t3}(Dual{:t2}(Dual{:t1}(0.0,0.0),Dual{:t1}(0.0,2.0)),
          Dual{:t2}(Dual{:t1}(0.0,2.0),Dual{:t1}(2.0,NaN)))

julia> x2^1
Dual{:t2}(Dual{:t1}(0.0,1.0),Dual{:t1}(1.0,NaN))

julia> x1^0
Dual{:t1}(1.0,NaN)
```

All I need to make it "work" is to special-case `Dual(0.0, ...) ^ 0` (`x1^0` above).  I'm not familiar with the whole ForwardDiff.jl codebase so I'm not entirely sure if this is the right "fix" (or what I see here is actually a bug).  But I can come up with some rationale for why this PR could be the right way to go:

1. It's more consistent.  Identities such as `x3^2 === x3 * x3` and `x2^1 === x2` (note the triple equal `===` for comparing `.partials`) for nested `Dual` didn't hold without this PR.
2. Taking the derivative of `x^y` at `x = y = 0` is problematic if both `x` and `y` are variables.  However, if `y = 0` is a non-`Dual` constant, I suppose we don't have such problem since this case corresponds to taking the limit `y -> 0` first and then do another limit for `x` to compute the derivative.

What do you think?

fixes #330
