### PR TITLE
Allow value and partials to have distinct types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ForwardDiff"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.12"
+version = "0.11.0"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"

--- a/src/apiutils.jl
+++ b/src/apiutils.jl
@@ -21,7 +21,7 @@ end
 @generated function dualize(::Type{T}, x::StaticArray) where T
     N = length(x)
     dx = Expr(:tuple, [:(Dual{T}(x[$i], chunk, Val{$i}())) for i in 1:N]...)
-    V = StaticArrays.similar_type(x, Dual{T,eltype(x),N})
+    V = StaticArrays.similar_type(x, Dual{T,eltype(x),N,eltype(x)})
     return quote
         chunk = Chunk{$N}()
         $(Expr(:meta, :inline))
@@ -53,38 +53,38 @@ end
     return Expr(:tuple, [:(single_seed(Partials{N,V}, Val{$i}())) for i in 1:N]...)
 end
 
-function seed!(duals::AbstractArray{Dual{T,V,N}}, x,
-               seed::Partials{N,V} = zero(Partials{N,V})) where {T,V,N}
+function seed!(duals::AbstractArray{Dual{T,V,N,P}}, x,
+               seed::Partials{N,P} = zero(Partials{N,P})) where {T,V,N,P}
     for i in eachindex(duals)
-        duals[i] = Dual{T,V,N}(x[i], seed)
+        duals[i] = Dual{T,V,N,P}(x[i], seed)
     end
     return duals
 end
 
-function seed!(duals::AbstractArray{Dual{T,V,N}}, x,
-               seeds::NTuple{N,Partials{N,V}}) where {T,V,N}
+function seed!(duals::AbstractArray{Dual{T,V,N,P}}, x,
+               seeds::NTuple{N,Partials{N,P}}) where {T,V,N,P}
     for i in 1:N
-        duals[i] = Dual{T,V,N}(x[i], seeds[i])
+        duals[i] = Dual{T,V,N,P}(x[i], seeds[i])
     end
     return duals
 end
 
-function seed!(duals::AbstractArray{Dual{T,V,N}}, x, index,
-               seed::Partials{N,V} = zero(Partials{N,V})) where {T,V,N}
+function seed!(duals::AbstractArray{Dual{T,V,N,P}}, x, index,
+               seed::Partials{N,P} = zero(Partials{N,P})) where {T,V,N,P}
     offset = index - 1
     for i in 1:N
         j = i + offset
-        duals[j] = Dual{T,V,N}(x[j], seed)
+        duals[j] = Dual{T,V,N,P}(x[j], seed)
     end
     return duals
 end
 
-function seed!(duals::AbstractArray{Dual{T,V,N}}, x, index,
-               seeds::NTuple{N,Partials{N,V}}, chunksize = N) where {T,V,N}
+function seed!(duals::AbstractArray{Dual{T,V,N,P}}, x, index,
+               seeds::NTuple{N,Partials{N,P}}, chunksize = N) where {T,V,N,P}
     offset = index - 1
     for i in 1:chunksize
         j = i + offset
-        duals[j] = Dual{T,V,N}(x[j], seeds[i])
+        duals[j] = Dual{T,V,N,P}(x[j], seeds[i])
     end
     return duals
 end

--- a/src/config.jl
+++ b/src/config.jl
@@ -83,7 +83,7 @@ function DerivativeConfig(f::F,
                           y::AbstractArray{Y},
                           x::X,
                           tag::T = Tag(f, X)) where {F,X<:Real,Y<:Real,T}
-    duals = similar(y, Dual{T,Y,1})
+    duals = similar(y, Dual{T,Y,1,Y})
     return DerivativeConfig{T,typeof(duals)}(duals)
 end
 
@@ -119,7 +119,7 @@ function GradientConfig(f::F,
                         ::Chunk{N} = Chunk(x),
                         ::T = Tag(f, V)) where {F,V,N,T}
     seeds = construct_seeds(Partials{N,V})
-    duals = similar(x, Dual{T,V,N})
+    duals = similar(x, Dual{T,V,N,V})
     return GradientConfig{T,V,N,typeof(duals)}(seeds, duals)
 end
 
