### PR TITLE
Bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ForwardDiff"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.25"
+version = "0.10.26"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"


### PR DESCRIPTION
This PR prepares a new release with https://github.com/JuliaDiff/ForwardDiff.jl/pull/576 which did not update the version number. A new release is required, e.g., by https://github.com/JuliaDiff/ReverseDiff.jl/pull/195.