### PR TITLE
Add overloads for fld and cld

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ForwardDiff"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.25"
+version = "0.10.26"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -284,6 +284,10 @@ Base.trunc(d::Dual) = trunc(value(d))
 Base.round(::Type{R}, d::Dual) where {R<:Real} = round(R, value(d))
 Base.round(d::Dual) = round(value(d))
 
+Base.fld(x::Dual, y::Dual) = fld(value(x), value(y))
+
+Base.cld(x::Dual, y::Dual) = cld(value(x), value(y))
+
 if VERSION ≥ v"1.4"
     Base.div(x::Dual, y::Dual, r::RoundingMode) = div(value(x), value(y), r)
 else

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -284,9 +284,9 @@ Base.trunc(d::Dual) = trunc(value(d))
 Base.round(::Type{R}, d::Dual) where {R<:Real} = round(R, value(d))
 Base.round(d::Dual) = round(value(d))
 
-Base.fld(x::Dual, y::Dual) = fld(value(x), value(y))
+Base.fld(x::T, y::T) where {T<:Dual} = fld(value(x), value(y))
 
-Base.cld(x::Dual, y::Dual) = cld(value(x), value(y))
+Base.cld(x::T, y::T) where {T<:Dual} = cld(value(x), value(y))
 
 if VERSION ≥ v"1.4"
     Base.div(x::Dual, y::Dual, r::RoundingMode) = div(value(x), value(y), r)

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -284,9 +284,9 @@ Base.trunc(d::Dual) = trunc(value(d))
 Base.round(::Type{R}, d::Dual) where {R<:Real} = round(R, value(d))
 Base.round(d::Dual) = round(value(d))
 
-Base.fld(x::T, y::T) where {T<:Dual} = fld(value(x), value(y))
+Base.fld(x::Dual, y::Dual) = fld(value(x), value(y))
 
-Base.cld(x::T, y::T) where {T<:Dual} = cld(value(x), value(y))
+Base.cld(x::Dual, y::Dual) = cld(value(x), value(y))
 
 if VERSION ≥ v"1.4"
     Base.div(x::Dual, y::Dual, r::RoundingMode) = div(value(x), value(y), r)

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -137,6 +137,14 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
         @test round(FDNUM2) === round(PRIMAL2)
         @test round(NESTED_FDNUM) === round(PRIMAL)
 
+        @test fld(FDNUM, FDNUM2) === fld(PRIMAL, PRIMAL2)
+        @test fld(FDNUM, PRIMAL2) === fld(PRIMAL, PRIMAL2)
+        @test fld(PRIMAL, FDNUM2) === fld(PRIMAL, PRIMAL2)
+
+        @test cld(FDNUM, FDNUM2) === cld(PRIMAL, PRIMAL2)
+        @test cld(FDNUM, PRIMAL2) === cld(PRIMAL, PRIMAL2)
+        @test cld(PRIMAL, FDNUM2) === cld(PRIMAL, PRIMAL2)
+
         @test div(FDNUM, FDNUM2) === div(PRIMAL, PRIMAL2)
         @test div(FDNUM, PRIMAL2) === div(PRIMAL, PRIMAL2)
         @test div(PRIMAL, FDNUM2) === div(PRIMAL, PRIMAL2)


### PR DESCRIPTION
This PR adds overloads for `fld` and `cld`, which currently throw a `MethodError` on master.