### PR TITLE
Add constructor calling convert for (::Type{<:Dual})(::Real), fix #336

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -315,6 +315,7 @@ end
 Base.convert(::Type{Dual{T,V,N}}, d::Dual{T}) where {T,V<:Real,N} = Dual{T}(convert(V, value(d)), convert(Partials{N,V}, partials(d)))
 Base.convert(::Type{Dual{T,V,N}}, x::Real) where {T,V<:Real,N} = Dual{T}(convert(V, x), zero(Partials{N,V}))
 Base.convert(::Type{D}, d::D) where {D<:Dual} = d
+(::Type{D})(x::Real) where {D<:Dual} = convert(D, x)
 
 Base.float(d::Dual{T,V,N}) where {T,V,N} = convert(Dual{T,promote_type(V, Float16),N}, d)
 Base.AbstractFloat(d::Dual{T,V,N}) where {T,V,N} = convert(Dual{T,promote_type(V, Float16),N}, d)


### PR DESCRIPTION
From an organizational perspective this extra method could also live at the top with the other constructors; I'm not sure what's preferred.