### PR TITLE
Enable SIMD with Base.literal_pow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ notifications:
 sudo: false
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'Pkg.clone(pwd()); Pkg.build("ForwardDiff"); Pkg.test("ForwardDiff"; coverage=true)';
-    - julia -O3 -e 'using Pkg; Pkg.add("StaticArrays"); include("test/SIMDTest.jl")';
+    - julia --color=yes -e 'Pkg.clone(pwd()); Pkg.build("ForwardDiff"); Pkg.test("ForwardDiff"; coverage=true)';
+    - julia --color=yes -O3 -e 'using Pkg; Pkg.add("StaticArrays"); include("test/SIMDTest.jl")';
 after_success:
-    - julia -e 'Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
-    - julia -e 'Pkg.add("Documenter")'
-    - julia -e 'include("docs/make.jl")'
+    - julia --color=yes -e 'Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+    - julia --color=yes -e 'Pkg.add("Documenter")'
+    - julia --color=yes -e 'include("docs/make.jl")'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ sudo: false
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
     - julia -e 'Pkg.clone(pwd()); Pkg.build("ForwardDiff"); Pkg.test("ForwardDiff"; coverage=true)';
-    - julia -O3 -e 'include("test/SIMDTest.jl")';
+    - julia -O3 -e 'using Pkg; Pkg.add("StaticArrays"); include("test/SIMDTest.jl")';
 after_success:
     - julia -e 'Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
     - julia -e 'Pkg.add("Documenter")'

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -425,6 +425,18 @@ for f in (:(Base.:^), :(NaNMath.pow))
     end
 end
 
+@inline Base.literal_pow(::typeof(^), x::Dual{T}, ::Val{0}) where {T} =
+    Dual{T}(one(value(x)), zero(partials(x)))
+
+for y in 1:3
+    @eval @inline function Base.literal_pow(::typeof(^), x::Dual{T}, ::Val{$y}) where {T}
+        v = value(x)
+        expv = v^$y
+        deriv = $y * v^$(y - 1)
+        return Dual{T}(expv, deriv * partials(x))
+    end
+end
+
 # hypot #
 #-------#
 

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -460,9 +460,10 @@ end
     x1 = Dual{:t1}(x0, 1.0)
     x2 = Dual{:t2}(x1, 1.0)
     x3 = Dual{:t3}(x2, 1.0)
-    @test x3^2 === x3 * x3
-    @test x2^1 === x2
-    @test x1^0 === Dual{:t1}(1.0, 0.0)
+    pow = ^  # to call non-literal power
+    @test pow(x3, 2) === x3^2 === x3 * x3
+    @test pow(x2, 1) === x2^1 === x2
+    @test pow(x1, 0) === x1^0 === Dual{:t1}(1.0, 0.0)
 end
 
 end # module

--- a/test/SIMDTest.jl
+++ b/test/SIMDTest.jl
@@ -3,6 +3,7 @@ module SIMDTest
 using Test
 using ForwardDiff: Dual, valtype
 using InteractiveUtils: code_llvm
