### PR TITLE
Fix for namespace bug in binary_dual_definition

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -226,7 +226,7 @@ function binary_dual_definition(M, f)
         dvy = $dvy
     end)
     expr = quote
-        @define_binary_dual_op(
+        $FD.@define_binary_dual_op(
             $M.$f,
             begin
                 vx, vy = $FD.value(x), $FD.value(y)


### PR DESCRIPTION
Ran into a an issue of `@define_binary_dual_op` not defined when trying to define a binary rule within a package (which, AFAIK, requires me to do `eval(ForwardDiff.binary_dual_definition(:MyPackage, :myfunc))`, thus giving rise to the error). 

This should fix it.