### PR TITLE
Remove pure function annotation

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -337,7 +337,7 @@ end
 # Promotion/Conversion #
 ########################
 
-Base.@pure function Base.promote_rule(::Type{Dual{T1,V1,N1}},
+function Base.promote_rule(::Type{Dual{T1,V1,N1}},
                                       ::Type{Dual{T2,V2,N2}}) where {T1,V1,N1,T2,V2,N2}
     # V1 and V2 might themselves be Dual types
     if T2 ≺ T1


### PR DESCRIPTION
According to conventional Julia wisdom, the use of `@pure` is a reserved right to Jameson and Jameson only. According to the docs:

>A pure function can only depend on immutable information. This also means a `@pure` function cannot use any global mutable state, including generic functions. Calls to generic functions depend on method tables which are mutable global state. Use with caution, incorrect `@pure` annotation of a function may introduce hard to identify bugs. Double check for calls to generic functions. This macro is intended for internal compiler use and may be subject to changes.

This assumption seems to be violated here. The use of `@pure` can also lead to peculiar compiler failures when normal runtime errors such as stack overflow are encountered. This bit me recently pretty hard.

