### PR TITLE
Move SIMD tests to a separate job and allow them to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: julia
+
 julia:
     - 1.0
     - 1.2
@@ -7,11 +8,39 @@ julia:
 matrix:
   allow_failures:
     - julia: nightly
+    - env: ALLOWFAILURES=1
+
 notifications:
     email: false
+
 sudo: false
+
 jobs:
   include:
+    # These tests need to be run in a process where bounds checking is not explicitly enabled
+# (like they are with Pkg.test)
+    - stage: test
+      script:
+        - julia --color=yes --project=. -e 'using Pkg; Pkg.instantiate()'
+        - julia --color=yes --check-bounds=no --code-coverage=none -O2 --project=. test/SIMDTest.jl
+      julia: 1.0
+      env: ALLOWFAILURES=1
+
+    - stage: test
+      script:
+        - julia --color=yes --project=. -e 'using Pkg; Pkg.instantiate()'
+        - julia --color=yes --check-bounds=no --code-coverage=none -O2 --project=. test/SIMDTest.jl
+      julia: 1.3
+      env: ALLOWFAILURES=1
+
+    - stage: test
+      script:
+        - julia --color=yes --project=. -e 'using Pkg; Pkg.instantiate()'
+        - julia --color=yes --check-bounds=no --code-coverage=none -O2 --project=. test/SIMDTest.jl
+      julia: nightly
+      env: ALLOWFAILURES=1
+
+
     - stage: "Documentation"
       julia: 1.2
       os: linux
@@ -19,5 +48,6 @@ jobs:
         - julia --color=yes --project=docs/ -e 'using Pkg; Pkg.instantiate()'
         - julia --color=yes --project=docs/ docs/make.jl
       after_success: skip
+
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/test/PartialsTest.jl
+++ b/test/PartialsTest.jl
@@ -137,6 +137,6 @@ end
 
 io = IOBuffer()
 show(io, MIME("text/plain"), Partials((1, 2, 3)))
-@test String(take!(io)) == "3-element ForwardDiff.Partials{3,Int64}:\n 1\n 2\n 3"
+@test String(take!(io)) == "3-element ForwardDiff.Partials{3,$Int}:\n 1\n 2\n 3"
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,11 +31,3 @@ println("done (took $t seconds).")
 println("Testing miscellaneous functionality...")
 t = @elapsed include("MiscTest.jl")
 println("done (took $t seconds).")
-
-# These tests need to be run in a process where bounds checking is not explicitly enabled
-# (like they are with Pkg.test)
-println("Testing SIMD vectorization...")
-project = Base.active_project()
-simdfile = joinpath(@__DIR__, "SIMDTest.jl")
-t = @elapsed run(`$(Base.julia_cmd()) --check-bounds=no --code-coverage=none -O2 --project=$project $simdfile`)
-println("done (took $t seconds).")


### PR DESCRIPTION
 to avoid overall test failure when they fail. This is needed because they
seem to be brittle.

I'll open an issue about making the tests more reliable but we risk merging something breaking (correctness and not just performance) as long as we fail overall when the SIMD tests fail.