### PR TITLE
Fix for derivative through sincospi gives StackOverflowError

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -612,9 +612,11 @@ end
 # sincospi #
 #----------#
 
-@inline function Base.sincospi(d::Dual{T}) where T
-    sd, cd = sincospi(value(d))
-    return (Dual{T}(sd, cd * π * partials(d)), Dual{T}(cd, -sd * π * partials(d)))
+if VERSION >= v"1.6-"
+    @inline function Base.sincospi(d::Dual{T}) where T
+        sd, cd = sincospi(value(d))
+        return (Dual{T}(sd, cd * π * partials(d)), Dual{T}(cd, -sd * π * partials(d)))
+    end
 end
 
 ###################

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -612,7 +612,7 @@ end
 # sincospi #
 #----------#
 
-if VERSION >= v"1.6-"
+if VERSION >= v"1.6.0-DEV.292"
     @inline function Base.sincospi(d::Dual{T}) where T
         sd, cd = sincospi(value(d))
         return (Dual{T}(sd, cd * π * partials(d)), Dual{T}(cd, -sd * π * partials(d)))

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -609,6 +609,14 @@ end
     return (Dual{T}(sd, cd * partials(d)), Dual{T}(cd, -sd * partials(d)))
 end
 
+# sincospi #
+#----------#
+
+@inline function Base.sincospi(d::Dual{T}) where T
+    sd, cd = sincospi(value(d))
+    return (Dual{T}(sd, cd * π * partials(d)), Dual{T}(cd, -sd * π * partials(d)))
+end
+
 ###################
 # Pretty Printing #
 ###################

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -449,7 +449,7 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
 
     @test all(map(dual_isapprox, ForwardDiff.sincos(FDNUM), (sin(FDNUM), cos(FDNUM))))
 
-    if VERSION >= v"1.6-"
+    if VERSION >= v"1.6.0-DEV.292"
         @test all(map(dual_isapprox, sincospi(FDNUM), (sinpi(FDNUM), cospi(FDNUM))))
     end
 

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -449,7 +449,9 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
 
     @test all(map(dual_isapprox, ForwardDiff.sincos(FDNUM), (sin(FDNUM), cos(FDNUM))))
 
-    @test all(map(dual_isapprox, sincospi(FDNUM), (sinpi(FDNUM), cospi(FDNUM))))
+    if VERSION >= v"1.6-"
+        @test all(map(dual_isapprox, sincospi(FDNUM), (sinpi(FDNUM), cospi(FDNUM))))
+    end
 
     if V === Float32
         @test typeof(sqrt(FDNUM)) === typeof(FDNUM)

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -449,6 +449,8 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
 
     @test all(map(dual_isapprox, ForwardDiff.sincos(FDNUM), (sin(FDNUM), cos(FDNUM))))
 
+    @test all(map(dual_isapprox, sincospi(FDNUM), (sinpi(FDNUM), cospi(FDNUM))))
+
     if V === Float32
         @test typeof(sqrt(FDNUM)) === typeof(FDNUM)
         @test typeof(sqrt(NESTED_FDNUM)) === typeof(NESTED_FDNUM)


### PR DESCRIPTION
Fixes https://github.com/JuliaDiff/ForwardDiff.jl/issues/497

Adds:
- [x] Specialized version of `Base.sincospi(::Dual)` to avoid stackoverflow error
- [x] Test case for the specialized `Base.sincospi(::Dual)`

NOTE: Julia 1.6 required