### PR TITLE
use explicit simd for iszero check on partials

### DIFF
--- a/src/ForwardDiff.jl
+++ b/src/ForwardDiff.jl
@@ -8,6 +8,7 @@ if VERSION >= v"1.6"
 end
 using Random
 using LinearAlgebra
+import SIMD: Vec
 
 import Printf
 import NaNMath


### PR DESCRIPTION
Now:

```asm
julia> code_native(ForwardDiff.iszero_tuple, Tuple{NTuple{4, Float64}}; debuginfo=:none)
        .section        __TEXT,__text,regular,pure_instructions
        vxorpd  %xmm0, %xmm0, %xmm0
        vcmpneqpd       (%rdi), %ymm0, %ymm0
        vmovmskpd       %ymm0, %eax
        testb   %al, %al
        sete    %al
        vzeroupper
        retq
        nopw    %cs:(%rax,%rax)
```

On master:

```asm
julia> code_native(ForwardDiff.iszero_tuple, Tuple{NTuple{4, Float64}}; debuginfo=:none)
        .section        __TEXT,__text,regular,pure_instructions
        vmovsd  (%rdi), %xmm1                   ## xmm1 = mem[0],zero
        vxorpd  %xmm0, %xmm0, %xmm0
        vucomisd        %xmm0, %xmm1
        jne     L46
        jp      L46
        vmovsd  8(%rdi), %xmm1                  ## xmm1 = mem[0],zero
        vucomisd        %xmm0, %xmm1
        jne     L46
        jp      L46
        vmovsd  16(%rdi), %xmm1                 ## xmm1 = mem[0],zero
        vxorpd  %xmm0, %xmm0, %xmm0
        vucomisd        %xmm0, %xmm1
        jne     L46
        jnp     L49
L46:
        xorl    %eax, %eax
        retq
L49:
        vcmpeqsd        24(%rdi), %xmm0, %xmm0
        vmovq   %xmm0, %rax
        andl    $1, %eax
        retq
```