### PR TITLE
Fix DiffRules-based definitions for complex-valued functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ForwardDiff"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.25"
+version = "0.10.27"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -421,7 +421,7 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
 
     if V != Int
         for (M, f, arity) in DiffRules.diffrules(filter_modules = nothing)
-            if f in (:hankelh1, :hankelh1x, :hankelh2, :hankelh2x, :/, :rem2pi)
+            if f in (:/, :rem2pi)
                 continue  # Skip these rules
             elseif !(isdefined(@__MODULE__, M) && isdefined(getfield(@__MODULE__, M), f))
                 continue  # Skip rules for methods not defined in the current scope
@@ -438,9 +438,20 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
                 end
                 @eval begin
                     x = rand() + $modifier
-                    dx = $M.$f(Dual{TestTag()}(x, one(x)))
-                    @test value(dx) == $M.$f(x)
-                    @test partials(dx, 1) == $deriv
+                    dx = @inferred $M.$f(Dual{TestTag()}(x, one(x)))
+                    actualval = $M.$f(x)
+                    @assert actualval isa Real || actualval isa Complex
+                    if actualval isa Real
+                        @test dx isa Dual{TestTag()}
+                        @test value(dx) == actualval
+                        @test partials(dx, 1) == $deriv
+                    else
+                        @test dx isa Complex{<:Dual{TestTag()}}
+                        @test value(real(dx)) == real(actualval)
+                        @test value(imag(dx)) == imag(actualval)
+                        @test partials(real(dx), 1) == real($deriv)
+                        @test partials(imag(dx), 1) == imag($deriv)
+                    end
                 end
             elseif arity == 2
                 derivs = DiffRules.diffrule(M, f, :x, :y)
@@ -453,14 +464,31 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
                 end
                 @eval begin
                     x, y = $x, $y
-                    dx = $M.$f(Dual{TestTag()}(x, one(x)), y)
-                    dy = $M.$f(x, Dual{TestTag()}(y, one(y)))
+                    dx = @inferred $M.$f(Dual{TestTag()}(x, one(x)), y)
+                    dy = @inferred $M.$f(x, Dual{TestTag()}(y, one(y)))
                     actualdx = $(derivs[1])
                     actualdy = $(derivs[2])
-                    @test value(dx) == $M.$f(x, y)
-                    @test value(dy) == value(dx)
-                    @test partials(dx, 1) ≈ actualdx nans=true
-                    @test partials(dy, 1) ≈ actualdy nans=true
+                    actualval = $M.$f(x, y)
+                    @assert actualval isa Real || actualval isa Complex
+                    if actualval isa Real
+                        @test dx isa Dual{TestTag()}
+                        @test dy isa Dual{TestTag()}
+                        @test value(dx) == actualval
+                        @test value(dy) == actualval
+                        @test partials(dx, 1) ≈ actualdx nans=true
+                        @test partials(dy, 1) ≈ actualdy nans=true
+                    else
+                        @test dx isa Complex{<:Dual{TestTag()}}
+                        @test dy isa Complex{<:Dual{TestTag()}}
+                        @test real(value(dx)) == real(actualval)
+                        @test real(value(dy)) == real(actualval)
+                        @test imag(value(dx)) == imag(actualval)
+                        @test imag(value(dy)) == imag(actualval)
+                        @test partials(real(dx), 1) ≈ real(actualdx) nans=true
+                        @test partials(real(dy), 1) ≈ real(actualdy) nans=true
+                        @test partials(imag(dx), 1) ≈ imag(actualdx) nans=true
+                        @test partials(imag(dy), 1) ≈ imag(actualdy) nans=true
+                    end
                 end
             end
         end


### PR DESCRIPTION
Currently, complex-valued functions (with real inputs!) for which derivatives are defined in DiffRules don't work with ForwardDiff since the return values for DiffRules-based definitions is enforced to be a `Dual` but should be a `Complex{<:Dual}` in these cases. E.g., the following example fails currently (and is therefore excluded from the tests):
```julia
julia> using ForwardDiff, SpecialFunctions

julia> hankelh1(1, 2.0)
0.5767248077568733 - 0.10703243154093756im

julia> hankelh1(1, ForwardDiff.Dual(2.0))
ERROR: ArgumentError: Cannot create a dual over scalar type Any. If the type behaves as a scalar, define ForwardDiff.can_dual(::Type{Any}) = true.
Stacktrace:
 [1] throw_cannot_dual(V::Type)
   @ ForwardDiff ~/.julia/packages/ForwardDiff/PBzup/src/dual.jl:41
 [2] ForwardDiff.Dual{Nothing, Any, 1}(value::ComplexF64, partials::ForwardDiff.Partials{1, Any})
   @ ForwardDiff ~/.julia/packages/ForwardDiff/PBzup/src/dual.jl:18
 [3] Dual
   @ ~/.julia/packages/ForwardDiff/PBzup/src/dual.jl:60 [inlined]
 [4] Dual
   @ ~/.julia/packages/ForwardDiff/PBzup/src/dual.jl:64 [inlined]
 [5] Dual
   @ ~/.julia/packages/ForwardDiff/PBzup/src/dual.jl:67 [inlined]
 [6] Dual
   @ ~/.julia/packages/ForwardDiff/PBzup/src/dual.jl:71 [inlined]
 [7] hankelh1(x::Int64, y::ForwardDiff.Dual{Nothing, Float64, 0})
   @ ForwardDiff ~/.julia/packages/ForwardDiff/PBzup/src/dual.jl:249
 [8] top-level scope
   @ REPL[9]:1
```

This PR fixes this issue and returns values of type `Complex{<:Dual}` if the primal function value is a `Complex` number. This fixes the example above:
```julia
julia> using ForwardDiff, SpecialFunctions

julia> hankelh1(1, 2.0)
0.5767248077568733 - 0.10703243154093756im

julia> hankelh1(1, ForwardDiff.Dual(2.0))
Dual{Nothing}(0.5767248077568733) - Dual{Nothing}(0.10703243154093756)*im
```