### PR TITLE
precompute chunks

### DIFF
--- a/src/prelude.jl
+++ b/src/prelude.jl
@@ -10,8 +10,11 @@ const DEFAULT_CHUNK_THRESHOLD = 10
 
 struct Chunk{N} end
 
+const CHUNKS = [Chunk{i}() for i in 1:DEFAULT_CHUNK_THRESHOLD]
+
 function Chunk(input_length::Integer, threshold::Integer = DEFAULT_CHUNK_THRESHOLD)
     N = pickchunksize(input_length, threshold)
+    N <= DEFAULT_CHUNK_THRESHOLD && return CHUNKS[N]
     return Chunk{N}()
 end
 


### PR DESCRIPTION
Benchmark

```jl
function rosenbrock(x)
   a = one(eltype(x))
   b = 100 * a
   result = zero(eltype(x))
   for i in 1:length(x)-1
       result += (a - x[i])^2 + b*(x[i+1] - x[i]^2)^2
   end
   return result
end

using BenchmarkTools
import ForwardDiff
const x = rand(10)
@btime ForwardDiff.gradient(rosenbrock, x)
```

Before
```jl
julia> @btime ForwardDiff.gradient(rosenbrock, x);
  4.484 μs (4 allocations: 2.03 KiB)
```

After
```jl
julia> @btime ForwardDiff.gradient(rosenbrock, x);
  851.246 ns (4 allocations: 2.03 KiB)
```

It feels silly this helps but numbers don't lie.