### PR TITLE
Release 1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ForwardDiff"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.12"
+version = "1.0.0"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"


### PR DESCRIPTION
Noone wants to change FowardDIff.
It is stable.
Even if one *does* want to change ForwardDiff, noone wants to change the API in a breaking way.

