### PR TITLE
Add definition for `logabsgamma`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ForwardDiff"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.28"
+version = "0.10.29"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ForwardDiff"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.29"
+version = "0.10.30"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -742,6 +742,15 @@ function LinearAlgebra.eigen(A::SymTridiagonal{<:Dual{Tg,T,N}}) where {Tg,T<:Rea
     Eigen(λ,Dual{Tg}.(Q, tuple.(parts...)))
 end
 
+# SpecialFunctions.logabsgamma           #
+# Derivative is not defined in DiffRules #
+#----------------------------------------#
+
+function SpecialFunctions.logabsgamma(d::Dual{T,<:Real}) where {T}
+    x = value(d)
+    y, s = SpecialFunctions.logabsgamma(x)
+    return (Dual{T}(y, SpecialFunctions.digamma(x) * partials(d)), s)
+end
 
 ###################
 # Pretty Printing #

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -540,7 +540,8 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
         @test dual_isapprox(f(PRIMAL, PRIMAL2, FDNUM3), Dual{TestTag()}(f(PRIMAL, PRIMAL2, PRIMAL3), PARTIALS3))
     end
 
-    @test all(map(dual_isapprox, logabsgamma(FDNUM), (loggamma(abs(FDNUM)), sign(gamma(FDNUM)))))
+    @test dual_isapprox(logabsgamma(FDNUM)[1], loggamma(abs(FDNUM)))
+    @test dual_isapprox(logabsgamma(FDNUM)[2], sign(gamma(FDNUM)))
 end
 
 @testset "Exponentiation of zero" begin

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -539,6 +539,8 @@ for N in (0,3), M in (0,4), V in (Int, Float32)
         @test dual_isapprox(f(FDNUM, PRIMAL2, PRIMAL3), Dual{TestTag()}(f(PRIMAL, PRIMAL2, PRIMAL3), PRIMAL2*PARTIALS))
         @test dual_isapprox(f(PRIMAL, PRIMAL2, FDNUM3), Dual{TestTag()}(f(PRIMAL, PRIMAL2, PRIMAL3), PARTIALS3))
     end
+
+    @test all(map(dual_isapprox, logabsgamma(FDNUM), (loggamma(abs(FDNUM)), sign(gamma(FDNUM)))))
 end
 
 @testset "Exponentiation of zero" begin


### PR DESCRIPTION
This PR adds a definition of `SpecialFunctions.logabsgamma(::Dual)`. SpecialFunctions is a dependency of ForwardDiff already, and in constrast to most other functions in SpecialFunctions derivatives of `logabsgamma` can't be defined via DiffRules since `logabsgamma` is not a real-valued function but returns a tuple `(log(abs(gamma(x)), sign(gamma(x)))`.