### PR TITLE
WIP/RFC make the partial scalars VecElements

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -68,7 +68,7 @@ end
 @inline Dual{T}(value, partials::Tuple{}) where {T} = Dual{T}(value, Partials{0,typeof(value)}(partials))
 @inline Dual{T}(value) where {T} = Dual{T}(value, ())
 @inline Dual{T}(x::Dual{T}) where {T} = Dual{T}(x, ())
-@inline Dual{T}(value, partial1, partials...) where {T} = Dual{T}(value, tuple(partial1, partials...))
+@inline Dual{T}(value, partial1, partials...) where {T} = Dual{T}(value, tuple(VecElement(partial1), VecElement.(partials)...))
 @inline Dual{T}(value::V, ::Chunk{N}, p::Val{i}) where {T,V,N,i} = Dual{T}(value, single_seed(Partials{N,V}, p))
 @inline Dual(args...) = Dual{Nothing}(args...)
 


### PR DESCRIPTION
Only implemented enough so that the benchmark in https://github.com/JuliaDiff/ForwardDiff.jl/pull/555 can be tested. Putting it up here in case people want to play with it.

Results of the benchmark in #555:

Branch:

```jl
julia> include("/home/kc/JuliaTests/fdiffbench.jl")
  0.818333 seconds (5.35 M allocations: 261.957 MiB, 14.27% gc time, 99.99% compilation time)
  810.158 ns (0 allocations: 0 bytes)
```

PR:

```jl
julia> include("/home/kc/JuliaTests/fdiffbench.jl")
  0.622877 seconds (4.19 M allocations: 216.628 MiB, 7.33% gc time, 99.99% compilation time)
  723.782 ns (0 allocations: 0 bytes)
```


