### PR TITLE
Relax type signatures on multiplication with partials

### DIFF
--- a/src/partials.jl
+++ b/src/partials.jl
@@ -81,7 +81,6 @@ Base.convert(::Type{Partials{N,V}}, partials::Partials{N,V}) where {N,V} = parti
 @inline Base.:+(a::Partials{N}, b::Partials{N}) where {N} = Partials(add_tuples(a.values, b.values))
 @inline Base.:-(a::Partials{N}, b::Partials{N}) where {N} = Partials(sub_tuples(a.values, b.values))
 @inline Base.:-(partials::Partials) = Partials(minus_tuple(partials.values))
-@inline Base.:*(x::Real, partials::Partials) = partials*x
 @inline Base.:*(x, partials::Partials) = partials*x
 
 @inline function _div_partials(a::Partials, b::Partials, aval, bval)
@@ -108,9 +107,6 @@ if NANSAFE_MODE_ENABLED
         return Partials(mul_tuples(a.values, b.values, x_a, x_b))
     end
 else
-    @inline function Base.:*(partials::Partials, x::Real)
-        return Partials(scale_tuple(partials.values, x))
-    end
     @inline function Base.:*(partials::Partials, x)
         return Partials(scale_tuple(partials.values, x))
     end


### PR DESCRIPTION
We need this for TPU work so that things like `XRTArrays` can be multiplied in.