### PR TITLE
Friendly errors on array vs. scalar mistakes

### DIFF
--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -69,7 +69,7 @@ Set `check` to `Val{false}()` to disable tag checking. This can lead to perturba
     return result
 end
 
-derivative(f, x::AbstractArray) = throw(ArgumentError("derivative(f,x) expects that x is a real number. Perhaps you meant gradient(f,x)?"))
+derivative(f, x::AbstractArray) = throw(DimensionMismatch("derivative(f, x) expects that x is a real number. Perhaps you meant gradient(f, x)?"))
 
 #####################
 # result extraction #

--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -69,6 +69,8 @@ Set `check` to `Val{false}()` to disable tag checking. This can lead to perturba
     return result
 end
 
+derivative(f, x::AbstractArray) = throw(ArgumentError("derivative(f,x) expects that x is a real number. Perhaps you meant gradient(f,x)?"))
+
 #####################
 # result extraction #
 #####################

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -91,12 +91,18 @@ function extract_gradient_chunk!(::Type{T}, result::DiffResult, dual, index, chu
     return result
 end
 
+extract_gradient_chunk!(::Type, result, dual::AbstractArray, index, chunksize) = throw(GRAD_ERROR)
+extract_gradient_chunk!(::Type, result::DiffResult, dual::AbstractArray, index, chunksize) = throw(GRAD_ERROR)
+
+const GRAD_ERROR = ArgumentError("gradient(f,x) expects that f(x) be a real number. Perhaps you meant jacobian(f,x)?")
+
 ###############
 # vector mode #
 ###############
 
 function vector_mode_gradient(f::F, x, cfg::GradientConfig{T}) where {T, F}
     ydual = vector_mode_dual_eval(f, x, cfg)
+    ydual isa Real || throw(GRAD_ERROR)
     result = similar(x, valtype(ydual))
     return extract_gradient!(T, result, ydual)
 end

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -49,6 +49,8 @@ end
 @inline gradient!(result::Union{AbstractArray,DiffResult}, f, x::StaticArray, cfg::GradientConfig) = gradient!(result, f, x)
 @inline gradient!(result::Union{AbstractArray,DiffResult}, f, x::StaticArray, cfg::GradientConfig, ::Val) = gradient!(result, f, x)
 
+gradient(f, x::Real) = throw(ArgumentError("gradient(f,x) expects that x is an array. Perhaps you meant derivative(f,x)?"))
+
 #####################
 # result extraction #
 #####################

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -49,7 +49,7 @@ end
 @inline gradient!(result::Union{AbstractArray,DiffResult}, f, x::StaticArray, cfg::GradientConfig) = gradient!(result, f, x)
 @inline gradient!(result::Union{AbstractArray,DiffResult}, f, x::StaticArray, cfg::GradientConfig, ::Val) = gradient!(result, f, x)
 
-gradient(f, x::Real) = throw(ArgumentError("gradient(f,x) expects that x is an array. Perhaps you meant derivative(f,x)?"))
+gradient(f, x::Real) = throw(DimensionMismatch("gradient(f, x) expects that x is an array. Perhaps you meant derivative(f, x)?"))
 
 #####################
 # result extraction #
@@ -96,7 +96,7 @@ end
 extract_gradient_chunk!(::Type, result, dual::AbstractArray, index, chunksize) = throw(GRAD_ERROR)
 extract_gradient_chunk!(::Type, result::DiffResult, dual::AbstractArray, index, chunksize) = throw(GRAD_ERROR)
 
-const GRAD_ERROR = ArgumentError("gradient(f,x) expects that f(x) be a real number. Perhaps you meant jacobian(f,x)?")
+const GRAD_ERROR = DimensionMismatch("gradient(f, x) expects that f(x) is a real number. Perhaps you meant jacobian(f, x)?")
 
 ###############
 # vector mode #

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -90,6 +90,8 @@ end
 @inline jacobian!(result::Union{AbstractArray,DiffResult}, f, x::StaticArray, cfg::JacobianConfig) = jacobian!(result, f, x)
 @inline jacobian!(result::Union{AbstractArray,DiffResult}, f, x::StaticArray, cfg::JacobianConfig, ::Val) = jacobian!(result, f, x)
 
+jacobian(f, x::Real) = throw(ArgumentError("jacobian(f,x) expects that x is an array. Perhaps you meant derivative(f,x)?"))
+
 #####################
 # result extraction #
 #####################

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -197,7 +197,7 @@ end
     return result
 end
 
-const JACOBIAN_ERROR = DimensionMismatch("jacobain(f, x) expexts that f(x) is an array")
+const JACOBIAN_ERROR = DimensionMismatch("jacobian(f, x) expexts that f(x) is an array. Perhaps you meant gradient(f, x)?")
 
 # chunk mode #
 #------------#

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -137,12 +137,17 @@ end
 reshape_jacobian(result, ydual, xdual) = reshape(result, length(ydual), length(xdual))
 reshape_jacobian(result::DiffResult, ydual, xdual) = reshape_jacobian(DiffResults.jacobian(result), ydual, xdual)
 
+extract_jacobian_chunk!(::Type, result, ydual::Real, index, chunksize) = throw(JACOBIAN_ERROR)
+
+const JACOBIAN_ERROR = ArgumentError("jacobain(f,x) expexts that f(x) is an array")
+
 ###############
 # vector mode #
 ###############
 
 function vector_mode_jacobian(f::F, x, cfg::JacobianConfig{T,V,N}) where {F,T,V,N}
     ydual = vector_mode_dual_eval(f, x, cfg)
+    ydual isa AbstractArray || throw(JACOBIAN_ERROR)
     result = similar(ydual, valtype(eltype(ydual)), length(ydual), N)
     extract_jacobian!(T, result, ydual, N)
     extract_value!(T, result, ydual)

--- a/test/DerivativeTest.jl
+++ b/test/DerivativeTest.jl
@@ -96,4 +96,8 @@ end
     @test (x -> ForwardDiff.derivative(y -> x^y,  1.5))(0.0) === 0.0
 end
 
+@testset "dimension error for derivative" begin
+    @test_throws DimensionMismatch ForwardDiff.derivative(sum, fill(2pi, 3))
+end
+
 end # module

--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -156,4 +156,10 @@ end
     @test isempty(g_grad_const(zeros(Float64, 0)))
 end
 
+@testset "dimension errors for gradient" begin
+    @test_throws DimensionMismatch ForwardDiff.gradient(identity, 2pi) # input
+    @test_throws DimensionMismatch ForwardDiff.gradient(identity, fill(2pi, 2)) # vector_mode_gradient
+    @test_throws DimensionMismatch ForwardDiff.gradient(identity, fill(2pi, 10^6)) # chunk_mode_gradient
+end
+
 end # module

--- a/test/JacobianTest.jl
+++ b/test/JacobianTest.jl
@@ -225,4 +225,10 @@ for T in (StaticArrays.SArray, StaticArrays.MArray)
     @test DiffResults.jacobian(sresult3) == DiffResults.jacobian(result)
 end
 
+@testset "dimension errors for jacobian" begin
+    @test_throws DimensionMismatch ForwardDiff.jacobian(identity, 2pi) # input
+    @test_throws DimensionMismatch ForwardDiff.jacobian(sum, fill(2pi, 2)) # vector_mode_jacobian
+    @test_throws DimensionMismatch ForwardDiff.jacobian(sum, fill(2pi, 10^6)) # chunk_mode_jacobian
+end
+
 end # module


### PR DESCRIPTION
The main purpose here is to change this:
```julia
julia> ForwardDiff.gradient(identity, rand(3))
ERROR: MethodError: no method matching extract_gradient!(::Type{ForwardDiff.Tag{typeof(identity), Float64}}, ::Vector{Vector{ForwardDiff.Dual{ForwardDiff.Tag{typeof(identity), Float64}, Float64, 3}}}, ::Vector{ForwardDiff.Dual{ForwardDiff.Tag{typeof(identity), Float64}, Float64, 3}})
Closest candidates are:
  extract_gradient!(::Type{T}, ::AbstractArray, ::ForwardDiff.Dual) where T at /Users/me/.julia/packages/ForwardDiff/qTmqf/src/gradient.jl:79
  extract_gradient!(::Type{T}, ::AbstractArray, ::Real) where T at /Users/me/.julia/packages/ForwardDiff/qTmqf/src/gradient.jl:78
  extract_gradient!(::Type{T}, ::DiffResults.DiffResult, ::ForwardDiff.Dual) where T at /Users/me/.julia/packages/ForwardDiff/qTmqf/src/gradient.jl:72
  ...
```
into this:
```julia
julia> ForwardDiff.gradient(identity, rand(3))  # with this PR
ERROR: ArgumentError: gradient(f,x) expects that f(x) be a real number. Perhaps you meant jacobian(f,x)?
```
since confusing these functions seems like a common mistake. For precedent:
```julia
julia> Zygote.gradient(identity, ones(3))
ERROR: Output should be scalar; gradients are not defined for output [1.0, 1.0, 1.0]
```
While I was doing this, I also made friendly errors for some wrong input types, as those also seem easy to confuse:
```julia
julia> ForwardDiff.gradient(identity, 3)  # with this PR
ERROR: ArgumentError: gradient(f,x) expects that x is an array. Perhaps you meant derivative(f,x)?
...

julia> Zygote.gradient(identity, 3)
(1,)
```
Although the error in this case was at least a MethodError of a function you called. And perhaps adding methods just to provide errors is poor style? Happy to remove these but perhaps worth discussing.
```julia
julia> ForwardDiff.gradient(identity, 3)
ERROR: MethodError: no method matching gradient(::typeof(identity), ::Int64)
Closest candidates are:
  gradient(::Any, ::StaticArrays.StaticArray) at /Users/me/.julia/packages/ForwardDiff/qTmqf/src/gradient.jl:44
  gradient(::Any, ::StaticArrays.StaticArray, ::ForwardDiff.GradientConfig) at /Users/me/.julia/packages/ForwardDiff/qTmqf/src/gradient.jl:45
  gradient(::Any, ::StaticArrays.StaticArray, ::ForwardDiff.GradientConfig, ::Val) at /Users/me/.julia/packages/ForwardDiff/qTmqf/src/gradient.jl:46
  ...
 ```
