### PR TITLE
That is pure, not `@pure`

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -323,8 +323,8 @@ end
 # Promotion/Conversion #
 ########################
 
-Base.@pure function Base.promote_rule(::Type{Dual{T1,V1,N1}},
-                                      ::Type{Dual{T2,V2,N2}}) where {T1,V1,N1,T2,V2,N2}
+function Base.promote_rule(::Type{Dual{T1,V1,N1}},
+                           ::Type{Dual{T2,V2,N2}}) where {T1,V1,N1,T2,V2,N2}
     # V1 and V2 might themselves be Dual types
     if T2 ≺ T1
         Dual{T1,promote_type(V1,Dual{T2,V2,N2}),N1}


### PR DESCRIPTION
From: https://github.com/YingboMa/ForwardDiff2.jl/pull/11#discussion_r361219444

> Are you sure we need this @pure.
This is a illegal usage as it calls generic functions.
And its not a particularly a safe usage illegal usage at that.
In that if someone wants to add support for V1 or V2, being their fancy new numeric type (say ArbFloat).
by overloading promote_type(::V, ::Dual) then bad things can happen.