### PR TITLE
Differentiation of eigen(::Symmetric)

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -682,7 +682,7 @@ end
 
 function LinearAlgebra.eigen(A::Symmetric{<:Dual{Tg,T,N}}) where {Tg,T<:Real,N}
     λ = eigvals(A)
-    _,Q = eigen(SymTridiagonal(value.(parent(A).dv),value.(parent(A).ev)))
+    _,Q = eigen(Symmetric(value.(parent(A))))
     parts = ntuple(j -> Q*_lyap_div!(Q' * getindex.(partials.(A), j) * Q - Diagonal(getindex.(partials.(λ), j)), value.(λ)), N)
     Eigen(λ,Dual{Tg}.(Q, tuple.(parts...)))
 end

--- a/test/JacobianTest.jl
+++ b/test/JacobianTest.jl
@@ -235,26 +235,14 @@ end
 @testset "eigen" begin
     @test ForwardDiff.jacobian(x -> eigvals(SymTridiagonal(x, x[1:end-1])), [1.,2.]) ≈ [(1 - 3/sqrt(5))/2 (1 - 1/sqrt(5))/2 ; (1 + 3/sqrt(5))/2 (1 + 1/sqrt(5))/2]
     @test ForwardDiff.jacobian(x -> eigvals(Symmetric(x*x')), [1.,2.]) ≈ [0 0; 2 4]
-
-    function numdiff(f, x, Δ=1.e-5);
-        f0 = f(x);
-        dx = zero(x);
-        res = zeros(length(f0), length(x));
-        for j=1:length(x)
-         fill!(dx, 0)
-         dx[j] = Δ
-         res[:,j] = (f(x+dx)-f(x-dx))/(2Δ)
-        end
-        return res
-    end
-
+    
     x0 = [1.0, 2.0];
     ev1(x) = eigen(Symmetric(x*x')).vectors[:,1]
-    @test ForwardDiff.jacobian(ev1, x0) ≈ numdiff(ev1, x0)
+    @test ForwardDiff.jacobian(ev1, x0) ≈ Calculus.finite_difference_jacobian(ev1, x0)
     ev2(x) = eigen(SymTridiagonal(x, x[1:end-1])).vectors[:,1]
-    @test ForwardDiff.jacobian(ev2, x0) ≈ numdiff(ev2, x0)
+    @test ForwardDiff.jacobian(ev2, x0) ≈ Calculus.finite_difference_jacobian(ev2, x0)
     x0_static = SVector{2}(x0)
-    @test ForwardDiff.jacobian(ev1, x0_static) ≈ numdiff(ev1, x0)
+    @test ForwardDiff.jacobian(ev1, x0_static) ≈ Calculus.finite_difference_jacobian(ev1, x0)
 end
 
 @testset "type stability" begin

--- a/test/JacobianTest.jl
+++ b/test/JacobianTest.jl
@@ -253,6 +253,8 @@ end
     @test ForwardDiff.jacobian(ev1, x0) ≈ numdiff(ev1, x0)
     ev2(x) = eigen(SymTridiagonal(x, x[1:end-1])).vectors[:,1]
     @test ForwardDiff.jacobian(ev2, x0) ≈ numdiff(ev2, x0)
+    x0_static = SVector{2}(x0)
+    @test ForwardDiff.jacobian(ev1, x0_static) ≈ numdif(ev1, x0)
 end
 
 @testset "type stability" begin

--- a/test/JacobianTest.jl
+++ b/test/JacobianTest.jl
@@ -235,6 +235,24 @@ end
 @testset "eigen" begin
     @test ForwardDiff.jacobian(x -> eigvals(SymTridiagonal(x, x[1:end-1])), [1.,2.]) ≈ [(1 - 3/sqrt(5))/2 (1 - 1/sqrt(5))/2 ; (1 + 3/sqrt(5))/2 (1 + 1/sqrt(5))/2]
     @test ForwardDiff.jacobian(x -> eigvals(Symmetric(x*x')), [1.,2.]) ≈ [0 0; 2 4]
+
+    function numdiff(f, x, Δ=1.e-5);
+        f0 = f(x);
+        dx = zero(x);
+        res = zeros(length(f0), length(x));
+        for j=1:length(x)
+         fill!(dx, 0)
+         dx[j] = Δ
+         res[:,j] = (f(x+dx)-f(x-dx))/(2Δ)
+        end
+        return res
+    end
+
+    x0 = [1.0, 2.0];
+    ev1(x) = eigen(Symmetric(x*x')).vectors[:,1]
+    @test ForwardDiff.jacobian(ev1, x0) ≈ numdiff(ev1, x0)
+    ev2(x) = eigen(SymTridiagonal(x, x[1:end-1])).vectors[:,1]
+    @test ForwardDiff.jacobian(ev2, x0) ≈ numdiff(ev2, x0)
 end
 
 @testset "type stability" begin

--- a/test/JacobianTest.jl
+++ b/test/JacobianTest.jl
@@ -254,7 +254,7 @@ end
     ev2(x) = eigen(SymTridiagonal(x, x[1:end-1])).vectors[:,1]
     @test ForwardDiff.jacobian(ev2, x0) ≈ numdiff(ev2, x0)
     x0_static = SVector{2}(x0)
-    @test ForwardDiff.jacobian(ev1, x0_static) ≈ numdif(ev1, x0)
+    @test ForwardDiff.jacobian(ev1, x0_static) ≈ numdiff(ev1, x0)
 end
 
 @testset "type stability" begin


### PR DESCRIPTION
This seemed nicely solved by @dlfivefifty in #513 (Discussed in #111 ), but I  got an error when applying to the `eigen` function and not the `eigvals` functions that was tested.
```julia
f(x) = eigen(Symmetric(x*x')).vectors[:,1];
x0 = [1.,2.];
ForwardDiff.jacobian(f, x0)
ERROR: type Array has no field dv
Stacktrace:
 [1] getproperty
   @ .\Base.jl:42 [inlined]
 [2] eigen(A::Symmetric{ForwardDiff.Dual{ForwardDiff.Tag{typeof(f), Float64}, Float64, 2}, Matrix{ForwardDiff.Dual{ForwardDiff.Tag{typeof(f), Float64}, Float64, 2}}})
   @ ForwardDiff C:\Users\meyer\.julia\packages\ForwardDiff\PBzup\src\dual.jl:685
 [3] f(x::Vector{ForwardDiff.Dual{ForwardDiff.Tag{typeof(f), Float64}, Float64, 2}})
   @ Main .\REPL[37]:1
 [4] vector_mode_dual_eval!(f::typeof(f), cfg::ForwardDiff.JacobianConfig{ForwardDiff.Tag{typeof(f), Float64}, Float64, 2, Vector{ForwardDiff.Dual{ForwardDiff.Tag{typeof(f), Float64}, Float64, 2}}}, x::Vector{Float64})
   @ ForwardDiff C:\Users\meyer\.julia\packages\ForwardDiff\PBzup\src\apiutils.jl:37
 [5] vector_mode_jacobian(f::typeof(f), x::Vector{Float64}, cfg::ForwardDiff.JacobianConfig{ForwardDiff.Tag{typeof(f), Float64}, Float64, 2, Vector{ForwardDiff.Dual{ForwardDiff.Tag{typeof(f), Float64}, Float64, 2}}})   @ ForwardDiff C:\Users\meyer\.julia\packages\ForwardDiff\PBzup\src\jacobian.jl:148
 [6] jacobian(f::Function, x::Vector{Float64}, cfg::ForwardDiff.JacobianConfig{ForwardDiff.Tag{typeof(f), Float64}, Float64, 2, Vector{ForwardDiff.Dual{ForwardDiff.Tag{typeof(f), Float64}, Float64, 2}}}, ::Val{true})   @ ForwardDiff C:\Users\meyer\.julia\packages\ForwardDiff\PBzup\src\jacobian.jl:21
 [7] jacobian(f::Function, x::Vector{Float64}, cfg::ForwardDiff.JacobianConfig{ForwardDiff.Tag{typeof(f), Float64}, Float64, 2, Vector{ForwardDiff.Dual{ForwardDiff.Tag{typeof(f), Float64}, Float64, 2}}}) (repeats 2 times)
   @ ForwardDiff C:\Users\meyer\.julia\packages\ForwardDiff\PBzup\src\jacobian.jl:19
 [8] top-level scope
   @ REPL[39]:1
```

This PR takes the original code suggested in #111, as I think there is a mixup between `SymTridiagonal` and `Symmetric` in the current implementation in master.
Edit: It also enables the differentiation of a Symmetric StaticMatrix. 