### PR TITLE
Complex Partials, Real to Complex Jacobian

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -112,6 +112,9 @@ end
     end
 end
 
+@inline partials(z::Complex{TD}) where {TD <: Dual} = real(z).partials + im*imag(z).partials
+@inline Base.@propagate_inbounds partials(z::Complex{TD}, i) where {TD} = real(z).partials[i] + im*imag(z).partials[i]
+
 
 @inline npartials(::Dual{T,V,N}) where {T,V,N} = N
 @inline npartials(::Type{Dual{T,V,N}}) where {T,V,N} = N
@@ -123,6 +126,8 @@ end
 @inline valtype(::Type{V}) where {V} = V
 @inline valtype(::Dual{T,V,N}) where {T,V,N} = V
 @inline valtype(::Type{Dual{T,V,N}}) where {T,V,N} = V
+@inline valtype(::Complex{Dual{T,V,N}}) where {T,V,N} = complex(V)
+@inline valtype(::Type{Complex{Dual{T,V,N}}}) where {T,V,N} = complex(V)
 
 @inline tagtype(::V) where {V} = Nothing
 @inline tagtype(::Type{V}) where {V} = Nothing

--- a/test/JacobianTest.jl
+++ b/test/JacobianTest.jl
@@ -242,4 +242,41 @@ end
     @inferred ForwardDiff.jacobian(g!, [1.0], [0.0])
 end
 
+##########################################
+# test specialized R^n -> C^m            #
+##########################################
+
+g(x) = [
+    x[1]^2 + im*x[2], 
+    im*x[1]^2 - x[2], 
+    x[1] * x[2] * im
+    ]
+
+x_in = randn(2)
+
+J = [
+    2*x_in[1] im; 
+    2*im*x_in[1] -1; 
+    x_in[2]*im x_in[1]*im
+    ]
+
+@testset "Real -> Complex Jacobian, No Chunking" begin
+    @test ForwardDiff.jacobian(g, x_in) == J
+
+    J_out = zeros(complex(eltype(x_in)), (3, 2))
+    ForwardDiff.jacobian!(J_out, g, x_in)
+    @test J_out == J
+end
+
+for c in 1:2
+    @testset "Chunked Real -> Complex Jacobian, Chunk = $c" begin
+        cfg = ForwardDiff.JacobianConfig(g, x_in, ForwardDiff.Chunk(c))
+        @test ForwardDiff.jacobian(g, x_in, cfg) == J
+
+        J_out = zeros(complex(eltype(x_in)), (3, 2))
+        ForwardDiff.jacobian!(J_out, g, x_in, cfg)
+        @test J_out == J
+    end
+end
+
 end # module

--- a/test/PartialsTest.jl
+++ b/test/PartialsTest.jl
@@ -7,7 +7,7 @@ using ForwardDiff: Partials
 
 samerng() = MersenneTwister(1)
 
-for N in (0, 3), T in (Int, Float32, Float64)
+for N in (0, 3), T in (Int, Float32, Float64, ComplexF32, ComplexF64)
     println("  ...testing Partials{$N,$T}")
 
     VALUES = (rand(T,N)...,)


### PR DESCRIPTION
This implements the `Partials` arithmetic with `Complex` numbers in addition to `Real`, and enables the retrieval of `partials` from `Complex{<:Dual}` numbers. 

A direct consequence of these changes is that `jacobian(f, x)` where `f` maps from R^n -> C^m works, as well as the in-place variation `jacobian!`. 

Tests are still passing and none of the differentiation methods (`gradient, jacobian, hessian`) were modified. Are there any problems generalizing the `Partials` arithmetic as I've done? My concern is that there may be some `Dual` methods which should be supported for full generality, but my local tests haven't uncovered any of them.