### PR TITLE
Call Random.seed! to avoid inconsistent test failure

### DIFF
--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -14,6 +14,7 @@ import Calculus
 struct TestTag end
 
 samerng() = MersenneTwister(1)
+Random.seed!(132)
 
 # By lower-bounding the Int range at 2, we avoid cases where differentiating an
 # exponentiation of an Int value would cause a DomainError due to reducing the


### PR DESCRIPTION
PR tests sometimes fail, I believe due to floating point errors. See e.g.

https://github.com/JuliaDiff/ForwardDiff.jl/pull/541


This should hopefully fix it.

