### PR TITLE
DEFAULT_CHUNK_THRESHOLD is configurable via Preferences.jl

### DIFF
--- a/docs/src/user/advanced.md
+++ b/docs/src/user/advanced.md
@@ -84,6 +84,12 @@ julia> @time ForwardDiff.gradient!(out, rosenbrock, x, cfg);
   0.281853 seconds (4 allocations: 160 bytes)
 ```
 
+The underlying heuristic will compute a suitable chunk size smaller or equal
+to the `ForwardDiff.DEFAULT_CHUNK_THRESHOLD` constant. As of ForwardDiff
+v0.10.32 and Julia 1.6, this constant can be configured at load time via
+[Preferences.jl](https://github.com/JuliaPackaging/Preferences.jl) by setting the
+`default_chunk_threshold` value.
+
 If your input dimension is constant across calls, you should explicitly select a chunk size
 rather than relying on ForwardDiff's heuristic. There are two reasons for this. The first is
 that ForwardDiff's heuristic depends only on the input dimension, whereas in reality the

--- a/src/prelude.jl
+++ b/src/prelude.jl
@@ -1,7 +1,9 @@
 @static if VERSION >= v"1.6"
     const NANSAFE_MODE_ENABLED = @load_preference("nansafe_mode", false)
+    const DEFAULT_CHUNK_THRESHOLD = @load_preference("default_chunk_threshold", 12)
 else
     const NANSAFE_MODE_ENABLED = false
+    const DEFAULT_CHUNK_THRESHOLD = 12
 end
 
 const AMBIGUOUS_TYPES = (AbstractFloat, Irrational, Integer, Rational, Real, RoundingMode)
@@ -9,8 +11,6 @@ const AMBIGUOUS_TYPES = (AbstractFloat, Irrational, Integer, Rational, Real, Rou
 const UNARY_PREDICATES = Symbol[:isinf, :isnan, :isfinite, :iseven, :isodd, :isreal, :isinteger]
 
 const BINARY_PREDICATES = Symbol[:isequal, :isless, :<, :>, :(==), :(!=), :(<=), :(>=)]
-
-const DEFAULT_CHUNK_THRESHOLD = 12
 
 struct Chunk{N} end
 


### PR DESCRIPTION
Context: I would like to set the `DEFAULT_CHUNK_THRESHOLD` for a project that uses ForwardDiff.jl through Zygote.jl. Since configuring the chunk size used in `Zygote.forwarddiff` is not supported by the Zygote API, I figured it may be okay to just expose this as a preference here.