@@ -156,7 +156,7 @@ function JacobianConfig(f::F,
                         ::Chunk{N} = Chunk(x),
                         ::T = Tag(f, V)) where {F,V,N,T}
     seeds = construct_seeds(Partials{N,V})
-    duals = similar(x, Dual{T,V,N})
+    duals = similar(x, Dual{T,V,N,V})
     return JacobianConfig{T,V,N,typeof(duals)}(seeds, duals)
 end
 
@@ -182,8 +182,8 @@ function JacobianConfig(f::F,
                         ::Chunk{N} = Chunk(x),
                         ::T = Tag(f, X)) where {F,Y,X,N,T}
     seeds = construct_seeds(Partials{N,X})
-    yduals = similar(y, Dual{T,Y,N})
-    xduals = similar(x, Dual{T,X,N})
+    yduals = similar(y, Dual{T,Y,N,Y})
+    xduals = similar(x, Dual{T,X,N,X})
     duals = (yduals, xduals)
     return JacobianConfig{T,X,N,typeof(duals)}(seeds, duals)
 end
@@ -197,7 +197,7 @@ Base.eltype(::Type{JacobianConfig{T,V,N,D}}) where {T,V,N,D} = Dual{T,V,N}
 
 struct HessianConfig{T,V,N,DG,DJ} <: AbstractConfig{N}
     jacobian_config::JacobianConfig{T,V,N,DJ}
-    gradient_config::GradientConfig{T,Dual{T,V,N},N,DG}
+    gradient_config::GradientConfig{T,Dual{T,V,N,V},N,DG}
 end
 
 """
@@ -254,4 +254,4 @@ end
 
 checktag(::HessianConfig{T},f,x) where {T} = checktag(T,f,x)
 Base.eltype(::Type{HessianConfig{T,V,N,DG,DJ}}) where {T,V,N,DG,DJ} =
-    Dual{T,Dual{T,V,N},N}
+    Dual{T,Dual{T,V,N,V},N,Dual{T,V,N,V}}

--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -11,7 +11,7 @@ This method assumes that `isa(f(x), Union{Real,AbstractArray})`.
 """
 @inline function derivative(f::F, x::R) where {F,R<:Real}
     T = typeof(Tag(f, R))
