### PR TITLE
Overload div for Dual

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ForwardDiff"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.15"
+version = "0.10.16"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -279,6 +279,12 @@ Base.trunc(d::Dual) = trunc(value(d))
 Base.round(::Type{R}, d::Dual) where {R<:Real} = round(R, value(d))
 Base.round(d::Dual) = round(value(d))
 
+if VERSION ≥ v"1.4"
+    Base.div(x::Dual, y::Dual, r::RoundingMode) = div(value(x), value(y), r)
+else
+    Base.div(x::Dual, y::Dual) = div(value(x), value(y))
+end
+
 Base.hash(d::Dual) = hash(value(d))
 Base.hash(d::Dual, hsh::UInt) = hash(value(d), hsh)
 

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -137,7 +137,12 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
         @test round(NESTED_FDNUM) === round(PRIMAL)
 
         @test div(FDNUM, FDNUM2) === div(PRIMAL, PRIMAL2)
+        @test div(FDNUM, PRIMAL2) === div(PRIMAL, PRIMAL2)
+        @test div(PRIMAL, FDNUM2) === div(PRIMAL, PRIMAL2)
+
         @test div(NESTED_FDNUM, NESTED_FDNUM2) === div(PRIMAL, PRIMAL2)
+        @test div(NESTED_FDNUM, PRIMAL2) === div(PRIMAL, PRIMAL2)
+        @test div(PRIMAL, NESTED_FDNUM2) === div(PRIMAL, PRIMAL2)
 
         if VERSION ≥ v"1.4"
             @test div(FDNUM, FDNUM2, RoundUp) === div(PRIMAL, PRIMAL2, RoundUp)

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -136,6 +136,14 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
         @test round(FDNUM2) === round(PRIMAL2)
         @test round(NESTED_FDNUM) === round(PRIMAL)
 
+        @test div(FDNUM, FDNUM2) === div(PRIMAL, PRIMAL2)
+        @test div(NESTED_FDNUM, NESTED_FDNUM2) === div(PRIMAL, PRIMAL2)
+
+        if VERSION ≥ v"1.4"
+            @test div(FDNUM, FDNUM2, RoundUp) === div(PRIMAL, PRIMAL2, RoundUp)
+            @test div(NESTED_FDNUM, NESTED_FDNUM2, RoundUp) === div(PRIMAL, PRIMAL2, RoundUp)
+        end
+
         @test Base.rtoldefault(typeof(FDNUM)) ≡ Base.rtoldefault(typeof(PRIMAL))
         @test Dual{TestTag()}(PRIMAL-eps(V), PARTIALS) ≈ FDNUM
         @test Base.rtoldefault(typeof(NESTED_FDNUM)) ≡ Base.rtoldefault(typeof(PRIMAL))


### PR DESCRIPTION
With this, `div` as well as functions that call it, like `fld` and `cld`, no longer error when passed a `Dual`.