### PR TITLE
Change `==` to ignore measure-zero branches

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ForwardDiff"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.32"
+version = "0.11.0"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ForwardDiff"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.30"
+version = "0.10.33"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ForwardDiff"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.11.0"
+version = "0.10.30"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -384,9 +384,21 @@ for pred in UNARY_PREDICATES
     @eval Base.$(pred)(d::Dual) = $(pred)(value(d))
 end
 
-# BINARY_PREDICATES = Symbol[:isequal, :isless, :<, :>, :(==), :(!=), :(<=), :(>=)] # prelude.jl
+# Before PR#481 this loop ran over this list:
+# BINARY_PREDICATES = Symbol[:isequal, :isless, :<, :>, :(==), :(!=), :(<=), :(>=)]
+# Not a minimal set, as Base defines some in terms of others.
+for pred in [:isless, :<, :>, :(<=), :(>=)]
+    @eval begin
+        @define_binary_dual_op(
+            Base.$(pred),
+            $(pred)(value(x), value(y)),
+            $(pred)(value(x), y),
+            $(pred)(x, value(y)),
+        )
+    end
+end
 
-Base.iszero(x::Dual) = iszero(value(x)) && iszero(partials(x))
+Base.iszero(x::Dual) = iszero(value(x)) && iszero(partials(x))  # shortcut, equivalent to x == zero(x)
 
 for pred in [:isequal, :(==)]
     @eval begin
@@ -405,17 +417,6 @@ end
     (!=)(value(x), y)        || !iszero(partials(x)),
     (!=)(x, value(y))        || !iszero(partials(y)),
 )
-
-for pred in [:isless, :<, :>, :(<=), :(>=)]
-    @eval begin
-        @define_binary_dual_op(
-            Base.$(pred),
-            $(pred)(value(x), value(y)),
-            $(pred)(value(x), y),
-            $(pred)(x, value(y)),
-        )
-    end
-end
 
 ########################
 # Promotion/Conversion #

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -390,18 +390,18 @@ for pred in [:isequal, :(==)]
     @eval begin
         @define_binary_dual_op(
             Base.$(pred),
-            $(pred)(value(x), value(y)) && $(pred)(partials(x),       partials(y)),
-            $(pred)(value(x), y)        && $(pred)(partials(x), zero(partials(x))),
-            $(pred)(x, value(y))        && $(pred)(zero(partials(y)), partials(y)),
+            $(pred)(value(x), value(y)) && $(pred)(partials(x), partials(y)),
+            $(pred)(value(x), y)        && iszero(partials(x)),
+            $(pred)(x, value(y))        && iszero(partials(y)),
         )
     end
 end
 
 @define_binary_dual_op(
     Base.:(!=),
-    (!=)(value(x), value(y)) || (!=)(partials(x),       partials(y)),
-    (!=)(value(x), y)        || (!=)(partials(x), zero(partials(x))),
-    (!=)(x, value(y))        || (!=)(zero(partials(y)), partials(y)),
+    (!=)(value(x), value(y)) || (!=)(partials(x), partials(y)),
+    (!=)(value(x), y)        || !iszero(partials(x)),
+    (!=)(x, value(y))        || !iszero(partials(y)),
 )
 
 for pred in [:isless, :<, :>, :(<=), :(>=)]
@@ -413,23 +413,11 @@ for pred in [:isless, :<, :>, :(<=), :(>=)]
             else
                 $(pred)(value(x), value(y))
             end,
-            if value(x) == y # only x is Dual
-                $(pred)(partials(x), zero(partials(x)))
-            else
-                $(pred)(value(x), value(y))
-            end,
-            if x == value(y) # only y is Dual
-                $(pred)(zero(partials(y)), partials(y))
-            else
-                $(pred)(value(x), value(y))
-            end,
+            $(pred)(value(x), y), # only x is Dual
+            $(pred)(x, value(y)), # only y is Dual
         )
     end
 end
-
-# @define_binary_dual_op(Base.:(==), false, false, false)
-# @define_binary_dual_op(Base.isequal, false, false, false)
-# @define_binary_dual_op(Base.:(!=), true, true, true)
 
 ########################
 # Promotion/Conversion #

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -384,7 +384,9 @@ for pred in UNARY_PREDICATES
     @eval Base.$(pred)(d::Dual) = $(pred)(value(d))
 end
 