+using StaticArrays: SVector
 
 const DUALS = (Dual(1., 2., 3., 4.),
                Dual(1., 2., 3., 4., 5.),
@@ -32,6 +33,9 @@ for D in map(typeof, DUALS)
     @test occursin(r"fadd \<.*?x double\>", div_bitcode)
     @test occursin(r"fmul \<.*?x double\>", div_bitcode)
 
+    pow_bitcode = sprint(io -> code_llvm(io, ^, (D, Int)))
+    @test occursin(r"fmul \<.*?x double\>", pow_bitcode)
+
     exp_bitcode = sprint(io -> code_llvm(io, ^, (D, D)))
     @test occursin(r"fadd \<.*?x double\>", exp_bitcode)
     if !(valtype(D) <: Dual)
@@ -42,6 +46,28 @@ for D in map(typeof, DUALS)
         sum_bitcode = sprint(io -> code_llvm(io, simd_sum, (Vector{D},)))
         @test occursin(r"fadd (fast |)\<.*?x double\>", sum_bitcode)
     end
+end
+
+# `pow2dot` is chosen so that `@code_llvm pow2dot(SVector(1:1.0:4...))`
+# generates code with SIMD instructions.
+# See:
+# https://github.com/JuliaDiff/ForwardDiff.jl/pull/332
+# https://github.com/JuliaDiff/ForwardDiff.jl/pull/331#issuecomment-406107260
+@inline pow2(x) = x^2
+pow2dot(xs) = pow2.(xs)
+
+# Nested dual such as `Dual(Dual(1., 2.), Dual(3., 4.))` only produces
+# "fmul <2 x double>" so it is excluded from the following test.
+const POW_DUALS = (Dual(1., 2.),
+                   Dual(1., 2., 3.),
+                   Dual(1., 2., 3., 4.),
+                   Dual(1., 2., 3., 4., 5.))
+
+@testset "SIMD square of $D" for D in map(typeof, POW_DUALS)
+    pow_bitcode = sprint(io -> code_llvm(io, pow2dot, (SVector{4, D},)))
+    @test occursin(r"(.*fmul \<4 x double\>){2}"s, pow_bitcode)
+    # "{2}" is for asserting that fmul has to appear at least twice:
+    # once for `.value` and once for `.partials`.
 end
 
 end # module

--- a/test/SIMDTest.jl
+++ b/test/SIMDTest.jl
@@ -18,7 +18,7 @@ function simd_sum(x::Vector{T}) where T
     return s
 end
 
-for D in map(typeof, DUALS)
+@testset "SIMD $D" for D in map(typeof, DUALS)
     plus_bitcode = sprint(io -> code_llvm(io, +, (D, D)))
     @test occursin("fadd <4 x double>", plus_bitcode)
 


### PR DESCRIPTION
This branch eliminates run-time branching (introduced in #331) and enables SIMD (previously impossible in master) for power functions with low degree (<= 3).  For example,

```julia
using ForwardDiff: Dual
using StaticArrays
x = Dual(1.0, 2.0)
xs = SVector(x, x, x, x)
@inline pow2(x) = x^2
f(xs) = pow2.(xs)
@code_llvm f(xs)
```

executed with `julia -O3` prints two `fmul <4 x double>` instructions (presumably one for `.value` and one for `.partials[1]`):

<details>

```llvm
define void @julia_f_63134(%SArray* noalias nocapture sret, %SArray* nocapture readonly dereferenceable(64)) #0 !dbg !5 {
top:
  %2 = getelementptr inbounds %SArray, %SArray* %1, i64 0, i32 0, i64 0, i32 0
  %3 = load double, double* %2, align 8
  %4 = fmul double %3, 2.000000e+00
  %5 = getelementptr inbounds %SArray, %SArray* %1, i64 0, i32 0, i64 0, i32 1, i32 0, i64 0
  %6 = load double, double* %5, align 8
  %7 = getelementptr inbounds %SArray, %SArray* %1, i64 0, i32 0, i64 1, i32 0
  %8 = load double, double* %7, align 8
  %9 = fmul double %8, 2.000000e+00
  %10 = getelementptr inbounds %SArray, %SArray* %1, i64 0, i32 0, i64 1, i32 1, i32 0, i64 0
  %11 = load double, double* %10, align 8
  %12 = insertelement <4 x double> undef, double %3, i32 0
  %13 = insertelement <4 x double> %12, double %4, i32 1
  %14 = insertelement <4 x double> %13, double %8, i32 2
  %15 = insertelement <4 x double> %14, double %9, i32 3
  %16 = insertelement <4 x double> %12, double %6, i32 1
  %17 = insertelement <4 x double> %16, double %8, i32 2
  %18 = insertelement <4 x double> %17, double %11, i32 3
  %19 = fmul <4 x double> %15, %18
  %20 = getelementptr inbounds %SArray, %SArray* %1, i64 0, i32 0, i64 2, i32 0
  %21 = load double, double* %20, align 8
  %22 = fmul double %21, 2.000000e+00
  %23 = getelementptr inbounds %SArray, %SArray* %1, i64 0, i32 0, i64 2, i32 1, i32 0, i64 0
  %24 = load double, double* %23, align 8
  %25 = getelementptr inbounds %SArray, %SArray* %1, i64 0, i32 0, i64 3, i32 0
  %26 = load double, double* %25, align 8
  %27 = fmul double %26, 2.000000e+00
  %28 = getelementptr inbounds %SArray, %SArray* %1, i64 0, i32 0, i64 3, i32 1, i32 0, i64 0
  %29 = load double, double* %28, align 8
  %30 = insertelement <4 x double> undef, double %21, i32 0
  %31 = insertelement <4 x double> %30, double %22, i32 1
  %32 = insertelement <4 x double> %31, double %26, i32 2
  %33 = insertelement <4 x double> %32, double %27, i32 3
  %34 = insertelement <4 x double> %30, double %24, i32 1
  %35 = insertelement <4 x double> %34, double %26, i32 2
  %36 = insertelement <4 x double> %35, double %29, i32 3
  %37 = fmul <4 x double> %33, %36
  %38 = bitcast %SArray* %0 to <4 x double>*
  store <4 x double> %19, <4 x double>* %38, align 8
  %39 = getelementptr inbounds %SArray, %SArray* %0, i64 0, i32 0, i64 2, i32 0
  %40 = bitcast double* %39 to <4 x double>*
  store <4 x double> %37, <4 x double>* %40, align 8
  ret void
}
```

</details>

 

In #331 branch and master, it was not possible to generate IR with SIMD instructions:

<details>

```llvm
define void @julia_f_63115(%SArray* noalias nocapture sret, %SArray* nocapture readonly dereferenceable(64)) #0 !dbg !5 {
top:
  %2 = getelementptr inbounds %SArray, %SArray* %1, i64 0, i32 0, i64 0, i32 0
  %3 = load double, double* %2, align 8
  %pow2 = fmul double %3, %3
  %4 = fadd double %3, 2.000000e+00
  %notlhs = fcmp ord double %pow2, 0.000000e+00
  %notrhs = fcmp uno double %4, 0.000000e+00
  %5 = or i1 %notrhs, %notlhs
  br i1 %5, label %L27, label %if

if:                                               ; preds = %top
  call void @jl_throw(i8** inttoptr (i64 140415041378608 to i8**))
  unreachable

L27:                                              ; preds = %top
  %6 = fadd double %3, 1.000000e+00
  %notlhs62 = fcmp ord double %3, 0.000000e+00
  %notrhs63 = fcmp uno double %6, 0.000000e+00
  %7 = or i1 %notlhs62, %notrhs63
  br i1 %7, label %L66, label %if55

if34:                                             ; preds = %L66
  call void @jl_throw(i8** inttoptr (i64 140415041378608 to i8**))
  unreachable

L124:                                             ; preds = %L66
  %8 = fadd double %47, 1.000000e+00
  %notlhs76 = fcmp ord double %47, 0.000000e+00
  %notrhs77 = fcmp uno double %8, 0.000000e+00
  %9 = or i1 %notlhs76, %notrhs77
  br i1 %9, label %L163, label %if52

if38:                                             ; preds = %L163
  call void @jl_throw(i8** inttoptr (i64 140415041378608 to i8**))
  unreachable

L221:                                             ; preds = %L163
  %10 = fadd double %43, 1.000000e+00
  %notlhs90 = fcmp ord double %43, 0.000000e+00
  %notrhs91 = fcmp uno double %10, 0.000000e+00
  %11 = or i1 %notlhs90, %notrhs91
  br i1 %11, label %L260, label %if49

if42:                                             ; preds = %L260
  call void @jl_throw(i8** inttoptr (i64 140415041378608 to i8**))
  unreachable

L318:                                             ; preds = %L260
  %12 = fadd double %39, 1.000000e+00
  %notlhs104 = fcmp ord double %39, 0.000000e+00
  %notrhs105 = fcmp uno double %12, 0.000000e+00
  %13 = or i1 %notlhs104, %notrhs105
  br i1 %13, label %L357, label %if46

if46:                                             ; preds = %L318
  call void @jl_throw(i8** inttoptr (i64 140415041378608 to i8**))
  unreachable

L357:                                             ; preds = %L318
  %14 = getelementptr inbounds %SArray, %SArray* %1, i64 0, i32 0, i64 0, i32 1, i32 0, i64 0
  %15 = load double, double* %14, align 8
  %16 = fmul double %15, 2.000000e+00
  %17 = fmul double %3, %16
  %18 = getelementptr inbounds %SArray, %SArray* %1, i64 0, i32 0, i64 1, i32 1, i32 0, i64 0
  %19 = load double, double* %18, align 8
  %20 = fmul double %19, 2.000000e+00
  %21 = fmul double %47, %20
  %22 = getelementptr inbounds %SArray, %SArray* %1, i64 0, i32 0, i64 2, i32 1, i32 0, i64 0
  %23 = load double, double* %22, align 8
  %24 = fmul double %23, 2.000000e+00
  %25 = fmul double %43, %24
  %26 = getelementptr inbounds %SArray, %SArray* %1, i64 0, i32 0, i64 3, i32 1, i32 0, i64 0
  %27 = load double, double* %26, align 8
  %28 = fmul double %27, 2.000000e+00
  %29 = fmul double %39, %28
  %30 = getelementptr inbounds %SArray, %SArray* %0, i64 0, i32 0, i64 0, i32 0
  store double %pow2, double* %30, align 8
  %31 = getelementptr inbounds %SArray, %SArray* %0, i64 0, i32 0, i64 0, i32 1, i32 0, i64 0
  store double %17, double* %31, align 8
  %32 = getelementptr inbounds %SArray, %SArray* %0, i64 0, i32 0, i64 1, i32 0
  store double %pow269, double* %32, align 8
  %33 = getelementptr inbounds %SArray, %SArray* %0, i64 0, i32 0, i64 1, i32 1, i32 0, i64 0
  store double %21, double* %33, align 8
  %34 = getelementptr inbounds %SArray, %SArray* %0, i64 0, i32 0, i64 2, i32 0
  store double %pow283, double* %34, align 8
  %35 = getelementptr inbounds %SArray, %SArray* %0, i64 0, i32 0, i64 2, i32 1, i32 0, i64 0
  store double %25, double* %35, align 8
  %36 = getelementptr inbounds %SArray, %SArray* %0, i64 0, i32 0, i64 3, i32 0
  store double %pow297, double* %36, align 8
  %37 = getelementptr inbounds %SArray, %SArray* %0, i64 0, i32 0, i64 3, i32 1, i32 0, i64 0
  store double %29, double* %37, align 8
  ret void

if49:                                             ; preds = %L221
  call void @jl_throw(i8** inttoptr (i64 140415041378608 to i8**))
  unreachable

L260:                                             ; preds = %L221
  %38 = getelementptr inbounds %SArray, %SArray* %1, i64 0, i32 0, i64 3, i32 0
  %39 = load double, double* %38, align 8
  %pow297 = fmul double %39, %39
  %40 = fadd double %39, 2.000000e+00
  %notlhs99 = fcmp ord double %pow297, 0.000000e+00
  %notrhs100 = fcmp uno double %40, 0.000000e+00
  %41 = or i1 %notrhs100, %notlhs99
  br i1 %41, label %L318, label %if42

if52:                                             ; preds = %L124
  call void @jl_throw(i8** inttoptr (i64 140415041378608 to i8**))
  unreachable

L163:                                             ; preds = %L124
  %42 = getelementptr inbounds %SArray, %SArray* %1, i64 0, i32 0, i64 2, i32 0
  %43 = load double, double* %42, align 8
  %pow283 = fmul double %43, %43
  %44 = fadd double %43, 2.000000e+00
  %notlhs85 = fcmp ord double %pow283, 0.000000e+00
  %notrhs86 = fcmp uno double %44, 0.000000e+00
  %45 = or i1 %notrhs86, %notlhs85
  br i1 %45, label %L221, label %if38

if55:                                             ; preds = %L27
  call void @jl_throw(i8** inttoptr (i64 140415041378608 to i8**))
  unreachable

L66:                                              ; preds = %L27
  %46 = getelementptr inbounds %SArray, %SArray* %1, i64 0, i32 0, i64 1, i32 0
  %47 = load double, double* %46, align 8
  %pow269 = fmul double %47, %47
  %48 = fadd double %47, 2.000000e+00
  %notlhs71 = fcmp ord double %pow269, 0.000000e+00
  %notrhs72 = fcmp uno double %48, 0.000000e+00
  %49 = or i1 %notrhs72, %notlhs71
  br i1 %49, label %L124, label %if34
}
```

</details>

 

My first implementation was using `@generated` and it generated `literal_pow` code for any degree.  I thought it was OK since `Base.literal_pow` has a fall-back implementation for higher degree power functions but it turned out this implantation was slower when the benchmark involves high degree power functions.  Limiting degree to three yields better performance for all degrees I've tired.  I get similar benchmark results in two machines:

* Machine 1 (a laptop)

    * `@generated`-based vs #331: https://gist.github.com/b44e7cfc85e682fa293182eae086ac5f
    * `for`-`@eval`-based vs #331: https://gist.github.com/2283e2397df7dd604147cf9077190084

* Machine 2 (a desktop)

    * `@generated`-based vs #331: https://gist.github.com/tkf/0350bc6f30405b489c41b697d3692b88
    * `for`-`@eval`-based vs #331: https://gist.github.com/3834bdee95980c7a9268cc7e57b9f495