-    return extract_derivative(T, f(Dual{T}(x, one(x))))
+    return extract_derivative(T, f(Dual{T}(x, oneunit(x))))
 end
 
 """
@@ -27,7 +27,7 @@ Set `check` to `Val{false}()` to disable tag checking. This can lead to perturba
     CHK && checktag(T, f!, x)
     ydual = cfg.duals
     seed!(ydual, y)
-    f!(ydual, Dual{T}(x, one(x)))
+    f!(ydual, Dual{T}(x, oneunit(x)))
     map!(value, y, ydual)
     return extract_derivative(T, ydual)
 end
@@ -43,7 +43,7 @@ This method assumes that `isa(f(x), Union{Real,AbstractArray})`.
 @inline function derivative!(result::Union{AbstractArray,DiffResult},
                              f::F, x::R) where {F,R<:Real}
     T = typeof(Tag(f, R))
-    ydual = f(Dual{T}(x, one(x)))
+    ydual = f(Dual{T}(x, oneunit(x)))
     result = extract_value!(T, result, ydual)
     result = extract_derivative!(T, result, ydual)
     return result
@@ -63,7 +63,7 @@ Set `check` to `Val{false}()` to disable tag checking. This can lead to perturba
     CHK && checktag(T, f!, x)
     ydual = cfg.duals
     seed!(ydual, y)
-    f!(ydual, Dual{T}(x, one(x)))
+    f!(ydual, Dual{T}(x, oneunit(x)))
     result = extract_value!(T, result, y, ydual)
     result = extract_derivative!(T, result, ydual)
     return result

--- a/src/partials.jl
+++ b/src/partials.jl
@@ -7,7 +7,7 @@ end
 ##############################
 
 @generated function single_seed(::Type{Partials{N,V}}, ::Val{i}) where {N,V,i}
-    ex = Expr(:tuple, [ifelse(i === j, :(one(V)), :(zero(V))) for j in 1:N]...)
+    ex = Expr(:tuple, [ifelse(i === j, :(oneunit(V)), :(zero(V))) for j in 1:N]...)
     return :(Partials($(ex)))
 end
 
@@ -92,18 +92,18 @@ end
 
 if NANSAFE_MODE_ENABLED
     @inline function Base.:*(partials::Partials, x::Real)
-        x = ifelse(!isfinite(x) && iszero(partials), one(x), x)
+        x = ifelse(!isfinite(x) && iszero(partials), oneunit(x), x)
         return Partials(scale_tuple(partials.values, x))
     end
 
     @inline function Base.:/(partials::Partials, x::Real)
-        x = ifelse(x == zero(x) && iszero(partials), one(x), x)
+        x = ifelse(x == zero(x) && iszero(partials), oneunit(x), x)
         return Partials(div_tuple_by_scalar(partials.values, x))
     end
 
     @inline function _mul_partials(a::Partials{N}, b::Partials{N}, x_a, x_b) where N
-        x_a = ifelse(!isfinite(x_a) && iszero(a), one(x_a), x_a)
-        x_b = ifelse(!isfinite(x_b) && iszero(b), one(x_b), x_b)
+        x_a = ifelse(!isfinite(x_a) && iszero(a), oneunit(x_a), x_a)
+        x_b = ifelse(!isfinite(x_b) && iszero(b), oneunit(x_b), x_b)
         return Partials(mul_tuples(a.values, b.values, x_a, x_b))
     end
 else
@@ -184,7 +184,7 @@ end
 @generated function one_tuple(::Type{NTuple{N,V}}) where {N,V}
     ex = tupexpr(i -> :(z), N)
     return quote
-        z = one(V)
+        z = oneunit(V)
         return $ex
     end
 end

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -57,10 +57,10 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
     @test Dual(PRIMAL, PARTIALS...) === Dual{Nothing}(PRIMAL, PARTIALS...)
     @test Dual(PRIMAL) === Dual{Nothing}(PRIMAL)
 
-    @test typeof(Dual{TestTag()}(widen(V)(PRIMAL), PARTIALS)) === Dual{TestTag(),widen(V),N}
-    @test typeof(Dual{TestTag()}(widen(V)(PRIMAL), PARTIALS.values)) === Dual{TestTag(),widen(V),N}
-    @test typeof(Dual{TestTag()}(widen(V)(PRIMAL), PARTIALS...)) === Dual{TestTag(),widen(V),N}
-    @test typeof(NESTED_FDNUM) == Dual{TestTag(),Dual{TestTag(),V,M},N}
+    @test typeof(Dual{TestTag()}(widen(V)(PRIMAL), PARTIALS)) === Dual{TestTag(),widen(V),N,widen(V)}
+    @test typeof(Dual{TestTag()}(widen(V)(PRIMAL), PARTIALS.values)) === Dual{TestTag(),widen(V),N,widen(V)}
+    @test typeof(Dual{TestTag()}(widen(V)(PRIMAL), PARTIALS...)) === Dual{TestTag(),widen(V),N,widen(V)}
+    @test typeof(NESTED_FDNUM) == Dual{TestTag(),Dual{TestTag(),V,M,V},N,Dual{TestTag(),V,M,V}}
 
     #############
     # Accessors #
@@ -88,8 +88,8 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
 
     @test ForwardDiff.valtype(FDNUM) == V
     @test ForwardDiff.valtype(typeof(FDNUM)) == V
-    @test ForwardDiff.valtype(NESTED_FDNUM) == Dual{TestTag(),V,M}
-    @test ForwardDiff.valtype(typeof(NESTED_FDNUM)) == Dual{TestTag(),V,M}
+    @test ForwardDiff.valtype(NESTED_FDNUM) == Dual{TestTag(),V,M,V}
+    @test ForwardDiff.valtype(typeof(NESTED_FDNUM)) == Dual{TestTag(),V,M,V}
 
     #####################
     # Generic Functions #
@@ -290,22 +290,22 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
 
     WIDE_T = widen(V)
 
-    @test promote_type(Dual{TestTag(),V,N}, V) == Dual{TestTag(),V,N}
-    @test promote_type(Dual{TestTag(),V,N}, WIDE_T) == Dual{TestTag(),WIDE_T,N}
-    @test promote_type(Dual{TestTag(),WIDE_T,N}, V) == Dual{TestTag(),WIDE_T,N}
-    @test promote_type(Dual{TestTag(),V,N}, Dual{TestTag(),V,N}) == Dual{TestTag(),V,N}
-    @test promote_type(Dual{TestTag(),V,N}, Dual{TestTag(),WIDE_T,N}) == Dual{TestTag(),WIDE_T,N}
-    @test promote_type(Dual{TestTag(),WIDE_T,N}, Dual{TestTag(),Dual{TestTag(),V,M},N}) == Dual{TestTag(),Dual{TestTag(),WIDE_T,M},N}
+    @test promote_type(Dual{TestTag(),V,N}, V) == Dual{TestTag(),V,N,V}
+    @test promote_type(Dual{TestTag(),V,N}, WIDE_T) == Dual{TestTag(),WIDE_T,N,WIDE_T}
+    @test promote_type(Dual{TestTag(),WIDE_T,N}, V) == Dual{TestTag(),WIDE_T,N,WIDE_T}
+    @test promote_type(Dual{TestTag(),V,N,V}, Dual{TestTag(),V,N,V}) == Dual{TestTag(),V,N,V}
+    @test promote_type(Dual{TestTag(),V,N}, Dual{TestTag(),WIDE_T,N}) == Dual{TestTag(),WIDE_T,N,WIDE_T}
+    @test promote_type(Dual{TestTag(),WIDE_T,N}, Dual{TestTag(),Dual{TestTag(),V,M},N}) == Dual{TestTag(),Dual{TestTag(),WIDE_T,M,WIDE_T},N,Dual{TestTag(),WIDE_T,M,WIDE_T}}
 
     # issue #322
-    @test promote_type(Bool, Dual{TestTag(),V,N}) == Dual{TestTag(),promote_type(Bool, V),N}
-    @test promote_type(BigFloat, Dual{TestTag(),V,N}) == Dual{TestTag(),promote_type(BigFloat, V),N}
+    @test promote_type(Bool, Dual{TestTag(),V,N}) == Dual{TestTag(),promote_type(Bool, V),N,promote_type(Bool, V)}
+    @test promote_type(BigFloat, Dual{TestTag(),V,N}) == Dual{TestTag(),promote_type(BigFloat, V),N,promote_type(BigFloat, V)}
 
     WIDE_FDNUM = convert(Dual{TestTag(),WIDE_T,N}, FDNUM)
     WIDE_NESTED_FDNUM = convert(Dual{TestTag(),Dual{TestTag(),WIDE_T,M},N}, NESTED_FDNUM)
 
-    @test typeof(WIDE_FDNUM) === Dual{TestTag(),WIDE_T,N}
-    @test typeof(WIDE_NESTED_FDNUM) === Dual{TestTag(),Dual{TestTag(),WIDE_T,M},N}
+    @test typeof(WIDE_FDNUM) === Dual{TestTag(),WIDE_T,N,WIDE_T}
+    @test typeof(WIDE_NESTED_FDNUM) === Dual{TestTag(),Dual{TestTag(),WIDE_T,M,WIDE_T},N,Dual{TestTag(),WIDE_T,M,WIDE_T}}
 
     @test value(WIDE_FDNUM) == PRIMAL
     @test value(WIDE_NESTED_FDNUM) == PRIMAL


### PR DESCRIPTION
This is one of those love/hate changes...in brief, it allows one to set up alternate rules for how the "epsilon" component of dual numbers behaves by changing the type of `Dual` from
```julia
struct Dual{T,V,N} <: Real
    value::V
    partials::Partials{N,V}
end
```
to
```julia
struct Dual{T,V,N,P} <: Real
    value::V
    partials::Partials{N,P}
end
```

Happy to discuss motivations for this change at my poster at JuliaCon (we should leave this open at least until then).

It also throws in a commit to change from `one` to `oneunit` in places where IMO the latter is technically the correct choice.

Someone with permissions should tag this "breaking change" (note the version bump to 0.11).