### PR TITLE
reduce occurences of tag errors

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,18 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1
+  - julia_version: nightly
 
-matrix:
-    allow_failures:
-      - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-      - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+# matrix:
+#   allow_failures:
+#   - julia_version: nightly
 
 branches:
   only:
@@ -22,19 +26,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"ForwardDiff\"); Pkg.build(\"ForwardDiff\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"ForwardDiff\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -82,9 +82,12 @@ end
 
 @inline value(::Type{T}, x) where T = x
 @inline value(::Type{T}, d::Dual{T}) where T = value(d)
-function value(::Type{T}, d::Dual{S}) where {T,S}
-    # TODO: in the case of nested Duals, it may be possible to "transpose" the Dual objects
-    throw(DualMismatchError(T,S))
+@inline function value(::Type{T}, d::Dual{S}) where {T,S}
+    if S ≺ T
+        d
+    else
+        throw(DualMismatchError(T,S))        
+    end
 end
 
 @inline partials(x) = Partials{0,typeof(x)}(tuple())
@@ -96,7 +99,14 @@ end
 
 @inline Base.@propagate_inbounds partials(::Type{T}, x, i...) where T = partials(x, i...)
 @inline Base.@propagate_inbounds partials(::Type{T}, d::Dual{T}, i...) where T = partials(d, i...)
-partials(::Type{T}, d::Dual{S}, i...) where {T,S} = throw(DualMismatchError(T,S))
+@inline function partials(::Type{T}, d::Dual{S}, i...) where {T,S}
+    if S ≺ T
+        zero(d)
+    else
+        throw(DualMismatchError(T,S))
+    end
+end
+
 
 @inline npartials(::Dual{T,V,N}) where {T,V,N} = N
 @inline npartials(::Type{Dual{T,V,N}}) where {T,V,N} = N

--- a/test/ConfusionTest.jl
+++ b/test/ConfusionTest.jl
@@ -66,4 +66,11 @@ let z = z83a
     @test ForwardDiff.hessian(h, [1.]) == zeros(1, 1)
 end
 
+@test ForwardDiff.derivative(1.0) do x
+    ForwardDiff.derivative(x) do y
+        x
+    end
+end == 0.0
+
+
 end # module


### PR DESCRIPTION
Nested differentiation can fail in cases where there are no operations involving the inner gradient, e.g.
```
ForwardDiff.derivative(1.0) do x
    ForwardDiff.derivative(x) do y
        x
    end
end
```

I'm pretty sure this is safe...