### PR TITLE
expand NaN-safe mode to cover individual zeros in Partials

### DIFF
--- a/docs/src/user/advanced.md
+++ b/docs/src/user/advanced.md
@@ -134,7 +134,7 @@ or `isinf(y)`, in which case a `NaN` derivative will be propagated instead.
 
 It is possible to fix this behavior by checking that the perturbation component is zero
 before attempting to propagate derivative information, but this check can noticeably
-decrease performance (~5%-10% on our benchmarks).
+decrease performance.
 
 In order to preserve performance in the majority of use cases, ForwardDiff disables this
 check by default. If your code is affected by this `NaN` behvaior, you can enable

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -292,7 +292,7 @@ end
 # Predicates #
 #------------#
 
-isconstant(d::Dual) = iszero(partials(d))
+isconstant(d::Dual) = all_zero_partials(partials(d))
 
 for pred in UNARY_PREDICATES
     @eval Base.$(pred)(d::Dual) = $(pred)(value(d))

--- a/src/partials.jl
+++ b/src/partials.jl
@@ -2,6 +2,8 @@ struct Partials{N,V} <: AbstractVector{V}
     values::NTuple{N,V}
 end
 
+Partials(values::Tuple) = Partials(promote(values...))
+
 ##############################
 # Utility/Accessor Functions #
 ##############################

--- a/test/PartialsTest.jl
+++ b/test/PartialsTest.jl
@@ -120,10 +120,14 @@ for N in (0, 3), T in (Int, Float32, Float64)
 
         if ForwardDiff.NANSAFE_MODE_ENABLED
             ZEROS = Partials((fill(zero(T), N)...,))
+            SEED = ForwardDiff.single_seed(Partials{N,T}, Val(N))
 
             @test (NaN * ZEROS).values == ZEROS.values
+            @test (NaN * SEED).values === promote(fill(zero(T), N - 1)..., NaN)
             @test (Inf * ZEROS).values == ZEROS.values
-            @test (ZEROS / 0).values == ZEROS.values
+            @test (Inf * SEED).values === promote(fill(zero(T), N - 1)..., Inf)
+            @test (ZEROS / 0.0).values == ZEROS.values
+            @test (SEED / 0.0).values === promote(fill(zero(T), N - 1)..., Inf)
 
             @test ForwardDiff._mul_partials(ZEROS, ZEROS, X, NaN).values == ZEROS.values
             @test ForwardDiff._mul_partials(ZEROS, ZEROS, NaN, X).values == ZEROS.values

--- a/test/PartialsTest.jl
+++ b/test/PartialsTest.jl
@@ -54,8 +54,8 @@ for N in (0, 3), T in (Int, Float32, Float64)
 
     @test rand(samerng(), PARTIALS) == rand(samerng(), typeof(PARTIALS))
 
-    @test ForwardDiff.iszero(PARTIALS) == (N == 0)
-    @test ForwardDiff.iszero(zero(PARTIALS))
+    @test ForwardDiff.all_zero_partials(PARTIALS) == (N == 0)
+    @test ForwardDiff.all_zero_partials(zero(PARTIALS))
 
     @test PARTIALS == copy(PARTIALS)
     @test (PARTIALS == PARTIALS2) == (N == 0)


### PR DESCRIPTION
This likely further decreases performance when NaN-safe mode is engaged, but I think it's more correct so it's worth the perf hit either way. NaN-safe mode is already the expected slow path so this shouldn't change user expectations too much. 

I'll do at least a simple benchmark to get a ballpark performance impact for the docs. Also need to add a test or two.

cc @AndreasNoack this fixes your example; does it help with whatever actual problem you were encountering?
