### PR TITLE
Avoid calling highly overloaded function in generated extraction functions

### DIFF
--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -53,12 +53,12 @@ end
 # result extraction #
 #####################
 
-@generated function extract_gradient(::Type{T}, y::Real, x::StaticArray) where T
+@generated function extract_gradient(::Type{T}, y::Real, x::S) where {T,S<:StaticArray}
     result = Expr(:tuple, [:(partials(T, y, $i)) for i in 1:length(x)]...)
-    V = StaticArrays.similar_type(x, valtype(y))
     return quote
         $(Expr(:meta, :inline))
-        return $V($result)
+        V = StaticArrays.similar_type(S, valtype($y))
+        return V($result)
     end
 end
 

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -94,13 +94,13 @@ end
 # result extraction #
 #####################
 
-@generated function extract_jacobian(::Type{T}, ydual::StaticArray, x::StaticArray) where T
+@generated function extract_jacobian(::Type{T}, ydual::StaticArray, x::S) where {T,S<:StaticArray}
     M, N = length(ydual), length(x)
     result = Expr(:tuple, [:(partials(T, ydual[$i], $j)) for i in 1:M, j in 1:N]...)
-    V = StaticArrays.similar_type(x, valtype(eltype(ydual)), Size(M, N))
     return quote
         $(Expr(:meta, :inline))
-        return $V($result)
+        V = StaticArrays.similar_type(S, valtype(eltype($ydual)), Size($M, $N))
+        return V($result)
     end
 end
 


### PR DESCRIPTION
Fixes https://github.com/JuliaDiff/ForwardDiff.jl/issues/468