-# BINARY_PREDICATES = Symbol[:isequal, :isless, :<, :>, :(==), :(!=), :(<=), :(>=)]
+# BINARY_PREDICATES = Symbol[:isequal, :isless, :<, :>, :(==), :(!=), :(<=), :(>=)] # prelude.jl
+
+Base.iszero(x::Dual) = iszero(value(x)) && iszero(partials(x))
 
 for pred in [:isequal, :(==)]
     @eval begin
@@ -408,13 +410,9 @@ for pred in [:isless, :<, :>, :(<=), :(>=)]
     @eval begin
         @define_binary_dual_op(
             Base.$(pred),
-            if value(x) == value(y) # both Dual
-                $(pred)(partials(x), partials(y))
-            else
-                $(pred)(value(x), value(y))
-            end,
-            $(pred)(value(x), y), # only x is Dual
-            $(pred)(x, value(y)), # only y is Dual
+            $(pred)(value(x), value(y)),
+            $(pred)(value(x), y),
+            $(pred)(x, value(y)),
         )
     end
 end

--- a/src/prelude.jl
+++ b/src/prelude.jl
@@ -10,7 +10,7 @@ const AMBIGUOUS_TYPES = (AbstractFloat, Irrational, Integer, Rational, Real, Rou
 
 const UNARY_PREDICATES = Symbol[:isinf, :isnan, :isfinite, :iseven, :isodd, :isreal, :isinteger]
 
-const BINARY_PREDICATES = Symbol[:isequal, :isless, :<, :>, :(==), :(!=), :(<=), :(>=)]
+const DEFAULT_CHUNK_THRESHOLD = 12
 
 struct Chunk{N} end
 

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -30,7 +30,7 @@ ForwardDiff.:≺(::Int, ::Type{TestTag()}) = false
 ForwardDiff.:≺(::Type{TestTag}, ::Type{OuterTestTag}) = true
 ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
 
-@testset "Dual{TestTag(),$V,$N} and Dual{TestTag(),Dual{TestTag(),$V,$M},$N}" for N in (0,3), M in (0,4), V in (Int, Float32)
+@testset "Dual{Z,$V,$N} and Dual{Z,Dual{Z,$V,$M},$N}" for N in (0,3), M in (0,4), V in (Int, Float32)
     println("  ...testing Dual{TestTag(),$V,$N} and Dual{TestTag(),Dual{TestTag(),$V,$M},$N}")
 
     PARTIALS = Partials{N,V}(ntuple(n -> intrand(V), N))
@@ -240,9 +240,10 @@ ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
     # M is the length of M_PARTIALS, which affects:
     # NESTED_FDNUM = Dual{TestTag()}(Dual{TestTag()}(PRIMAL, M_PARTIALS), NESTED_PARTIALS)
 
-@show N M 
+    @show N M NESTED_FDNUM PRIMAL M_PARTIALS2 NESTED_PARTIALS2
     @test isequal(NESTED_FDNUM, Dual{TestTag()}(Dual{TestTag()}(PRIMAL, M_PARTIALS2), NESTED_PARTIALS2)) == (N == M == 0)
-    @test isequal(NESTED_FDNUM, NESTED_FDNUM2) == isequal(PRIMAL, PRIMAL2) && (N == M == 0)
+    @show N M NESTED_FDNUM NESTED_FDNUM2 PRIMAL PRIMAL2
+    @test isequal(NESTED_FDNUM, NESTED_FDNUM2) == isequal(PRIMAL, PRIMAL2)
 
     @test (FDNUM == Dual{TestTag()}(PRIMAL, PARTIALS2)) == (N == 0)
     @test (PRIMAL == PRIMAL2) == (FDNUM == FDNUM2)

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -222,7 +222,7 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
 
     # Predicates #
     #------------#
-
+#=
     @test ForwardDiff.isconstant(zero(FDNUM))
     @test ForwardDiff.isconstant(one(FDNUM))
     @test ForwardDiff.isconstant(FDNUM) == (N == 0)
@@ -280,7 +280,7 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
     @test Dual{TestTag()}(Dual{TestTag()}(2, M_PARTIALS), NESTED_PARTIALS) >= Dual{TestTag()}(Dual{TestTag()}(1, M_PARTIALS2), NESTED_PARTIALS2)
     @test Dual{TestTag()}(Dual{TestTag()}(1, M_PARTIALS), NESTED_PARTIALS) >= Dual{TestTag()}(Dual{TestTag()}(1, M_PARTIALS2), NESTED_PARTIALS2)
     @test !(Dual{TestTag()}(Dual{TestTag()}(1, M_PARTIALS), NESTED_PARTIALS) >= Dual{TestTag()}(Dual{TestTag()}(2, M_PARTIALS2), NESTED_PARTIALS2))
-
+=#
     @test isnan(Dual{TestTag()}(NaN, PARTIALS))
     @test !(isnan(FDNUM))
 
@@ -344,7 +344,7 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
     @test typeof(WIDE_NESTED_FDNUM) === Dual{TestTag(),Dual{TestTag(),WIDE_T,M},N}
 
     @test value(WIDE_FDNUM) == PRIMAL
-    @test value(WIDE_NESTED_FDNUM) == PRIMAL
+    # @test !(value(WIDE_NESTED_FDNUM) == PRIMAL)
 
     @test convert(Dual, FDNUM) === FDNUM
     @test convert(Dual, NESTED_FDNUM) === NESTED_FDNUM

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -464,7 +464,7 @@ ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
     @test abs(NESTED_FDNUM) === NESTED_FDNUM
 
     if V != Int
-        for (M, f, arity) in DiffRules.diffrules(filter_modules = nothing)
+        @testset "$f" for (M, f, arity) in DiffRules.diffrules(filter_modules = nothing)
             if f in (:/, :rem2pi)
                 continue  # Skip these rules
             elseif !(isdefined(@__MODULE__, M) && isdefined(getfield(@__MODULE__, M), f))
@@ -524,10 +524,14 @@ ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
                     else
                         @test dx isa Complex{<:Dual{TestTag()}}
                         @test dy isa Complex{<:Dual{TestTag()}}
-                        @test real(value(dx)) == real(actualval)
-                        @test real(value(dy)) == real(actualval)
-                        @test imag(value(dx)) == imag(actualval)
-                        @test imag(value(dy)) == imag(actualval)
+                        # @test real(value(dx)) == real(actualval)
+                        # @test real(value(dy)) == real(actualval)
+                        # @test imag(value(dx)) == imag(actualval)
+                        # @test imag(value(dy)) == imag(actualval)
+                        @test value(real(dx)) == real(actualval)
+                        @test value(real(dy)) == real(actualval)
+                        @test value(imag(dx)) == imag(actualval)
+                        @test value(imag(dy)) == imag(actualval)
                         @test partials(real(dx), 1) ≈ real(actualdx) nans=true
                         @test partials(real(dy), 1) ≈ real(actualdy) nans=true
                         @test partials(imag(dx), 1) ≈ imag(actualdx) nans=true

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -30,7 +30,7 @@ ForwardDiff.:≺(::Int, ::Type{TestTag()}) = false
 ForwardDiff.:≺(::Type{TestTag}, ::Type{OuterTestTag}) = true
 ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
 
-for N in (0,3), M in (0,4), V in (Int, Float32)
+@testset "Dual{TestTag(),$V,$N} and Dual{TestTag(),Dual{TestTag(),$V,$M},$N}" for N in (0,3), M in (0,4), V in (Int, Float32)
     println("  ...testing Dual{TestTag(),$V,$N} and Dual{TestTag(),Dual{TestTag(),$V,$M},$N}")
 
     PARTIALS = Partials{N,V}(ntuple(n -> intrand(V), N))
@@ -237,7 +237,7 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
     @test isequal(NESTED_FDNUM, Dual{TestTag()}(Dual{TestTag()}(PRIMAL, M_PARTIALS2), NESTED_PARTIALS2)) == (N == M == 0)
     # @test isequal(PRIMAL, PRIMAL2) == isequal(NESTED_FDNUM, NESTED_FDNUM2)
 
-    @info "weird test?" N M V PRIMAL PRIMAL2 NESTED_FDNUM NESTED_FDNUM2
+    @info "Predicates" N M V PRIMAL PRIMAL2 NESTED_FDNUM NESTED_FDNUM2
 
     @test (FDNUM == Dual{TestTag()}(PRIMAL, PARTIALS2)) == (N == 0)
     @test (PRIMAL == PRIMAL2) == (FDNUM == FDNUM2)

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -229,7 +229,6 @@ ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
 
     # Predicates #
     #------------#
-    @testset "Predicates" begin
 
     @test ForwardDiff.isconstant(zero(FDNUM))
     @test ForwardDiff.isconstant(one(FDNUM))
@@ -340,7 +339,6 @@ ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
     @test isodd(Dual{TestTag()}(Dual{TestTag()}(1)))
     @test !(isodd(Dual{TestTag()}(Dual{TestTag()}(2))))
 
-    end
     ########################
     # Promotion/Conversion #
     ########################
@@ -414,7 +412,6 @@ ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
 
     # Division #
     #----------#
-    @testset "Division" begin
 
     if M > 0 && N > 0
         # Recall that FDNUM = Dual{TestTag()}(PRIMAL, PARTIALS) has N partials, 
@@ -435,11 +432,8 @@ ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
     @test dual_isapprox(NESTED_FDNUM / PRIMAL, Dual{TestTag()}(value(NESTED_FDNUM) / PRIMAL, partials(NESTED_FDNUM) / PRIMAL))
     @test dual_isapprox(PRIMAL / NESTED_FDNUM, Dual{TestTag()}(PRIMAL / value(NESTED_FDNUM), (-(PRIMAL) / value(NESTED_FDNUM)^2) * partials(NESTED_FDNUM)))
 
-    end
-
     # Exponentiation #
     #----------------#
-    @testset "Exponentiation" begin
 
     # If V == Int, the LHS terms are Int's. Large inputs cause integer overflow
     # within the generic fallback of `isapprox`, resulting in a DomainError.
@@ -454,7 +448,6 @@ ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
 
     @test partials(NaNMath.pow(Dual{TestTag()}(-2.0, 1.0), Dual{TestTag()}(2.0, 0.0)), 1) == -4.0
 
-    end
     ###################################
     # General Mathematical Operations #
     ###################################
@@ -547,7 +540,6 @@ ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
 
     # Special Cases #
     #---------------#
-    @testset "Special Cases" begin
 
     @test_broken dual_isapprox(hypot(FDNUM, FDNUM2, FDNUM), sqrt(2*(FDNUM^2) + FDNUM2^2))
     @test_broken dual_isapprox(hypot(FDNUM, FDNUM2, FDNUM3), sqrt(FDNUM^2 + FDNUM2^2 + FDNUM3^2))

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -235,7 +235,9 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
     @test isequal(PRIMAL, PRIMAL2) == isequal(FDNUM, FDNUM2)
 
     @test isequal(NESTED_FDNUM, Dual{TestTag()}(Dual{TestTag()}(PRIMAL, M_PARTIALS2), NESTED_PARTIALS2)) == (N == M == 0)
-    @test isequal(PRIMAL, PRIMAL2) == isequal(NESTED_FDNUM, NESTED_FDNUM2)
+    # @test isequal(PRIMAL, PRIMAL2) == isequal(NESTED_FDNUM, NESTED_FDNUM2)
+
+    @info "weird test?" N M V PRIMAL PRIMAL2 NESTED_FDNUM NESTED_FDNUM2
 
     @test (FDNUM == Dual{TestTag()}(PRIMAL, PARTIALS2)) == (N == 0)
     @test (PRIMAL == PRIMAL2) == (FDNUM == FDNUM2)

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -222,7 +222,7 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
 
     # Predicates #
     #------------#
-#=
+
     @test ForwardDiff.isconstant(zero(FDNUM))
     @test ForwardDiff.isconstant(one(FDNUM))
     @test ForwardDiff.isconstant(FDNUM) == (N == 0)
@@ -231,13 +231,13 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
     @test ForwardDiff.isconstant(one(NESTED_FDNUM))
     @test ForwardDiff.isconstant(NESTED_FDNUM) == (N == 0)
 
-    @test isequal(FDNUM, Dual{TestTag()}(PRIMAL, PARTIALS2))
+    @test isequal(FDNUM, Dual{TestTag()}(PRIMAL, PARTIALS2)) == (N == 0)
     @test isequal(PRIMAL, PRIMAL2) == isequal(FDNUM, FDNUM2)
 
-    @test isequal(NESTED_FDNUM, Dual{TestTag()}(Dual{TestTag()}(PRIMAL, M_PARTIALS2), NESTED_PARTIALS2))
+    @test isequal(NESTED_FDNUM, Dual{TestTag()}(Dual{TestTag()}(PRIMAL, M_PARTIALS2), NESTED_PARTIALS2)) == (N == M == 0)
     @test isequal(PRIMAL, PRIMAL2) == isequal(NESTED_FDNUM, NESTED_FDNUM2)
 
-    @test FDNUM == Dual{TestTag()}(PRIMAL, PARTIALS2)
+    @test (FDNUM == Dual{TestTag()}(PRIMAL, PARTIALS2)) == (N == 0)
     @test (PRIMAL == PRIMAL2) == (FDNUM == FDNUM2)
     @test (PRIMAL == PRIMAL2) == (NESTED_FDNUM == NESTED_FDNUM2)
 
@@ -280,7 +280,7 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
     @test Dual{TestTag()}(Dual{TestTag()}(2, M_PARTIALS), NESTED_PARTIALS) >= Dual{TestTag()}(Dual{TestTag()}(1, M_PARTIALS2), NESTED_PARTIALS2)
     @test Dual{TestTag()}(Dual{TestTag()}(1, M_PARTIALS), NESTED_PARTIALS) >= Dual{TestTag()}(Dual{TestTag()}(1, M_PARTIALS2), NESTED_PARTIALS2)
     @test !(Dual{TestTag()}(Dual{TestTag()}(1, M_PARTIALS), NESTED_PARTIALS) >= Dual{TestTag()}(Dual{TestTag()}(2, M_PARTIALS2), NESTED_PARTIALS2))
-=#
+
     @test isnan(Dual{TestTag()}(NaN, PARTIALS))
     @test !(isnan(FDNUM))
 
@@ -344,7 +344,7 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
     @test typeof(WIDE_NESTED_FDNUM) === Dual{TestTag(),Dual{TestTag(),WIDE_T,M},N}
 
     @test value(WIDE_FDNUM) == PRIMAL
-    # @test !(value(WIDE_NESTED_FDNUM) == PRIMAL)
+    @test (value(WIDE_NESTED_FDNUM) == PRIMAL) == (M == 0)
 
     @test convert(Dual, FDNUM) === FDNUM
     @test convert(Dual, NESTED_FDNUM) === NESTED_FDNUM

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -240,6 +240,7 @@ ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
     # M is the length of M_PARTIALS, which affects:
     # NESTED_FDNUM = Dual{TestTag()}(Dual{TestTag()}(PRIMAL, M_PARTIALS), NESTED_PARTIALS)
 
+@show N M 
     @test isequal(NESTED_FDNUM, Dual{TestTag()}(Dual{TestTag()}(PRIMAL, M_PARTIALS2), NESTED_PARTIALS2)) == (N == M == 0)
     @test isequal(NESTED_FDNUM, NESTED_FDNUM2) == isequal(PRIMAL, PRIMAL2) && (N == M == 0)
 

--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -84,9 +84,9 @@ end
 
 println("  ...testing specialized StaticArray codepaths")
 
-x = rand(3, 3)
+@testset "$T" for T in (StaticArrays.SArray, StaticArrays.MArray)
+    x = rand(3, 3)
 
-for T in (StaticArrays.SArray, StaticArrays.MArray)
     sx = T{Tuple{3,3}}(x)
 
     cfg = ForwardDiff.GradientConfig(nothing, x)

--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -201,13 +201,15 @@ end
     # Issue 536, version with 3-arg *, Julia 1.7:
     @test ForwardDiff.derivative(x -> sum(x*a*b), 0.0) ≈ sum(a * b)
 
-    # version with just mul!
-    dx = ForwardDiff.derivative(0.0) do x
-        c = similar(a, typeof(x))
-        mul!(c, a, b, x, false)
-        sum(c)
+    if VERSION >= v"1.3"
+        # version with just mul!
+        dx = ForwardDiff.derivative(0.0) do x
+            c = similar(a, typeof(x))
+            mul!(c, a, b, x, false)
+            sum(c)
+        end
+        @test dx ≈ sum(a * b)
     end
-    @test dx ≈ sum(a * b)
 end
 
 end # module

--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -20,7 +20,7 @@ x = [0.1, 0.2, 0.3]
 v = f(x)
 g = [-9.4, 15.6, 52.0]
 
-for c in (1, 2, 3), tag in (nothing, Tag(f, eltype(x)))
+@testset "Rosenbrock, chunk size = $c and tag = $(repr(tag))" for c in (1, 2, 3), tag in (nothing, Tag(f, eltype(x)))
     println("  ...running hardcoded test with chunk size = $c and tag = $(repr(tag))")
     cfg = ForwardDiff.GradientConfig(f, x, ForwardDiff.Chunk{c}(), tag)
 
@@ -56,7 +56,7 @@ cfgx = ForwardDiff.GradientConfig(sin, x)
 # test vs. Calculus.jl #
 ########################
 
-for f in DiffTests.VECTOR_TO_NUMBER_FUNCS
+@testset "$f" for f in DiffTests.VECTOR_TO_NUMBER_FUNCS
     v = f(X)
     g = ForwardDiff.gradient(f, X)
     @test isapprox(g, Calculus.gradient(f, X), atol=FINITEDIFF_ERROR)

--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -190,6 +190,10 @@ end
     ∇A = [6 0 0; 0 3 -pi; 0 0 2]
     @test ForwardDiff.gradient(det2, A) ≈ ∇A
     @test ForwardDiff.gradient(det, A) ≈ ∇A
+
+    # And issue 407
+    @test ForwardDiff.hessian(det, A) ≈ ForwardDiff.hessian(det2, A)
+
 end
 
 end # module

--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -175,8 +175,8 @@ end
     @test ForwardDiff.gradient(f, [0.2,25.0]) == [7875.0, 0.0]
 end
 
-# Issue 197
 @testset "det with branches" begin
+    # Issue 197
     det2(A) = return (
         A[1,1]*(A[2,2]*A[3,3]-A[2,3]*A[3,2]) -
         A[1,2]*(A[2,1]*A[3,3]-A[2,3]*A[3,1]) +
@@ -193,6 +193,12 @@ end
 
     # And issue 407
     @test ForwardDiff.hessian(det, A) ≈ ForwardDiff.hessian(det2, A)
+    
+    # https://discourse.julialang.org/t/forwarddiff-and-zygote-return-wrong-jacobian-for-log-det-l/77961
+    S = [1.0 0.8; 0.8 1.0]
+    L = cholesky(S).L
+    @test ForwardDiff.gradient(L -> log(det(L)), Matrix(L)) ≈ [1.0 -1.3333333333333337; 0.0 1.666666666666667]
+    @test ForwardDiff.gradient(L -> logdet(L), Matrix(L)) ≈ [1.0 -1.3333333333333337; 0.0 1.666666666666667]
 end
 
 @testset "branches in mul!" begin

--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -193,7 +193,21 @@ end
 
     # And issue 407
     @test ForwardDiff.hessian(det, A) ≈ ForwardDiff.hessian(det2, A)
+end
 
+@testset "branches in mul!" begin
+    a, b = rand(3,3), rand(3,3)
+
+    # Issue 536, version with 3-arg *, Julia 1.7:
+    @test ForwardDiff.derivative(x -> sum(x*a*b), 0.0) ≈ sum(a * b)
+
+    # version with just mul!
+    dx = ForwardDiff.derivative(0.0) do x
+        c = similar(a, typeof(x))
+        mul!(c, a, b, x, false)
+        sum(c)
+    end
+    @test dx ≈ sum(a * b)
 end
 
 end # module

--- a/test/HessianTest.jl
+++ b/test/HessianTest.jl
@@ -3,6 +3,7 @@ module HessianTest
 import Calculus
 
 using Test
+using LinearAlgebra
 using ForwardDiff
 using ForwardDiff: Dual, Tag
 using StaticArrays

--- a/test/HessianTest.jl
+++ b/test/HessianTest.jl
@@ -157,4 +157,11 @@ for T in (StaticArrays.SArray, StaticArrays.MArray)
     @test DiffResults.hessian(sresult3) == DiffResults.hessian(result)
 end
 
+@testset "branches in dot" begin
+    # https://github.com/JuliaDiff/ForwardDiff.jl/issues/551
+    H = [1 2 3; 4 5 6; 7 8 9];
+    @test ForwardDiff.hessian(x->dot(x,H,x), fill(0.00001, 3)) ≈ [2 6 10; 6 10 14; 10 14 18]
+    @test ForwardDiff.hessian(x->dot(x,H,x), zeros(3)) ≈ [2 6 10; 6 10 14; 10 14 18]
+end
+
 end # module

--- a/test/JacobianTest.jl
+++ b/test/JacobianTest.jl
@@ -226,6 +226,10 @@ for T in (StaticArrays.SArray, StaticArrays.MArray)
     @test DiffResults.jacobian(sresult3) == DiffResults.jacobian(result)
 end
 
+#########
+# misc. #
+#########
+
 @testset "dimension errors for jacobian" begin
     @test_throws DimensionMismatch ForwardDiff.jacobian(identity, 2pi) # input
     @test_throws DimensionMismatch ForwardDiff.jacobian(sum, fill(2pi, 2)) # vector_mode_jacobian

--- a/test/PartialsTest.jl
+++ b/test/PartialsTest.jl
@@ -7,7 +7,7 @@ using ForwardDiff: Partials
 
 samerng() = MersenneTwister(1)
 
-for N in (0, 3), T in (Int, Float32, Float64)
+@testset "Partials{$N,$T}" for N in (0, 3), T in (Int, Float32, Float64)
     println("  ...testing Partials{$N,$T}")
 
     VALUES = (rand(T,N)...,)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using ForwardDiff, Test
 
-@testset "ForwardDiff" begin
+@testset "ForwardDiff.jl" begin
     t0 = time()
     @testset "Partials" begin
         println("##### Testing Partials...")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,9 +4,9 @@ println("Testing Partials...")
 t = @elapsed include("PartialsTest.jl")
 println("done (took $t seconds).")
 
-# println("Testing Dual...")
-# t = @elapsed include("DualTest.jl")
-# println("done (took $t seconds).")
+println("Testing Dual...")
+t = @elapsed include("DualTest.jl")
+println("done (took $t seconds).")
 
 println("Testing derivative functionality...")
 t = @elapsed include("DerivativeTest.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,39 +1,51 @@
-using ForwardDiff
+using ForwardDiff, Test
 
-println("Testing Partials...")
-t = @elapsed include("PartialsTest.jl")
-println("done (took $t seconds).")
-
-println("Testing Dual...")
-t = @elapsed include("DualTest.jl")
-println("done (took $t seconds).")
-
-println("Testing derivative functionality...")
-t = @elapsed include("DerivativeTest.jl")
-println("done (took $t seconds).")
-
-println("Testing gradient functionality...")
-t = @elapsed include("GradientTest.jl")
-println("done (took $t seconds).")
-
-println("Testing jacobian functionality...")
-t = @elapsed include("JacobianTest.jl")
-println("done (took $t seconds).")
-
-println("Testing hessian functionality...")
-t = @elapsed include("HessianTest.jl")
-println("done (took $t seconds).")
-
-println("Testing perturbation confusion functionality...")
-t = @elapsed include("ConfusionTest.jl")
-println("done (took $t seconds).")
-
-println("Testing miscellaneous functionality...")
-t = @elapsed include("MiscTest.jl")
-println("done (took $t seconds).")
-
-if VERSION >= v"1.5-"
-    println("Testing allocations...")
-    t = @elapsed include("AllocationsTest.jl")
-    println("done (took $t seconds).")
+@testset "ForwardDiff" begin
+    @testset "Partials" begin
+        println("Testing Partials...")
+        t = @elapsed include("PartialsTest.jl")
+        println("done (took $t seconds).")
+    end
+    @testset "Dual" begin
+        println("Testing Dual...")
+        t = @elapsed include("DualTest.jl")
+        println("done (took $t seconds).")
+    end
+    @testset "Derivative" begin
+        println("Testing derivative functionality...")
+        t = @elapsed include("DerivativeTest.jl")
+        println("done (took $t seconds).")
+    end
+    @testset "Gradient" begin
+        println("Testing gradient functionality...")
+        t = @elapsed include("GradientTest.jl")
+        println("done (took $t seconds).")
+    end
+    @testset "Jacobian" begin
+        println("Testing jacobian functionality...")
+        t = @elapsed include("JacobianTest.jl")
+        println("done (took $t seconds).")
+    end
+    @testset "Hessian" begin
+        println("Testing hessian functionality...")
+        t = @elapsed include("HessianTest.jl")
+        println("done (took $t seconds).")
+    end
+    @testset "Perturbation confusion" begin
+        println("Testing perturbation confusion functionality...")
+        t = @elapsed include("ConfusionTest.jl")
+        println("done (took $t seconds).")
+    end
+    @testset "Miscellaneous" begin
+        println("Testing miscellaneous functionality...")
+        t = @elapsed include("MiscTest.jl")
+        println("done (took $t seconds).")
+    end
+    if VERSION >= v"1.5-"
+        @testset "Allocations" begin
+            println("Testing allocations...")
+            t = @elapsed include("AllocationsTest.jl")
+            println("done (took $t seconds).")
+        end
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using ForwardDiff, Test, Random
 
 SEED = trunc(Int, time())
-println("Testing with Random.seed!($SEED)")
+println("##### Random.seed!($SEED), on VERSION == $VERSION")
 Random.seed!(SEED)
 
 @testset "ForwardDiff.jl" begin
@@ -53,5 +53,5 @@ Random.seed!(SEED)
             println("##### done (took $t seconds).")
         end
     end
-    println("##### Running all ForwardDiff tests took $(t0 - time()) seconds.")
+    println("##### Running all ForwardDiff tests took $(time() - t0) seconds.")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,51 +1,53 @@
 using ForwardDiff, Test
 
 @testset "ForwardDiff" begin
+    t0 = time()
     @testset "Partials" begin
-        println("Testing Partials...")
+        println("##### Testing Partials...")
         t = @elapsed include("PartialsTest.jl")
-        println("done (took $t seconds).")
+        println("##### done (took $t seconds).")
     end
     @testset "Dual" begin
-        println("Testing Dual...")
+        println("##### Testing Dual...")
         t = @elapsed include("DualTest.jl")
-        println("done (took $t seconds).")
+        println("##### done (took $t seconds).")
     end
-    @testset "Derivative" begin
-        println("Testing derivative functionality...")
+    @testset "Derivatives" begin
+        println("##### Testing derivative functionality...")
         t = @elapsed include("DerivativeTest.jl")
-        println("done (took $t seconds).")
+        println("##### done (took $t seconds).")
     end
-    @testset "Gradient" begin
-        println("Testing gradient functionality...")
+    @testset "Gradients" begin
+        println("##### Testing gradient functionality...")
         t = @elapsed include("GradientTest.jl")
-        println("done (took $t seconds).")
+        println("##### done (took $t seconds).")
     end
-    @testset "Jacobian" begin
-        println("Testing jacobian functionality...")
+    @testset "Jacobians" begin
+        println("##### Testing jacobian functionality...")
         t = @elapsed include("JacobianTest.jl")
-        println("done (took $t seconds).")
+        println("##### done (took $t seconds).")
     end
-    @testset "Hessian" begin
-        println("Testing hessian functionality...")
+    @testset "Hessians" begin
+        println("##### Testing hessian functionality...")
         t = @elapsed include("HessianTest.jl")
-        println("done (took $t seconds).")
+        println("##### done (took $t seconds).")
     end
-    @testset "Perturbation confusion" begin
-        println("Testing perturbation confusion functionality...")
+    @testset "Perturbation Confusion" begin
+        println("##### Testing perturbation confusion functionality...")
         t = @elapsed include("ConfusionTest.jl")
-        println("done (took $t seconds).")
+        println("##### done (took $t seconds).")
     end
     @testset "Miscellaneous" begin
-        println("Testing miscellaneous functionality...")
+        println("##### Testing miscellaneous functionality...")
         t = @elapsed include("MiscTest.jl")
-        println("done (took $t seconds).")
+        println("##### done (took $t seconds).")
     end
     if VERSION >= v"1.5-"
         @testset "Allocations" begin
-            println("Testing allocations...")
+            println("##### Testing allocations...")
             t = @elapsed include("AllocationsTest.jl")
-            println("done (took $t seconds).")
+            println("##### done (took $t seconds).")
         end
     end
+    println("##### Running all ForwardDiff tests took $(t0 - time()) seconds.")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,9 +4,9 @@ println("Testing Partials...")
 t = @elapsed include("PartialsTest.jl")
 println("done (took $t seconds).")
 
-println("Testing Dual...")
-t = @elapsed include("DualTest.jl")
-println("done (took $t seconds).")
+# println("Testing Dual...")
+# t = @elapsed include("DualTest.jl")
+# println("done (took $t seconds).")
 
 println("Testing derivative functionality...")
 t = @elapsed include("DerivativeTest.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,8 @@
-using ForwardDiff, Test
+using ForwardDiff, Test, Random
+
+SEED = trunc(Int, time())
+println("Testing with Random.seed!($SEED)")
+Random.seed!(SEED)
 
 @testset "ForwardDiff.jl" begin
     t0 = time()


### PR DESCRIPTION
This changes the meaning of `==` for dual numbers, to demand that both real and ~~imaginary~~ dual parts match. 

Fixes #197, fixes #407. Edit -- also closes #490, closes #506, closes #536, closes #542, closes #551.

See #480 for too-long discussion of why I think this makes sense. And comments on functions like `>`, which this PR does not alter.