### PR TITLE
Support complex output in `derivative`

### DIFF
--- a/test/DerivativeTest.jl
+++ b/test/DerivativeTest.jl
@@ -100,4 +100,8 @@ end
     @test_throws DimensionMismatch ForwardDiff.derivative(sum, fill(2pi, 3))
 end
 
+@testset "complex output" begin
+    @test ForwardDiff.derivative(x -> (1+im)*x, 0) == (1+im)
+end
+
 end # module


### PR DESCRIPTION
This allows the differentiation of real->complex functions, which is unambiguous and not tricky (unlike complex->something)