### PR TITLE
remove generated functions on tuples

### DIFF
--- a/src/partials.jl
+++ b/src/partials.jl
@@ -6,10 +6,7 @@ end
 # Utility/Accessor Functions #
 ##############################
 
-@generated function single_seed(::Type{Partials{N,V}}, ::Val{i}) where {N,V,i}
-    ex = Expr(:tuple, [ifelse(i === j, :(one(V)), :(zero(V))) for j in 1:N]...)
-    return :(Partials($(ex)))
-end
+single_seed(::Type{Partials{N,V}}, ::Val{i}) where {N,V,i} = Partials(ntuple(j -> j == i ? one(V) : zero(V), Val(N)))
 
 @inline valtype(::Partials{N,V}) where {N,V} = V
 @inline valtype(::Type{Partials{N,V}}) where {N,V} = V
@@ -34,18 +31,20 @@ Base.mightalias(x::AbstractArray, y::Partials) = false
 # Generic Functions #
 #####################
 
-@inline Base.iszero(partials::Partials) = iszero_tuple(partials.values)
+@inline Base.iszero(partials::Partials) = all(iszero, partials.values)
 
 @inline Base.zero(partials::Partials) = zero(typeof(partials))
-@inline Base.zero(::Type{Partials{N,V}}) where {N,V} = Partials{N,V}(zero_tuple(NTuple{N,V}))
+@inline Base.zero(::Type{Partials{N,V}}) where {N,V} = Partials{N,V}(ntuple(_ -> zero(V), Val(N)))
 
 @inline Base.one(partials::Partials) = one(typeof(partials))
-@inline Base.one(::Type{Partials{N,V}}) where {N,V} = Partials{N,V}(one_tuple(NTuple{N,V}))
+@inline Base.one(::Type{Partials{N,V}}) where {N,V} = Partials{N,V}(ntuple(_ -> one(V), Val(N)))
 
 @inline Random.rand(partials::Partials) = rand(typeof(partials))
-@inline Random.rand(::Type{Partials{N,V}}) where {N,V} = Partials{N,V}(rand_tuple(NTuple{N,V}))
+@inline Random.rand(::Type{Partials{N,V}}) where {N,V} = Partials{N,V}(ntuple(_ -> rand(V), Val(N)))
+
 @inline Random.rand(rng::AbstractRNG, partials::Partials) = rand(rng, typeof(partials))
-@inline Random.rand(rng::AbstractRNG, ::Type{Partials{N,V}}) where {N,V} = Partials{N,V}(rand_tuple(rng, NTuple{N,V}))
+@inline Random.rand(rng::AbstractRNG, ::Type{Partials{N,V}}) where {N,V} = Partials{N,V}(ntuple(_ -> rand(rng, V), Val(N)))
+
 
 Base.isequal(a::Partials{N}, b::Partials{N}) where {N} = isequal(a.values, b.values)
 Base.:(==)(a::Partials{N}, b::Partials{N}) where {N} = a.values == b.values
@@ -78,10 +77,10 @@ Base.convert(::Type{Partials{N,V}}, partials::Partials{N,V}) where {N,V} = parti
 # Arithmetic Functions #
 ########################
 
-@inline Base.:+(a::Partials{N}, b::Partials{N}) where {N} = Partials(add_tuples(a.values, b.values))
-@inline Base.:-(a::Partials{N}, b::Partials{N}) where {N} = Partials(sub_tuples(a.values, b.values))
-@inline Base.:-(partials::Partials) = Partials(minus_tuple(partials.values))
-@inline Base.:*(x::Real, partials::Partials) = partials*x
+@inline Base.:+(a::Partials{N}, b::Partials{N}) where {N} = Partials(a.values .+ b.values)
+@inline Base.:-(a::Partials{N}, b::Partials{N}) where {N} = Partials(a.values .- b.values)
+@inline Base.:-(partials::Partials) = Partials(.-partials.values)
+@inline Base.:*(x::Real, partials::Partials) = partials * x
 
 @inline function _div_partials(a::Partials, b::Partials, aval, bval)
     return _mul_partials(a, b, inv(bval), -(aval / (bval*bval)))
