### PR TITLE
Overload floatmin, floatmax

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -684,7 +684,7 @@ function Base.show(io::IO, d::Dual{T,V,N}) where {T,V,N}
 end
 
 for op in (:(Base.typemin), :(Base.typemax), :(Base.floatmin), :(Base.floatmax))
-    @eval function Base.typemin(::Type{ForwardDiff.Dual{T,V,N}}) where {T,V,N}
+    @eval function $op(::Type{ForwardDiff.Dual{T,V,N}}) where {T,V,N}
         ForwardDiff.Dual{T,V,N}($op(V))
     end
 end

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -683,12 +683,10 @@ function Base.show(io::IO, d::Dual{T,V,N}) where {T,V,N}
     print(io, ")")
 end
 
-function Base.typemin(::Type{ForwardDiff.Dual{T,V,N}}) where {T,V,N}
-    ForwardDiff.Dual{T,V,N}(typemin(V))
-end
-
-function Base.typemax(::Type{ForwardDiff.Dual{T,V,N}}) where {T,V,N}
-    ForwardDiff.Dual{T,V,N}(typemax(V))
+for op in (:(Base.typemin), :(Base.typemax), :(Base.floatmin), :(Base.floatmax))
+    @eval function Base.typemin(::Type{ForwardDiff.Dual{T,V,N}}) where {T,V,N}
+        ForwardDiff.Dual{T,V,N}($op(V))
+    end
 end
 
 if VERSION >= v"1.6.0-rc1"

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -503,6 +503,14 @@ end
     @test typeof(dinf) === typeof(d1)
     @test !isfinite(dminf)
     @test !isfinite(dinf)
+
+    dfmin = floatmin(typeof(d1))
+    dfmax = floatmax(typeof(d1))
+    @test dfmin < d1 < dfmax
+    @test typeof(dfmin) === typeof(d1)
+    @test typeof(dfmax) === typeof(d1)
+    @test isfinite(dfmin)
+    @test isfinite(dfmax)
 end
 
 @testset "Integer" begin


### PR DESCRIPTION
This is needed to support adaptivity with infinite arrays. 

For a some-what esoteric example, with this PR we can differentiate a renormalized Bessel function from it's 3-term recurrence:
```julia
julia> J̃ = z -> (LazyBandedMatrices.SymTridiagonal(-2*(0:∞)/z, ones(∞)) \ [1; zeros(∞)])[1]
#9 (generic function with 1 method)

julia> J̃(0.5) ≈ besselj(0,0.5)/besselj(1,0.5)
true

julia> derivative(J̃,0.5) ≈ derivative(x -> besselj(0,x)/besselj(1,x), 0.5)
true
```

More interesting examples are adaptively solving ODEs with parameters via spectral methods.