### PR TITLE
Fix x^y for the case when x is zero.

### DIFF
--- a/src/partials.jl
+++ b/src/partials.jl
@@ -34,7 +34,7 @@ Base.mightalias(x::AbstractArray, y::Partials) = false
 # Generic Functions #
 #####################
 
-@inline iszero(partials::Partials) = iszero_tuple(partials.values)
+@inline Base.iszero(partials::Partials) = iszero_tuple(partials.values)
 
 @inline Base.zero(partials::Partials) = zero(typeof(partials))
 @inline Base.zero(::Type{Partials{N,V}}) where {N,V} = Partials{N,V}(zero_tuple(NTuple{N,V}))

--- a/test/DerivativeTest.jl
+++ b/test/DerivativeTest.jl
@@ -89,4 +89,11 @@ for f! in DiffTests.INPLACE_NUMBER_TO_ARRAY_FUNCS
     @test isapprox(DiffResults.derivative(out), d)
 end
 
+@testset "exponential function at base zero" begin
+    @test (x -> ForwardDiff.derivative(y -> x^y, -0.5))(0.0) === -Inf
+    @test (x -> ForwardDiff.derivative(y -> x^y,  0.0))(0.0) === -Inf
+    @test (x -> ForwardDiff.derivative(y -> x^y,  0.5))(0.0) === 0.0
+    @test (x -> ForwardDiff.derivative(y -> x^y,  1.5))(0.0) === 0.0
+end
+
 end # module

--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -141,4 +141,11 @@ for T in (StaticArrays.SArray, StaticArrays.MArray)
     @test DiffResults.gradient(sresult3) == DiffResults.gradient(result)
 end
 
+@testset "exponential function at base zero" begin
+    @test isequal(ForwardDiff.gradient(t -> t[1]^t[2], [0.0, -0.5]), [NaN, NaN])
+    @test isequal(ForwardDiff.gradient(t -> t[1]^t[2], [0.0,  0.0]), [NaN, NaN])
+    @test isequal(ForwardDiff.gradient(t -> t[1]^t[2], [0.0,  0.5]), [Inf, NaN])
+    @test isequal(ForwardDiff.gradient(t -> t[1]^t[2], [0.0,  1.5]), [0.0, 0.0])
+end
+
 end # module


### PR DESCRIPTION
Currently, the derivative in the exponent is wrong then the base is zero, i.e. it gives
```julia
julia> (x -> ForwardDiff.derivative(y -> x^y,  0.5))(0.0)
NaN
```
even though the limit is well defined. With this PR, it becomes
```julia
julia> (x -> ForwardDiff.derivative(y -> x^y,  0.5))(0.0)
0.0
```