@@ -93,32 +92,33 @@ end
 if NANSAFE_MODE_ENABLED
     @inline function Base.:*(partials::Partials, x::Real)
         x = ifelse(!isfinite(x) && iszero(partials), one(x), x)
-        return Partials(scale_tuple(partials.values, x))
+        return Partials(partials.values .* x)
     end
 
     @inline function Base.:/(partials::Partials, x::Real)
         x = ifelse(x == zero(x) && iszero(partials), one(x), x)
-        return Partials(div_tuple_by_scalar(partials.values, x))
+        return Partials(partials.values ./ x)
     end
 
     @inline function _mul_partials(a::Partials{N}, b::Partials{N}, x_a, x_b) where N
         x_a = ifelse(!isfinite(x_a) && iszero(a), one(x_a), x_a)
         x_b = ifelse(!isfinite(x_b) && iszero(b), one(x_b), x_b)
-        return Partials(mul_tuples(a.values, b.values, x_a, x_b))
+        return Partials(a.values .* x_a .+ b.values .* x_b)
     end
 else
     @inline function Base.:*(partials::Partials, x::Real)
-        return Partials(scale_tuple(partials.values, x))
+        return Partials(partials.values .* x)
     end
 
     @inline function Base.:/(partials::Partials, x::Real)
-        return Partials(div_tuple_by_scalar(partials.values, x))
+        return Partials(partials.values ./ x)
     end
 
     @inline function _mul_partials(a::Partials{N}, b::Partials{N}, x_a, x_b) where N
-        return Partials(mul_tuples(a.values, b.values, x_a, x_b))
+        return Partials(a.values .* x_a .+ b.values .* x_b)
     end
 end
+
 
 # edge cases where N == 0 #
 #-------------------------#
@@ -140,86 +140,6 @@ end
 @inline _mul_partials(a::Partials{0,A}, b::Partials{0,B}, afactor, bfactor) where {A,B} = Partials{0,promote_type(A,B)}(tuple())
 @inline _mul_partials(a::Partials{0,A}, b::Partials{N,B}, afactor, bfactor) where {N,A,B} = bfactor * b
 @inline _mul_partials(a::Partials{N,A}, b::Partials{0,B}, afactor, bfactor) where {N,A,B} = afactor * a
-
-##################################
-# Generated Functions on NTuples #
-##################################
-# The below functions are generally
-# equivalent to directly mapping over
-# tuples using `map`, but run a bit
-# faster since they generate inline code
-# that doesn't rely on closures.
-
-function tupexpr(f, N)
-    ex = Expr(:tuple, [f(i) for i=1:N]...)
-    return quote
-        $(Expr(:meta, :inline))
-        @inbounds return $ex
-    end
-end
-
-@inline iszero_tuple(::Tuple{}) = true
-@inline zero_tuple(::Type{Tuple{}}) = tuple()
-@inline one_tuple(::Type{Tuple{}}) = tuple()
-@inline rand_tuple(::AbstractRNG, ::Type{Tuple{}}) = tuple()
-@inline rand_tuple(::Type{Tuple{}}) = tuple()
-
-@generated function iszero_tuple(tup::NTuple{N,V}) where {N,V}
-    ex = Expr(:&&, [:(z == tup[$i]) for i=1:N]...)
-    return quote
-        z = zero(V)
-        $(Expr(:meta, :inline))
-        @inbounds return $ex
-    end
-end
-
-@generated function zero_tuple(::Type{NTuple{N,V}}) where {N,V}
-    ex = tupexpr(i -> :(z), N)
-    return quote
-        z = zero(V)
-        return $ex
-    end
-end
-
-@generated function one_tuple(::Type{NTuple{N,V}}) where {N,V}
-    ex = tupexpr(i -> :(z), N)
-    return quote
-        z = one(V)
-        return $ex
-    end
-end
-
-@generated function rand_tuple(rng::AbstractRNG, ::Type{NTuple{N,V}}) where {N,V}
-    return tupexpr(i -> :(rand(rng, V)), N)
-end
-
-@generated function rand_tuple(::Type{NTuple{N,V}}) where {N,V}
-    return tupexpr(i -> :(rand(V)), N)
-end
-
-@generated function scale_tuple(tup::NTuple{N}, x) where N
-    return tupexpr(i -> :(tup[$i] * x), N)
-end
-
-@generated function div_tuple_by_scalar(tup::NTuple{N}, x) where N
-    return tupexpr(i -> :(tup[$i] / x), N)
-end
-
-@generated function add_tuples(a::NTuple{N}, b::NTuple{N})  where N
-    return tupexpr(i -> :(a[$i] + b[$i]), N)
-end
-
-@generated function sub_tuples(a::NTuple{N}, b::NTuple{N})  where N
-    return tupexpr(i -> :(a[$i] - b[$i]), N)
-end
-
-@generated function minus_tuple(tup::NTuple{N}) where N
-    return tupexpr(i -> :(-tup[$i]), N)
-end
-
-@generated function mul_tuples(a::NTuple{N}, b::NTuple{N}, afactor, bfactor) where N
-    return tupexpr(i -> :((afactor * a[$i]) + (bfactor * b[$i])), N)
-end
 
 ###################
 # Pretty Printing #


