### PR TITLE
Remove bogus AbstractFloat conversion.

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -86,7 +86,7 @@ end
     if S ≺ T
         d
     else
-        throw(DualMismatchError(T,S))        
+        throw(DualMismatchError(T,S))
     end
 end
 
@@ -358,7 +358,6 @@ Base.convert(::Type{Dual{T,V,N}}, x::Number) where {T,V,N} = Dual{T}(convert(V, 
 Base.convert(::Type{D}, d::D) where {D<:Dual} = d
 
 Base.float(d::Dual{T,V,N}) where {T,V,N} = convert(Dual{T,promote_type(V, Float16),N}, d)
-Base.AbstractFloat(d::Dual{T,V,N}) where {T,V,N} = convert(Dual{T,promote_type(V, Float16),N}, d)
 
 ###################################
 # General Mathematical Operations #


### PR DESCRIPTION
Fixes
```julia
julia> using ForwardDiff: Dual

julia> AbstractFloat(Dual(1.0, 2.0)) isa AbstractFloat
false
```