### PR TITLE
RFC: Shorten tags by using the objectid of the function instead of di…

### DIFF
--- a/src/config.jl
+++ b/src/config.jl
@@ -14,8 +14,8 @@ const TAGCOUNT = Threads.Atomic{UInt}(0)
 end
 
 function Tag(f::F, ::Type{V}) where {F,V}
-    tagcount(Tag{F,V}) # trigger generated function
-    Tag{F,V}()
+    tagcount(Tag{objectid(F),V}) # trigger generated function
+    Tag{objectid(F),V}()
 end
 
 Tag(::Nothing, ::Type{V}) where {V} = nothing


### PR DESCRIPTION
…rectly the function

Right now duals of duals of duals have an exponential growth in the type name because the functions then to have closures which hold values with the values, so as you begin to nest you see the previous nest in the function type (multiple times). This makes the tag always the same size.  `julia> objectid(typeof(f)) #0x0000000006be1dbe`. Now instead of a massive tag you just get a small tag, but it's some essentially random number. But it's not random in the sense of always being different: it is a deterministic hash:

```julia
julia> f(x) = x
f (generic function with 1 method)

julia> objectid(typeof(f))
0x0000000006be1dbe
```

so it plays the same as before with precompilation.  Is this a good idea?