### PR DESCRIPTION
Performance seems ok but I havent done big extensive testing:

```
julia> p = rand(ForwardDiff.Partials{8, Float32});

julia> @code_llvm p+p

  %3 = bitcast { [8 x float] } addrspace(11)* %1 to <8 x float> addrspace(11)*
  %4 = load <8 x float>, <8 x float> addrspace(11)* %3, align 4
  %5 = bitcast { [8 x float] } addrspace(11)* %2 to <8 x float> addrspace(11)*
  %6 = load <8 x float>, <8 x float> addrspace(11)* %5, align 4
  %7 = fadd <8 x float> %4, %6
  %8 = bitcast { [8 x float] }* %0 to <8 x float>*
  store <8 x float> %7, <8 x float>* %8, align 4
  ret void
}


julia> @code_llvm ForwardDiff._mul_partials(p, p, 2.f0, 4.f0);

  %5 = bitcast { [8 x float] } addrspace(11)* %1 to <8 x float> addrspace(11)*
  %6 = load <8 x float>, <8 x float> addrspace(11)* %5, align 4
  %7 = insertelement <8 x float> undef, float %3, i32 0
  %8 = shufflevector <8 x float> %7, <8 x float> undef, <8 x i32> zeroinitializer
  %9 = fmul <8 x float> %8, %6

  %10 = bitcast { [8 x float] } addrspace(11)* %2 to <8 x float> addrspace(11)*
  %11 = load <8 x float>, <8 x float> addrspace(11)* %10, align 4
  %12 = insertelement <8 x float> undef, float %4, i32 0
  %13 = shufflevector <8 x float> %12, <8 x float> undef, <8 x i32> zeroinitializer
  %14 = fmul <8 x float> %13, %11

  %15 = fadd <8 x float> %9, %14

  %16 = bitcast { [8 x float] }* %0 to <8 x float>*
  store <8 x float> %15, <8 x float>* %16, align 4
  ret void
}
```

Rosenbrock benchmark

```jl
using ForwardDiff: GradientConfig, Chunk, gradient!

function rosenbrock(x)
    a = one(eltype(x))
    b = 100 * a
    result = zero(eltype(x))
    for i in 1:length(x)-1
        result += (a - x[i])^2 + b*(x[i+1] - x[i]^2)^2
    end
    return result
end

# input vector
x = rand(10000);

# output buffer
out = similar(x);

cfg = ForwardDiff.GradientConfig(rosenbrock, x);
```

Before:

```jl
julia> @btime ForwardDiff.gradient!(out, rosenbrock, x, cfg);
  147.659 ms (0 allocations: 0 bytes)
```

After:

```jl
julia> @btime ForwardDiff.gradient!(out, rosenbrock, x, cfg);
  147.660 ms (0 allocations: 0 bytes)
```
