### PR TITLE
Partials do not alias

### DIFF
--- a/src/partials.jl
+++ b/src/partials.jl
@@ -2,6 +2,8 @@ struct Partials{N,V} <: AbstractVector{V}
     values::NTuple{N,V}
 end
 
+Base.mightalias(x::AbstractArray, y::Partials) = false
+
 ##############################
 # Utility/Accessor Functions #
 ##############################

--- a/src/partials.jl
+++ b/src/partials.jl
@@ -2,8 +2,6 @@ struct Partials{N,V} <: AbstractVector{V}
     values::NTuple{N,V}
 end
 
-Base.mightalias(x::AbstractArray, y::Partials) = false
-
 ##############################
 # Utility/Accessor Functions #
 ##############################
@@ -28,6 +26,9 @@ Base.iterate(partials::Partials) = iterate(partials.values)
 Base.iterate(partials::Partials, i) = iterate(partials.values, i)
 
 Base.IndexStyle(::Type{<:Partials}) = IndexLinear()
+
+# Can be deleted after https://github.com/JuliaLang/julia/pull/29854 is on a release
+Base.mightalias(x::AbstractArray, y::Partials) = false
 
 #####################
 # Generic Functions #


### PR DESCRIPTION
Benchmark

```jl
function rosenbrock(x)
   a = one(eltype(x))
   b = 100 * a
   result = zero(eltype(x))
   for i in 1:length(x)-1
       result += (a - x[i])^2 + b*(x[i+1] - x[i]^2)^2
   end
   return result
end

using BenchmarkTools
import ForwardDiff
const x = rand(10)
const y = similar(x)
const gradient_cache = ForwardDiff.GradientConfig(rosenbrock, x)
@btime ForwardDiff.gradient!(y, rosenbrock, x, gradient_cache)
```

Before

```jl
julia> @btime ForwardDiff.gradient!(y, rosenbrock, x, gradient_cache)
  247.428 ns (1 allocation: 96 bytes)
```

After

```jl
julia> @btime ForwardDiff.gradient!(y, rosenbrock, x, gradient_cache)
  178.401 ns (0 allocations: 0 bytes)
```