### PR TITLE
Int(::Dual) and Integer(::Dual)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ForwardDiff"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.18"
+version = "0.10.19"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -305,8 +305,14 @@ end
 @inline Base.one(d::Dual) = one(typeof(d))
 @inline Base.one(::Type{Dual{T,V,N}}) where {T,V,N} = Dual{T}(one(V), zero(Partials{N,V}))
 
-@inline Base.Int(d::Dual) = Int(value(d))
-@inline Base.Integer(d::Dual) = Integer(value(d))
+@inline function Base.Int(d::Dual)
+    all(iszero, partials(d)) || throw(InexactError(:Int, Int, d))
+    Int(value(d))
+end
+@inline function Base.Integer(d::Dual)
+    all(iszero, partials(d)) || throw(InexactError(:Integer, Integer, d))
+    Integer(value(d))
+end
 
 @inline Random.rand(rng::AbstractRNG, d::Dual) = rand(rng, value(d))
 @inline Random.rand(::Type{Dual{T,V,N}}) where {T,V,N} = Dual{T}(rand(V), zero(Partials{N,V}))

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -305,6 +305,9 @@ end
 @inline Base.one(d::Dual) = one(typeof(d))
 @inline Base.one(::Type{Dual{T,V,N}}) where {T,V,N} = Dual{T}(one(V), zero(Partials{N,V}))
 
+@inline Base.Int(d::Dual) = Int(value(d))
+@inline Base.Integer(d::Dual) = Integer(value(d))
+
 @inline Random.rand(rng::AbstractRNG, d::Dual) = rand(rng, value(d))
 @inline Random.rand(::Type{Dual{T,V,N}}) where {T,V,N} = Dual{T}(rand(V), zero(Partials{N,V}))
 @inline Random.rand(rng::AbstractRNG, ::Type{Dual{T,V,N}}) where {T,V,N} = Dual{T}(rand(rng, V), zero(Partials{N,V}))

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -505,11 +505,16 @@ end
 end
 
 @testset "Integer" begin
-    x = Dual(1.0,1.2)
+    x = Dual(1.0,0)
+    @test Int(x) ≡ Integer(x) ≡ convert(Int,x) ≡ convert(Integer,x) ≡ 1
+    x = Dual(1.0,0,0)
     @test Int(x) ≡ Integer(x) ≡ convert(Int,x) ≡ convert(Integer,x) ≡ 1
     @test_throws InexactError Int(Dual(1.5,1.2))
     @test_throws InexactError Integer(Dual(1.5,1.2))
+    @test_throws InexactError Int(Dual(1,1))
+    @test_throws InexactError Integer(Dual(1,1,2))
     @test length(UnitRange(Dual(1.5), Dual(3.5))) == 3
+    @test length(UnitRange(Dual(1.5,1), Dual(3.5,3))) == 3
 end
 
 end # module

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -504,4 +504,12 @@ end
     @test !isfinite(dinf)
 end
 
+@testset "Integer" begin
+    x = Dual(1.0,1.2)
+    @test Int(x) ≡ Integer(x) ≡ convert(Int,x) ≡ convert(Integer,x) ≡ 1
+    @test_throws InexactError Int(Dual(1.5,1.2))
+    @test_throws InexactError Integer(Dual(1.5,1.2))
+    @test length(UnitRange(Dual(1.5), Dual(3.5))) == 3
+end
+
 end # module


### PR DESCRIPTION
This adds convert routines for integers. I need this to fix the following bug:
```julia
julia> length(UnitRange(Dual(1.0), Dual(2.0)))
ERROR: MethodError: no method matching Integer(::Dual{Nothing, Float64, 0})
Closest candidates are:
  (::Type{T})(::T) where T<:Number at boot.jl:760
  (::Type{T})(::AbstractChar) where T<:Union{AbstractChar, Number} at char.jl:50
  (::Type{T})(::Base.TwicePrecision) where T<:Number at twiceprecision.jl:243
  ...
Stacktrace:
 [1] unsafe_length(r::UnitRange{Dual{Nothing, Float64, 0}})
   @ Base ./range.jl:559
 [2] length(r::UnitRange{Dual{Nothing, Float64, 0}})
   @ Base ./range.jl:561
 [3] top-level scope
   @ REPL[4]:1
```