### PR TITLE
Error message contains "expexts"; changed it to expects

### DIFF
--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -197,7 +197,7 @@ end
     return result
 end
 
-const JACOBIAN_ERROR = DimensionMismatch("jacobian(f, x) expexts that f(x) is an array. Perhaps you meant gradient(f, x)?")
+const JACOBIAN_ERROR = DimensionMismatch("jacobian(f, x) expects that f(x) is an array. Perhaps you meant gradient(f, x)?")
 
 # chunk mode #
 #------------#


### PR DESCRIPTION
Typo in argument to JACOBIAN_ERROR DimensionMismatch