### PR TITLE
Dispatch on StaticArray instead of SArray

### DIFF
--- a/src/apiutils.jl
+++ b/src/apiutils.jl
@@ -18,16 +18,18 @@ end
 # vector mode function evaluation #
 ###################################
 
-@generated function dualize(::Type{T}, x::SArray{S,V,D,N}) where {T,S,V,D,N}
+@generated function dualize(::Type{T}, x::StaticArray) where T
+    N = length(x)
     dx = Expr(:tuple, [:(Dual{T}(x[$i], chunk, Val{$i}())) for i in 1:N]...)
+    V = StaticArrays.similar_type(x, Dual{T,eltype(x),N})
     return quote
-        chunk = Chunk{N}()
+        chunk = Chunk{$N}()
         $(Expr(:meta, :inline))
-        return SArray{S}($(dx))
+        return $V($(dx))
     end
 end
 
-@inline static_dual_eval(::Type{T}, f, x::SArray) where {T} = f(dualize(T, x))
+@inline static_dual_eval(::Type{T}, f, x::StaticArray) where T = f(dualize(T, x))
 
 function vector_mode_dual_eval(f::F, x, cfg::Union{JacobianConfig,GradientConfig}) where {F}
     xdual = cfg.duals

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -39,23 +39,24 @@ function gradient!(result::Union{AbstractArray,DiffResult}, f::F, x::AbstractArr
     return result
 end
 
-@inline gradient(f, x::SArray)                      = vector_mode_gradient(f, x)
-@inline gradient(f, x::SArray, cfg::GradientConfig) = gradient(f, x)
-@inline gradient(f, x::SArray, cfg::GradientConfig, ::Val) = gradient(f, x)
+@inline gradient(f, x::StaticArray)                      = vector_mode_gradient(f, x)
+@inline gradient(f, x::StaticArray, cfg::GradientConfig) = gradient(f, x)
+@inline gradient(f, x::StaticArray, cfg::GradientConfig, ::Val) = gradient(f, x)
 
-@inline gradient!(result::Union{AbstractArray,DiffResult}, f, x::SArray) = vector_mode_gradient!(result, f, x)
-@inline gradient!(result::Union{AbstractArray,DiffResult}, f, x::SArray, cfg::GradientConfig) = gradient!(result, f, x)
-@inline gradient!(result::Union{AbstractArray,DiffResult}, f, x::SArray, cfg::GradientConfig, ::Val) = gradient!(result, f, x)
+@inline gradient!(result::Union{AbstractArray,DiffResult}, f, x::StaticArray) = vector_mode_gradient!(result, f, x)
+@inline gradient!(result::Union{AbstractArray,DiffResult}, f, x::StaticArray, cfg::GradientConfig) = gradient!(result, f, x)
+@inline gradient!(result::Union{AbstractArray,DiffResult}, f, x::StaticArray, cfg::GradientConfig, ::Val) = gradient!(result, f, x)
 
 #####################
 # result extraction #
 #####################
 
-@generated function extract_gradient(::Type{T}, y::Real, ::SArray{S,X,D,N}) where {T,S,X,D,N}
-    result = Expr(:tuple, [:(partials(T, y, $i)) for i in 1:N]...)
+@generated function extract_gradient(::Type{T}, y::Real, x::StaticArray) where T
+    result = Expr(:tuple, [:(partials(T, y, $i)) for i in 1:length(x)]...)
+    V = StaticArrays.similar_type(x, valtype(y))
     return quote
         $(Expr(:meta, :inline))
-        return SArray{S}($result)
+        return $V($result)
     end
 end
 
@@ -104,13 +105,13 @@ function vector_mode_gradient!(result, f::F, x, cfg::GradientConfig{T}) where {T
     return result
 end
 
-@inline function vector_mode_gradient(f::F, x::SArray{S,V}) where {F,S,V}
-    T = typeof(Tag(f,V))
+@inline function vector_mode_gradient(f, x::StaticArray)
+    T = typeof(Tag(f, eltype(x)))
     return extract_gradient(T, static_dual_eval(T, f, x), x)
 end
 
-@inline function vector_mode_gradient!(result, f::F, x::SArray{S,V}) where {F,S,V}
-    T = typeof(Tag(f,V))
+@inline function vector_mode_gradient!(result, f, x::StaticArray)
+    T = typeof(Tag(f, eltype(x)))
     return extract_gradient!(T, result, static_dual_eval(T, f, x))
 end
 

--- a/src/hessian.jl
+++ b/src/hessian.jl
@@ -68,19 +68,19 @@ function hessian!(result::DiffResult, f, x::AbstractArray, cfg::HessianConfig{T}
     return ∇f!.result
 end
 
-hessian(f, x::SArray) = jacobian(y -> gradient(f, y), x)
-hessian(f, x::SArray, cfg::HessianConfig) = hessian(f, x)
-hessian(f, x::SArray, cfg::HessianConfig, ::Val) = hessian(f, x)
+hessian(f, x::StaticArray) = jacobian(y -> gradient(f, y), x)
+hessian(f, x::StaticArray, cfg::HessianConfig) = hessian(f, x)
+hessian(f, x::StaticArray, cfg::HessianConfig, ::Val) = hessian(f, x)
 
-hessian!(result::AbstractArray, f, x::SArray) = jacobian!(result, y -> gradient(f, y), x)
+hessian!(result::AbstractArray, f, x::StaticArray) = jacobian!(result, y -> gradient(f, y), x)
 
-hessian!(result::MutableDiffResult, f, x::SArray) = hessian!(result, f, x, HessianConfig(f, result, x))
+hessian!(result::MutableDiffResult, f, x::StaticArray) = hessian!(result, f, x, HessianConfig(f, result, x))
 
-hessian!(result::ImmutableDiffResult, f, x::SArray, cfg::HessianConfig) = hessian!(result, f, x)
-hessian!(result::ImmutableDiffResult, f, x::SArray, cfg::HessianConfig, ::Val) = hessian!(result, f, x)
+hessian!(result::ImmutableDiffResult, f, x::StaticArray, cfg::HessianConfig) = hessian!(result, f, x)
+hessian!(result::ImmutableDiffResult, f, x::StaticArray, cfg::HessianConfig, ::Val) = hessian!(result, f, x)
 
-function hessian!(result::ImmutableDiffResult, f::F, x::SArray{S,V}) where {F,S,V}
-    T = typeof(Tag(f,V))
+function hessian!(result::ImmutableDiffResult, f, x::StaticArray)
+    T = typeof(Tag(f, eltype(x)))
     d1 = dualize(T, x)
     d2 = dualize(T, d1)
     fd2 = f(d2)

--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -84,58 +84,61 @@ end
 println("  ...testing specialized StaticArray codepaths")
 
 x = rand(3, 3)
-sx = StaticArrays.SArray{Tuple{3,3}}(x)
 
-cfg = ForwardDiff.GradientConfig(nothing, x)
-scfg = ForwardDiff.GradientConfig(nothing, sx)
+for T in (StaticArrays.SArray, StaticArrays.MArray)
+    sx = T{Tuple{3,3}}(x)
 
-actual = ForwardDiff.gradient(prod, x)
-@test ForwardDiff.gradient(prod, sx) == actual
-@test ForwardDiff.gradient(prod, sx, cfg) == actual
-@test ForwardDiff.gradient(prod, sx, scfg) == actual
-@test ForwardDiff.gradient(prod, sx, scfg) isa StaticArray
-@test ForwardDiff.gradient(prod, sx, scfg, Val{false}()) == actual
-@test ForwardDiff.gradient(prod, sx, scfg, Val{false}()) isa StaticArray
+    cfg = ForwardDiff.GradientConfig(nothing, x)
+    scfg = ForwardDiff.GradientConfig(nothing, sx)
 
-out = similar(x)
-ForwardDiff.gradient!(out, prod, sx)
-@test out == actual
+    actual = ForwardDiff.gradient(prod, x)
+    @test ForwardDiff.gradient(prod, sx) == actual
+    @test ForwardDiff.gradient(prod, sx, cfg) == actual
+    @test ForwardDiff.gradient(prod, sx, scfg) == actual
+    @test ForwardDiff.gradient(prod, sx, scfg) isa StaticArray
+    @test ForwardDiff.gradient(prod, sx, scfg, Val{false}()) == actual
+    @test ForwardDiff.gradient(prod, sx, scfg, Val{false}()) isa StaticArray
 
-out = similar(x)
-ForwardDiff.gradient!(out, prod, sx, cfg)
-@test out == actual
+    out = similar(x)
+    ForwardDiff.gradient!(out, prod, sx)
+    @test out == actual
 
-out = similar(x)
-ForwardDiff.gradient!(out, prod, sx, scfg)
-@test out == actual
+    out = similar(x)
+    ForwardDiff.gradient!(out, prod, sx, cfg)
+    @test out == actual
 
-result = DiffResults.GradientResult(x)
-result = ForwardDiff.gradient!(result, prod, x)
+    out = similar(x)
+    ForwardDiff.gradient!(out, prod, sx, scfg)
+    @test out == actual
 
-result1 = DiffResults.GradientResult(x)
-result2 = DiffResults.GradientResult(x)
-result3 = DiffResults.GradientResult(x)
-result1 = ForwardDiff.gradient!(result1, prod, sx)
-result2 = ForwardDiff.gradient!(result2, prod, sx, cfg)
-result3 = ForwardDiff.gradient!(result3, prod, sx, scfg)
-@test DiffResults.value(result1) == DiffResults.value(result)
-@test DiffResults.value(result2) == DiffResults.value(result)
-@test DiffResults.value(result3) == DiffResults.value(result)
-@test DiffResults.gradient(result1) == DiffResults.gradient(result)
-@test DiffResults.gradient(result2) == DiffResults.gradient(result)
-@test DiffResults.gradient(result3) == DiffResults.gradient(result)
+    result = DiffResults.GradientResult(x)
+    result = ForwardDiff.gradient!(result, prod, x)
 
-sresult1 = DiffResults.GradientResult(sx)
-sresult2 = DiffResults.GradientResult(sx)
-sresult3 = DiffResults.GradientResult(sx)
-sresult1 = ForwardDiff.gradient!(sresult1, prod, sx)
-sresult2 = ForwardDiff.gradient!(sresult2, prod, sx, cfg)
-sresult3 = ForwardDiff.gradient!(sresult3, prod, sx, scfg)
-@test DiffResults.value(sresult1) == DiffResults.value(result)
-@test DiffResults.value(sresult2) == DiffResults.value(result)
-@test DiffResults.value(sresult3) == DiffResults.value(result)
-@test DiffResults.gradient(sresult1) == DiffResults.gradient(result)
-@test DiffResults.gradient(sresult2) == DiffResults.gradient(result)
-@test DiffResults.gradient(sresult3) == DiffResults.gradient(result)
+    result1 = DiffResults.GradientResult(x)
+    result2 = DiffResults.GradientResult(x)
+    result3 = DiffResults.GradientResult(x)
+    result1 = ForwardDiff.gradient!(result1, prod, sx)
+    result2 = ForwardDiff.gradient!(result2, prod, sx, cfg)
+    result3 = ForwardDiff.gradient!(result3, prod, sx, scfg)
+    @test DiffResults.value(result1) == DiffResults.value(result)
+    @test DiffResults.value(result2) == DiffResults.value(result)
+    @test DiffResults.value(result3) == DiffResults.value(result)
+    @test DiffResults.gradient(result1) == DiffResults.gradient(result)
+    @test DiffResults.gradient(result2) == DiffResults.gradient(result)
+    @test DiffResults.gradient(result3) == DiffResults.gradient(result)
+
+    sresult1 = DiffResults.GradientResult(sx)
+    sresult2 = DiffResults.GradientResult(sx)
+    sresult3 = DiffResults.GradientResult(sx)
+    sresult1 = ForwardDiff.gradient!(sresult1, prod, sx)
+    sresult2 = ForwardDiff.gradient!(sresult2, prod, sx, cfg)
+    sresult3 = ForwardDiff.gradient!(sresult3, prod, sx, scfg)
+    @test DiffResults.value(sresult1) == DiffResults.value(result)
+    @test DiffResults.value(sresult2) == DiffResults.value(result)
+    @test DiffResults.value(sresult3) == DiffResults.value(result)
+    @test DiffResults.gradient(sresult1) == DiffResults.gradient(result)
+    @test DiffResults.gradient(sresult2) == DiffResults.gradient(result)
+    @test DiffResults.gradient(sresult3) == DiffResults.gradient(result)
+end
 
 end # module

--- a/test/HessianTest.jl
+++ b/test/HessianTest.jl
@@ -95,64 +95,66 @@ end
 println("  ...testing specialized StaticArray codepaths")
 
 x = rand(3, 3)
-sx = StaticArrays.SArray{Tuple{3,3}}(x)
+for T in (StaticArrays.SArray, StaticArrays.MArray)
+    sx = T{Tuple{3,3}}(x)
 
-cfg = ForwardDiff.HessianConfig(nothing, x)
-scfg = ForwardDiff.HessianConfig(nothing, sx)
+    cfg = ForwardDiff.HessianConfig(nothing, x)
+    scfg = ForwardDiff.HessianConfig(nothing, sx)
 
-actual = ForwardDiff.hessian(prod, x)
-@test ForwardDiff.hessian(prod, sx) == actual
-@test ForwardDiff.hessian(prod, sx, cfg) == actual
-@test ForwardDiff.hessian(prod, sx, scfg) == actual
-@test ForwardDiff.hessian(prod, sx, scfg) isa StaticArray
-@test ForwardDiff.hessian(prod, sx, scfg, Val{false}()) == actual
-@test ForwardDiff.hessian(prod, sx, scfg, Val{false}()) isa StaticArray
+    actual = ForwardDiff.hessian(prod, x)
+    @test ForwardDiff.hessian(prod, sx) == actual
+    @test ForwardDiff.hessian(prod, sx, cfg) == actual
+    @test ForwardDiff.hessian(prod, sx, scfg) == actual
+    @test ForwardDiff.hessian(prod, sx, scfg) isa StaticArray
+    @test ForwardDiff.hessian(prod, sx, scfg, Val{false}()) == actual
+    @test ForwardDiff.hessian(prod, sx, scfg, Val{false}()) isa StaticArray
 
-out = similar(x, 9, 9)
-ForwardDiff.hessian!(out, prod, sx)
-@test out == actual
+    out = similar(x, 9, 9)
+    ForwardDiff.hessian!(out, prod, sx)
+    @test out == actual
 
-out = similar(x, 9, 9)
-ForwardDiff.hessian!(out, prod, sx, cfg)
-@test out == actual
+    out = similar(x, 9, 9)
+    ForwardDiff.hessian!(out, prod, sx, cfg)
+    @test out == actual
 
-out = similar(x, 9, 9)
-ForwardDiff.hessian!(out, prod, sx, scfg)
-@test out == actual
+    out = similar(x, 9, 9)
+    ForwardDiff.hessian!(out, prod, sx, scfg)
+    @test out == actual
 
-result = DiffResults.HessianResult(x)
-result = ForwardDiff.hessian!(result, prod, x)
+    result = DiffResults.HessianResult(x)
+    result = ForwardDiff.hessian!(result, prod, x)
 
-result1 = DiffResults.HessianResult(x)
-result2 = DiffResults.HessianResult(x)
-result3 = DiffResults.HessianResult(x)
-result1 = ForwardDiff.hessian!(result1, prod, sx)
-result2 = ForwardDiff.hessian!(result2, prod, sx, ForwardDiff.HessianConfig(prod, result2, x, ForwardDiff.Chunk(x), nothing))
-result3 = ForwardDiff.hessian!(result3, prod, sx, ForwardDiff.HessianConfig(prod, result3, x, ForwardDiff.Chunk(x), nothing))
-@test DiffResults.value(result1) == DiffResults.value(result)
-@test DiffResults.value(result2) == DiffResults.value(result)
-@test DiffResults.value(result3) == DiffResults.value(result)
-@test DiffResults.gradient(result1) == DiffResults.gradient(result)
-@test DiffResults.gradient(result2) == DiffResults.gradient(result)
-@test DiffResults.gradient(result3) == DiffResults.gradient(result)
-@test DiffResults.hessian(result1) == DiffResults.hessian(result)
-@test DiffResults.hessian(result2) == DiffResults.hessian(result)
-@test DiffResults.hessian(result3) == DiffResults.hessian(result)
+    result1 = DiffResults.HessianResult(x)
+    result2 = DiffResults.HessianResult(x)
+    result3 = DiffResults.HessianResult(x)
+    result1 = ForwardDiff.hessian!(result1, prod, sx)
+    result2 = ForwardDiff.hessian!(result2, prod, sx, ForwardDiff.HessianConfig(prod, result2, x, ForwardDiff.Chunk(x), nothing))
+    result3 = ForwardDiff.hessian!(result3, prod, sx, ForwardDiff.HessianConfig(prod, result3, x, ForwardDiff.Chunk(x), nothing))
+    @test DiffResults.value(result1) == DiffResults.value(result)
+    @test DiffResults.value(result2) == DiffResults.value(result)
+    @test DiffResults.value(result3) == DiffResults.value(result)
+    @test DiffResults.gradient(result1) == DiffResults.gradient(result)
+    @test DiffResults.gradient(result2) == DiffResults.gradient(result)
+    @test DiffResults.gradient(result3) == DiffResults.gradient(result)
+    @test DiffResults.hessian(result1) == DiffResults.hessian(result)
+    @test DiffResults.hessian(result2) == DiffResults.hessian(result)
+    @test DiffResults.hessian(result3) == DiffResults.hessian(result)
 
-sresult1 = DiffResults.HessianResult(sx)
-sresult2 = DiffResults.HessianResult(sx)
-sresult3 = DiffResults.HessianResult(sx)
-sresult1 = ForwardDiff.hessian!(sresult1, prod, sx)
-sresult2 = ForwardDiff.hessian!(sresult2, prod, sx, ForwardDiff.HessianConfig(prod, sresult2, x, ForwardDiff.Chunk(x), nothing))
-sresult3 = ForwardDiff.hessian!(sresult3, prod, sx, ForwardDiff.HessianConfig(prod, sresult3, x, ForwardDiff.Chunk(x), nothing))
-@test DiffResults.value(sresult1) == DiffResults.value(result)
-@test DiffResults.value(sresult2) == DiffResults.value(result)
-@test DiffResults.value(sresult3) == DiffResults.value(result)
-@test DiffResults.gradient(sresult1) == DiffResults.gradient(result)
-@test DiffResults.gradient(sresult2) == DiffResults.gradient(result)
-@test DiffResults.gradient(sresult3) == DiffResults.gradient(result)
-@test DiffResults.hessian(sresult1) == DiffResults.hessian(result)
-@test DiffResults.hessian(sresult2) == DiffResults.hessian(result)
-@test DiffResults.hessian(sresult3) == DiffResults.hessian(result)
+    sresult1 = DiffResults.HessianResult(sx)
+    sresult2 = DiffResults.HessianResult(sx)
+    sresult3 = DiffResults.HessianResult(sx)
+    sresult1 = ForwardDiff.hessian!(sresult1, prod, sx)
+    sresult2 = ForwardDiff.hessian!(sresult2, prod, sx, ForwardDiff.HessianConfig(prod, sresult2, x, ForwardDiff.Chunk(x), nothing))
+    sresult3 = ForwardDiff.hessian!(sresult3, prod, sx, ForwardDiff.HessianConfig(prod, sresult3, x, ForwardDiff.Chunk(x), nothing))
+    @test DiffResults.value(sresult1) == DiffResults.value(result)
+    @test DiffResults.value(sresult2) == DiffResults.value(result)
+    @test DiffResults.value(sresult3) == DiffResults.value(result)
+    @test DiffResults.gradient(sresult1) == DiffResults.gradient(result)
+    @test DiffResults.gradient(sresult2) == DiffResults.gradient(result)
+    @test DiffResults.gradient(sresult3) == DiffResults.gradient(result)
+    @test DiffResults.hessian(sresult1) == DiffResults.hessian(result)
+    @test DiffResults.hessian(sresult2) == DiffResults.hessian(result)
+    @test DiffResults.hessian(sresult3) == DiffResults.hessian(result)
+end
 
 end # module

--- a/test/JacobianTest.jl
+++ b/test/JacobianTest.jl
@@ -166,61 +166,63 @@ end
 println("  ...testing specialized StaticArray codepaths")
 
 x = rand(3, 3)
-sx = StaticArrays.SArray{Tuple{3,3}}(x)
+for T in (StaticArrays.SArray, StaticArrays.MArray)
+    sx = T{Tuple{3,3}}(x)
 
-cfg = ForwardDiff.JacobianConfig(nothing, x)
-scfg = ForwardDiff.JacobianConfig(nothing, sx)
+    cfg = ForwardDiff.JacobianConfig(nothing, x)
+    scfg = ForwardDiff.JacobianConfig(nothing, sx)
 
-_diff(A) = diff(A; dims=1)
+    _diff(A) = diff(A; dims=1)
 
-actual = ForwardDiff.jacobian(_diff, x)
-@test ForwardDiff.jacobian(_diff, sx) == actual
-@test ForwardDiff.jacobian(_diff, sx, cfg) == actual
-@test ForwardDiff.jacobian(_diff, sx, scfg) == actual
-@test ForwardDiff.jacobian(_diff, sx, scfg) isa StaticArray
-@test ForwardDiff.jacobian(_diff, sx, scfg, Val{false}()) == actual
-@test ForwardDiff.jacobian(_diff, sx, scfg, Val{false}()) isa StaticArray
+    actual = ForwardDiff.jacobian(_diff, x)
+    @test ForwardDiff.jacobian(_diff, sx) == actual
+    @test ForwardDiff.jacobian(_diff, sx, cfg) == actual
+    @test ForwardDiff.jacobian(_diff, sx, scfg) == actual
+    @test ForwardDiff.jacobian(_diff, sx, scfg) isa StaticArray
+    @test ForwardDiff.jacobian(_diff, sx, scfg, Val{false}()) == actual
+    @test ForwardDiff.jacobian(_diff, sx, scfg, Val{false}()) isa StaticArray
 
-out = similar(x, 6, 9)
-ForwardDiff.jacobian!(out, _diff, sx)
-@test out == actual
+    out = similar(x, 6, 9)
+    ForwardDiff.jacobian!(out, _diff, sx)
+    @test out == actual
 
-out = similar(x, 6, 9)
-ForwardDiff.jacobian!(out, _diff, sx, cfg)
-@test out == actual
+    out = similar(x, 6, 9)
+    ForwardDiff.jacobian!(out, _diff, sx, cfg)
+    @test out == actual
 
-out = similar(x, 6, 9)
-ForwardDiff.jacobian!(out, _diff, sx, scfg)
-@test out == actual
+    out = similar(x, 6, 9)
+    ForwardDiff.jacobian!(out, _diff, sx, scfg)
+    @test out == actual
 
-result = DiffResults.JacobianResult(similar(x, 6), x)
-result = ForwardDiff.jacobian!(result, _diff, x)
+    result = DiffResults.JacobianResult(similar(x, 6), x)
+    result = ForwardDiff.jacobian!(result, _diff, x)
 
-result1 = DiffResults.JacobianResult(similar(sx, 6), sx)
-result2 = DiffResults.JacobianResult(similar(sx, 6), sx)
-result3 = DiffResults.JacobianResult(similar(sx, 6), sx)
-result1 = ForwardDiff.jacobian!(result1, _diff, sx)
-result2 = ForwardDiff.jacobian!(result2, _diff, sx, cfg)
-result3 = ForwardDiff.jacobian!(result3, _diff, sx, scfg)
-@test DiffResults.value(result1) == DiffResults.value(result)
-@test DiffResults.value(result2) == DiffResults.value(result)
-@test DiffResults.value(result3) == DiffResults.value(result)
-@test DiffResults.jacobian(result1) == DiffResults.jacobian(result)
-@test DiffResults.jacobian(result2) == DiffResults.jacobian(result)
-@test DiffResults.jacobian(result3) == DiffResults.jacobian(result)
+    result1 = DiffResults.JacobianResult(similar(sx, 6), sx)
+    result2 = DiffResults.JacobianResult(similar(sx, 6), sx)
+    result3 = DiffResults.JacobianResult(similar(sx, 6), sx)
+    result1 = ForwardDiff.jacobian!(result1, _diff, sx)
+    result2 = ForwardDiff.jacobian!(result2, _diff, sx, cfg)
+    result3 = ForwardDiff.jacobian!(result3, _diff, sx, scfg)
+    @test DiffResults.value(result1) == DiffResults.value(result)
+    @test DiffResults.value(result2) == DiffResults.value(result)
+    @test DiffResults.value(result3) == DiffResults.value(result)
+    @test DiffResults.jacobian(result1) == DiffResults.jacobian(result)
+    @test DiffResults.jacobian(result2) == DiffResults.jacobian(result)
+    @test DiffResults.jacobian(result3) == DiffResults.jacobian(result)
 
-sy = @SVector fill(zero(eltype(sx)), 6)
-sresult1 = DiffResults.JacobianResult(sy, sx)
-sresult2 = DiffResults.JacobianResult(sy, sx)
-sresult3 = DiffResults.JacobianResult(sy, sx)
-sresult1 = ForwardDiff.jacobian!(sresult1, _diff, sx)
-sresult2 = ForwardDiff.jacobian!(sresult2, _diff, sx, cfg)
-sresult3 = ForwardDiff.jacobian!(sresult3, _diff, sx, scfg)
-@test DiffResults.value(sresult1) == DiffResults.value(result)
-@test DiffResults.value(sresult2) == DiffResults.value(result)
-@test DiffResults.value(sresult3) == DiffResults.value(result)
-@test DiffResults.jacobian(sresult1) == DiffResults.jacobian(result)
-@test DiffResults.jacobian(sresult2) == DiffResults.jacobian(result)
-@test DiffResults.jacobian(sresult3) == DiffResults.jacobian(result)
+    sy = @SVector fill(zero(eltype(sx)), 6)
+    sresult1 = DiffResults.JacobianResult(sy, sx)
+    sresult2 = DiffResults.JacobianResult(sy, sx)
+    sresult3 = DiffResults.JacobianResult(sy, sx)
+    sresult1 = ForwardDiff.jacobian!(sresult1, _diff, sx)
+    sresult2 = ForwardDiff.jacobian!(sresult2, _diff, sx, cfg)
+    sresult3 = ForwardDiff.jacobian!(sresult3, _diff, sx, scfg)
+    @test DiffResults.value(sresult1) == DiffResults.value(result)
+    @test DiffResults.value(sresult2) == DiffResults.value(result)
+    @test DiffResults.value(sresult3) == DiffResults.value(result)
+    @test DiffResults.jacobian(sresult1) == DiffResults.jacobian(result)
+    @test DiffResults.jacobian(sresult2) == DiffResults.jacobian(result)
+    @test DiffResults.jacobian(sresult3) == DiffResults.jacobian(result)
+end
 
 end # module


### PR DESCRIPTION
Currently only `SArray`s are supported and no other `StaticArray`s such as `SLArray`s (https://github.com/JuliaDiffEq/LabelledArrays.jl). Together with a similar PR to DiffResults this seems to fix issues I experienced with `SLArray`s without breaking existing `SArray` support. However, since we do not dispatch on the mutability of the static arrays unfortunately even `DiffResult`s for mutable static arrays such as `MArray` will be immutable. 