### PR TITLE
Define `precision` for `Dual`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ForwardDiff"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.25"
+version = "0.10.26"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -262,6 +262,15 @@ Base.copy(d::Dual) = d
 Base.eps(d::Dual) = eps(value(d))
 Base.eps(::Type{D}) where {D<:Dual} = eps(valtype(D))
 
+# We overload Base._precision to support the base keyword in Julia 1.8
+# https://github.com/JuliaLang/julia/pull/42428
+let precision = VERSION >= v"1.8.0-DEV.725" ? :_precision : :precision
+    @eval begin
+        Base.$precision(d::Dual) = Base.$precision(value(d))
+        Base.$precision(::Type{D}) where {D<:Dual} = Base.$precision(valtype(D))
+    end
+end
+
 function Base.nextfloat(d::ForwardDiff.Dual{T,V,N}) where {T,V,N}
     ForwardDiff.Dual{T}(nextfloat(d.value), d.partials)
 end

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -270,7 +270,7 @@ if VERSION < v"1.8.0-DEV.725"
 else
     Base.precision(d::Dual; base::Integer=2) = precision(value(d); base=base)
     function Base.precision(::Type{D}; base::Integer=2) where {D<:Dual}
-        precision(valtype(d); base=base)
+        precision(valtype(D); base=base)
     end
 end
 

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -262,12 +262,15 @@ Base.copy(d::Dual) = d
 Base.eps(d::Dual) = eps(value(d))
 Base.eps(::Type{D}) where {D<:Dual} = eps(valtype(D))
 
-# We overload Base._precision to support the base keyword in Julia 1.8
+# The `base` keyword was added in Julia 1.8:
 # https://github.com/JuliaLang/julia/pull/42428
-let precision = VERSION >= v"1.8.0-DEV.725" ? :_precision : :precision
-    @eval begin
-        Base.$precision(d::Dual) = Base.$precision(value(d))
-        Base.$precision(::Type{D}) where {D<:Dual} = Base.$precision(valtype(D))
+if VERSION < v"1.8.0-DEV.725"
+    Base.precision(d::Dual) = precision(value(d))
+    Base.precision(::Type{D}) where {D<:Dual} = precision(valtype(D))
+else
+    Base.precision(d::Dual; base::Integer=2) = precision(value(d); base=base)
+    function Base.precision(::Type{D}; base::Integer=2) where {D<Dual}
+        precision(valtype(d); base=base)
     end
 end
 

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -269,7 +269,7 @@ if VERSION < v"1.8.0-DEV.725"
     Base.precision(::Type{D}) where {D<:Dual} = precision(valtype(D))
 else
     Base.precision(d::Dual; base::Integer=2) = precision(value(d); base=base)
-    function Base.precision(::Type{D}; base::Integer=2) where {D<Dual}
+    function Base.precision(::Type{D}; base::Integer=2) where {D<:Dual}
         precision(valtype(d); base=base)
     end
 end

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -105,6 +105,17 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
         @test eps(NESTED_FDNUM) === eps(PRIMAL)
         @test eps(typeof(NESTED_FDNUM)) === eps(V)
 
+        @test precision(FDNUM) === precision(PRIMAL)
+        @test precision(typeof(FDNUM)) === precision(V)
+        @test precision(NESTED_FDNUM) === precision(PRIMAL)
+        @test precision(typeof(NESTED_FDNUM)) === precision(V)
+        if VERSION >= v"1.8.0-DEV.725" # https://github.com/JuliaLang/julia/pull/42428
+            @test precision(FDNUM; base=10) === precision(PRIMAL; base=10)
+            @test precision(typeof(FDNUM); base=10) === precision(V; base=10)
+            @test precision(NESTED_FDNUM; base=10) === precision(PRIMAL; base=10)
+            @test precision(typeof(NESTED_FDNUM); base=10) === precision(V; base=10)
+        end
+
         @test floor(Int, FDNUM) === floor(Int, PRIMAL)
         @test floor(Int, FDNUM2) === floor(Int, PRIMAL2)
         @test floor(Int, NESTED_FDNUM) === floor(Int, PRIMAL)


### PR DESCRIPTION
Similar to `eps`, this PR adds an implementation of `precision(::Dual)` and `precision(::Type{<:Dual})`, with support of the `base` keyword argument in Julia 1.8.

This is useful e.g. in LogExpFunctions (https://github.com/JuliaStats/LogExpFunctions.jl/pull/37#issuecomment-1062235555) to define precision-specific branches.