### PR TITLE
RFC: Gradient for multiple-argument functions

### DIFF
--- a/docs/src/user/api.md
+++ b/docs/src/user/api.md
@@ -60,3 +60,14 @@ ForwardDiff.GradientConfig
 ForwardDiff.JacobianConfig
 ForwardDiff.HessianConfig
 ```
+
+## Convenience functions for `f(xs::Union{Real, AbstractArray}...)`
+
+For a function accepting multiple arguments, the gradient of `f(xs...)::Real` may be thought of as a tuple with an entry for each argument. 
+Likewise the Jacobain of `f(xs...)::AbstractArray`. There are two convenience functions to compute all these components; 
+they are efficient for scalar `xs` but do not permit all the pre-allocation and configuration of the one-argument methods above.
+
+```@docs
+ForwardDiff.multigrad
+ForwardDiff.multijacobian
+```

--- a/src/ForwardDiff.jl
+++ b/src/ForwardDiff.jl
@@ -20,6 +20,7 @@ include("derivative.jl")
 include("gradient.jl")
 include("jacobian.jl")
 include("hessian.jl")
+include("multi.jl")
 
 export DiffResults
 

--- a/src/multi.jl
+++ b/src/multi.jl
@@ -1,0 +1,65 @@
+"""
+    ForwardDiff.multigrad(f, xs...)
+
+Return a tuple containing the components of the gradient, 
+`∂f/∂x` for each argument `x ∈ xs`. Requires that `f(xs...) isa Real`.
+
+These are arrays for array arguments, using [`gradient`](@ref),
+and numbers for scalar arguments, using [`derivative`](@ref).
+
+Any other type of argument is assumed not to be differentiable, 
+indicated by `nothing`. Any keyword arguments are likewise not 
+differentiated, but are passed to the function: `f(xs...; kw...)`.
+"""
+function multigrad(f, xs...; kw...)
+    ntuple(length(xs)) do i
+        g = y -> f(ntuple(j -> j==i ? y : xs[j], length(xs))...; kw...)
+        x = xs[i]
+        if x isa AbstractArray
+            ForwardDiff.gradient(g, xs[i])
+        elseif x isa Number
+            ForwardDiff.derivative(g, xs[i])
+        else
+            nothing
+        end
+    end
+end
+
+multigrad(f, xs::Real...; kw...) = multigrad(f, promote(xs...)...; kw...)
+
+function multigrad(f, xs::Vararg{T,N}; kw...) where {T<:Real,N}
+    args = ntuple(N) do i
+        Dual(xs[i], ntuple(j -> T(j==i), N))
+    end
+    y = f(args...; kw...)
+    y isa Number || throw(DimensionMismatch(
+        "multigrad(f, xs...) expects that f return a real number. Perhaps you meant multijacobi(f, x)?"))
+    Tuple(partials(y))
+end
+
+"""
+    ForwardDiff.multijacobi(f, xs...)
+
+Return a tuple containing the components of the Jacobian, 
+`∂f/∂x` for each argument `x ∈ xs`. Requires that `f(xs...) isa AbstractArray`.
+
+For array arguments `x` these are matrices, using [`jacobian`](@ref),
+and for scalar arguments they are vectors, using [`vec(derivative(...))`](@ref).
+
+Any other type of argument is assumed not to be differentiable, 
+indicated by `nothing`. Any keyword arguments are likewise not 
+differentiated, but are passed to the function: `f(xs...; kw...)`.
+"""
+function multijacobi(f, xs...; kw...)
+    ntuple(length(xs)) do i
+        g = y -> f(ntuple(j -> j==i ? y : xs[j], length(xs))...; kw...)
+        x = xs[i]
+        if x isa AbstractArray
+            ForwardDiff.jacobian(g, xs[i])
+        elseif x isa Number
+            vec(ForwardDiff.derivative(g, xs[i]))
+        else
+            nothing
+        end
+    end
+end


### PR DESCRIPTION
This adds a convenience function to compute the gradient of `f(xs...)`, viewed as a tuple containing the components belonging to each argument -- the same behaviour as `Zygote.gradient`. And another for the Jacobian.

It would be awkward to specify GradientConfig etc. for such an object, so perhaps these should be seen as convenience functions. (The case when everything is a scalar should be efficient, though.)

Is this a good idea?

One use case is testing things, I think that's why https://github.com/JuliaDiff/FiniteDifferences.jl/pull/26 added a similar multi-arg Jacobian. 

Needs tests, possibly a better implementation (the loop over arguments might produce type instability), probably better names for the functions.