### PR TITLE
Restrict `getindex` for partials to a single Int

### DIFF
--- a/src/partials.jl
+++ b/src/partials.jl
@@ -20,7 +20,7 @@ end
 @inline Base.length(::Partials{N}) where {N} = N
 @inline Base.size(::Partials{N}) where {N} = (N,)
 
-@inline Base.@propagate_inbounds Base.getindex(partials::Partials, I...) = partials.values[I...]
+@inline Base.@propagate_inbounds Base.getindex(partials::Partials, i::Int) = partials.values[i]
 
 Base.iterate(partials::Partials) = iterate(partials.values)
 Base.iterate(partials::Partials, i) = iterate(partials.values, i)

--- a/test/PartialsTest.jl
+++ b/test/PartialsTest.jl
@@ -135,4 +135,8 @@ for N in (0, 3), T in (Int, Float32, Float64)
     end
 end
 
+io = IOBuffer()
+show(io, MIME("text/plain"), Partials((1, 2, 3)))
+@test String(take!(io)) == "3-element ForwardDiff.Partials{3,Int64}:\n 1\n 2\n 3"
+
 end # module


### PR DESCRIPTION
Fixes a display bug:

```julia
julia> p = ForwardDiff.Partials((1,2,3))
3-element ForwardDiff.Partials{3,Int64}:
Error showing value of type ForwardDiff.Partials{3,Int64}:
ERROR: MethodError: no method matching 
getindex(::Tuple{Int64,Int64,Int64}, ::Int64, ::Int64)
```