### PR TITLE
Fix the documentation badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![CI](https://github.com/JuliaDiff/ForwardDiff.jl/workflows/CI/badge.svg) [![Coverage Status](https://coveralls.io/repos/JuliaDiff/ForwardDiff.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/JuliaDiff/ForwardDiff.jl?branch=master)
 
 [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliadiff.org/ForwardDiff.jl/stable)
-[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://juliadiff.org/ForwardDiff.jl/latest)
+[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliadiff.org/ForwardDiff.jl/dev)
 
 # ForwardDiff.jl
 


### PR DESCRIPTION
The "latest badge" is deprecated.
See https://github.com/JuliaDocs/Documenter.jl/pull/1151.

I've replaced [![](https://img.shields.io/badge/docs-latest-blue.svg)](https://juliadiff.org/ForwardDiff.jl/latest) with [![](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliadiff.org/ForwardDiff.jl/dev).