### PR TITLE
Forbid offsets

### DIFF
--- a/src/ForwardDiff.jl
+++ b/src/ForwardDiff.jl
@@ -8,7 +8,7 @@ if VERSION >= v"1.6"
 end
 using Random
 using LinearAlgebra
-
+using Base: require_one_based_indexing
 import Printf
 import NaNMath
 import SpecialFunctions

--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -24,6 +24,7 @@ Set `check` to `Val{false}()` to disable tag checking. This can lead to perturba
 """
 @inline function derivative(f!, y::AbstractArray, x::Real,
                             cfg::DerivativeConfig{T} = DerivativeConfig(f!, y, x), ::Val{CHK}=Val{true}()) where {T, CHK}
+    require_one_based_indexing(y)
     CHK && checktag(T, f!, x)
     ydual = cfg.duals
     seed!(ydual, y)
@@ -42,6 +43,7 @@ This method assumes that `isa(f(x), Union{Real,AbstractArray})`.
 """
 @inline function derivative!(result::Union{AbstractArray,DiffResult},
                              f::F, x::R) where {F,R<:Real}
+    require_one_based_indexing(result)
     T = typeof(Tag(f, R))
     ydual = f(Dual{T}(x, one(x)))
     result = extract_value!(T, result, ydual)
@@ -60,6 +62,7 @@ Set `check` to `Val{false}()` to disable tag checking. This can lead to perturba
 @inline function derivative!(result::Union{AbstractArray,DiffResult},
                              f!, y::AbstractArray, x::Real,
                              cfg::DerivativeConfig{T} = DerivativeConfig(f!, y, x), ::Val{CHK}=Val{true}()) where {T, CHK}
+    require_one_based_indexing(result, y)
     CHK && checktag(T, f!, x)
     ydual = cfg.duals
     seed!(ydual, y)

--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -43,7 +43,7 @@ This method assumes that `isa(f(x), Union{Real,AbstractArray})`.
 """
 @inline function derivative!(result::Union{AbstractArray,DiffResult},
                              f::F, x::R) where {F,R<:Real}
-    require_one_based_indexing(result)
+    result isa DiffResult || require_one_based_indexing(result)
     T = typeof(Tag(f, R))
     ydual = f(Dual{T}(x, one(x)))
     result = extract_value!(T, result, ydual)
@@ -62,7 +62,7 @@ Set `check` to `Val{false}()` to disable tag checking. This can lead to perturba
 @inline function derivative!(result::Union{AbstractArray,DiffResult},
                              f!, y::AbstractArray, x::Real,
                              cfg::DerivativeConfig{T} = DerivativeConfig(f!, y, x), ::Val{CHK}=Val{true}()) where {T, CHK}
-    require_one_based_indexing(result, y)
+    result isa DiffResult ? require_one_based_indexing(y) : require_one_based_indexing(result, y)
     CHK && checktag(T, f!, x)
     ydual = cfg.duals
     seed!(ydual, y)

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -33,7 +33,7 @@ This method assumes that `isa(f(x), Real)`.
 
 """
 function gradient!(result::Union{AbstractArray,DiffResult}, f::F, x::AbstractArray, cfg::GradientConfig{T} = GradientConfig(f, x), ::Val{CHK}=Val{true}()) where {T, CHK, F}
-    require_one_based_indexing(result, x)
+    result isa DiffResult ? require_one_based_indexing(x) : require_one_based_indexing(result, x)
     CHK && checktag(T, f, x)
     if chunksize(cfg) == length(x)
         vector_mode_gradient!(result, f, x, cfg)

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -14,6 +14,7 @@ This method assumes that `isa(f(x), Real)`.
 Set `check` to `Val{false}()` to disable tag checking. This can lead to perturbation confusion, so should be used with care.
 """
 function gradient(f, x::AbstractArray, cfg::GradientConfig{T} = GradientConfig(f, x), ::Val{CHK}=Val{true}()) where {T, CHK}
+    require_one_based_indexing(x)
     CHK && checktag(T, f, x)
     if chunksize(cfg) == length(x)
         return vector_mode_gradient(f, x, cfg)
@@ -32,6 +33,7 @@ This method assumes that `isa(f(x), Real)`.
 
 """
 function gradient!(result::Union{AbstractArray,DiffResult}, f::F, x::AbstractArray, cfg::GradientConfig{T} = GradientConfig(f, x), ::Val{CHK}=Val{true}()) where {T, CHK, F}
+    require_one_based_indexing(result, x)
     CHK && checktag(T, f, x)
     if chunksize(cfg) == length(x)
         vector_mode_gradient!(result, f, x, cfg)

--- a/src/hessian.jl
+++ b/src/hessian.jl
@@ -12,6 +12,7 @@ This method assumes that `isa(f(x), Real)`.
 Set `check` to `Val{false}()` to disable tag checking. This can lead to perturbation confusion, so should be used with care.
 """
 function hessian(f, x::AbstractArray, cfg::HessianConfig{T} = HessianConfig(f, x), ::Val{CHK}=Val{true}()) where {T,CHK}
+    require_one_based_indexing(x)
     CHK && checktag(T, f, x)
     ∇f = y -> gradient(f, y, cfg.gradient_config, Val{false}())
     return jacobian(∇f, x, cfg.jacobian_config, Val{false}())
@@ -28,6 +29,7 @@ This method assumes that `isa(f(x), Real)`.
 Set `check` to `Val{false}()` to disable tag checking. This can lead to perturbation confusion, so should be used with care.
 """
 function hessian!(result::AbstractArray, f, x::AbstractArray, cfg::HessianConfig{T} = HessianConfig(f, x), ::Val{CHK}=Val{true}()) where {T,CHK}
+    require_one_based_indexing(result, x)
     CHK && checktag(T, f, x)
     ∇f = y -> gradient(f, y, cfg.gradient_config, Val{false}())
     jacobian!(result, ∇f, x, cfg.jacobian_config, Val{false}())
@@ -62,6 +64,7 @@ because `isa(result, DiffResult)`, `cfg` is constructed as `HessianConfig(f, res
 Set `check` to `Val{false}()` to disable tag checking. This can lead to perturbation confusion, so should be used with care.
 """
 function hessian!(result::DiffResult, f, x::AbstractArray, cfg::HessianConfig{T} = HessianConfig(f, result, x), ::Val{CHK}=Val{true}()) where {T,CHK}
+    require_one_based_indexing(x)
     CHK && checktag(T, f, x)
     ∇f! = InnerGradientForHess(result, cfg, f)
     jacobian!(DiffResults.hessian(result), ∇f!, DiffResults.gradient(result), x, cfg.jacobian_config, Val{false}())

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -55,7 +55,7 @@ This method assumes that `isa(f(x), AbstractArray)`.
 Set `check` to `Val{false}()` to disable tag checking. This can lead to perturbation confusion, so should be used with care.
 """
 function jacobian!(result::Union{AbstractArray,DiffResult}, f, x::AbstractArray, cfg::JacobianConfig{T} = JacobianConfig(f, x), ::Val{CHK}=Val{true}()) where {T, CHK}
-    require_one_based_indexing(result, x)
+    result isa DiffResult ? require_one_based_indexing(x) : require_one_based_indexing(result, x)
     CHK && checktag(T, f, x)
     if chunksize(cfg) == length(x)
         vector_mode_jacobian!(result, f, x, cfg)
@@ -76,7 +76,7 @@ This method assumes that `isa(f(x), AbstractArray)`.
 Set `check` to `Val{false}()` to disable tag checking. This can lead to perturbation confusion, so should be used with care.
 """
 function jacobian!(result::Union{AbstractArray,DiffResult}, f!, y::AbstractArray, x::AbstractArray, cfg::JacobianConfig{T} = JacobianConfig(f!, y, x), ::Val{CHK}=Val{true}()) where {T,CHK}
-    require_one_based_indexing(result, y, x)
+    result isa DiffResult ? require_one_based_indexing(y, x) : require_one_based_indexing(result, y, x)
     CHK && checktag(T, f!, x)
     if chunksize(cfg) == length(x)
         vector_mode_jacobian!(result, f!, y, x, cfg)

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -16,6 +16,7 @@ This method assumes that `isa(f(x), AbstractArray)`.
 Set `check` to `Val{false}()` to disable tag checking. This can lead to perturbation confusion, so should be used with care.
 """
 function jacobian(f, x::AbstractArray, cfg::JacobianConfig{T} = JacobianConfig(f, x), ::Val{CHK}=Val{true}()) where {T,CHK}
+    require_one_based_indexing(x)
     CHK && checktag(T, f, x)
     if chunksize(cfg) == length(x)
         return vector_mode_jacobian(f, x, cfg)
@@ -33,6 +34,7 @@ stored in `y`.
 Set `check` to `Val{false}()` to disable tag checking. This can lead to perturbation confusion, so should be used with care.
 """
 function jacobian(f!, y::AbstractArray, x::AbstractArray, cfg::JacobianConfig{T} = JacobianConfig(f!, y, x), ::Val{CHK}=Val{true}()) where {T, CHK}
+    require_one_based_indexing(y, x)
     CHK && checktag(T, f!, x)
     if chunksize(cfg) == length(x)
         return vector_mode_jacobian(f!, y, x, cfg)
@@ -53,6 +55,7 @@ This method assumes that `isa(f(x), AbstractArray)`.
 Set `check` to `Val{false}()` to disable tag checking. This can lead to perturbation confusion, so should be used with care.
 """
 function jacobian!(result::Union{AbstractArray,DiffResult}, f, x::AbstractArray, cfg::JacobianConfig{T} = JacobianConfig(f, x), ::Val{CHK}=Val{true}()) where {T, CHK}
+    require_one_based_indexing(result, x)
     CHK && checktag(T, f, x)
     if chunksize(cfg) == length(x)
         vector_mode_jacobian!(result, f, x, cfg)
@@ -73,6 +76,7 @@ This method assumes that `isa(f(x), AbstractArray)`.
 Set `check` to `Val{false}()` to disable tag checking. This can lead to perturbation confusion, so should be used with care.
 """
 function jacobian!(result::Union{AbstractArray,DiffResult}, f!, y::AbstractArray, x::AbstractArray, cfg::JacobianConfig{T} = JacobianConfig(f!, y, x), ::Val{CHK}=Val{true}()) where {T,CHK}
+    require_one_based_indexing(result, y, x)
     CHK && checktag(T, f!, x)
     if chunksize(cfg) == length(x)
         vector_mode_jacobian!(result, f!, y, x, cfg)

--- a/src/prelude.jl
+++ b/src/prelude.jl
@@ -70,9 +70,3 @@ function qualified_cse!(expr)
     end
     return cse_expr
 end
-
-# This allows us to call `Base.require_one_based_indexing` in `gradient!` etc:
-Base.has_offset_axes(::DiffResults.DiffResult) = false
-# And this is only needed for VERSION < v"1.2"
-require_one_based_indexing(A...) = !Base.has_offset_axes(A...) || throw(ArgumentError(
-    "offset arrays are not supported but got an array with index other than 1"))

--- a/src/prelude.jl
+++ b/src/prelude.jl
@@ -70,3 +70,9 @@ function qualified_cse!(expr)
     end
     return cse_expr
 end
+
+# This allows us to call `Base.require_one_based_indexing` in `gradient!` etc:
+Base.has_offset_axes(::DiffResults.DiffResult) = false
+# And this is only needed for VERSION < v"1.2"
+require_one_based_indexing(A...) = !Base.has_offset_axes(A...) || throw(ArgumentError(
+    "offset arrays are not supported but got an array with index other than 1"))


### PR DESCRIPTION
This follows LinearAlgebra in explicitly forbidding offset arrays. They don't work anyway, but this replaces a BoundsError with something deliberate:
```julia
julia> ForwardDiff.gradient(sum, OffsetArray([1,2,3], 3))  # before
ERROR: BoundsError: attempt to access 3-element OffsetArray(::Vector{Dual{ForwardDiff.Tag{typeof(sum), Int64}, Int64, 3}}, 4:6) with eltype Dual{ForwardDiff.Tag{typeof(sum), Int64}, Int64, 3} with indices 4:6 at index [1:3]
Stacktrace:
  [1] throw_boundserror(A::OffsetVector{Dual{ForwardDiff.Tag{typeof(sum), Int64}, Int64, 3}, Vector{Dual{ForwardDiff.Tag{typeof(sum), Int64}, Int64, 3}}}, I::Tuple{UnitRange{Int64}})
    @ Base ./abstractarray.jl:703
  [2] checkbounds
    @ ./abstractarray.jl:668 [inlined]
  [3] view
    @ ./subarray.jl:177 [inlined]
  [4] maybeview
    @ ./views.jl:148 [inlined]
  [5] dotview
    @ ./broadcast.jl:1201 [inlined]
  [6] seed!(duals::OffsetVector{Dual{ForwardDiff.Tag{typeof(sum), Int64}, Int64, 3}, Vector{Dual{ForwardDiff.Tag{typeof(sum), Int64}, Int64, 3}}}, x::OffsetVector{Int64, Vector{Int64}}, seeds::Tuple{ForwardDiff.Partials{3, Int64}, ForwardDiff.Partials{3, Int64}, ForwardDiff.Partials{3, Int64}})
    @ ForwardDiff ~/.julia/dev/ForwardDiff/src/apiutils.jl:65
  [7] vector_mode_dual_eval!
    @ ~/.julia/dev/ForwardDiff/src/apiutils.jl:36 [inlined]
  [8] vector_mode_gradient(f::typeof(sum), x::OffsetVector{Int64, Vector{Int64}}, cfg::ForwardDiff.GradientConfig{ForwardDiff.Tag{typeof(sum), Int64}, Int64, 3, OffsetVector{Dual{ForwardDiff.Tag{typeof(sum), Int64}, Int64, 3}, Vector{Dual{ForwardDiff.Tag{typeof(sum), Int64}, Int64, 3}}}})
    @ ForwardDiff ~/.julia/dev/ForwardDiff/src/gradient.jl:106
  [9] gradient(f::Function, x::OffsetVector{Int64, Vector{Int64}}, cfg::ForwardDiff.GradientConfig{ForwardDiff.Tag{typeof(sum), Int64}, Int64, 3, OffsetVector{Dual{ForwardDiff.Tag{typeof(sum), Int64}, Int64, 3}, Vector{Dual{ForwardDiff.Tag{typeof(sum), Int64}, Int64, 3}}}}, ::Val{true})
    @ ForwardDiff ~/.julia/dev/ForwardDiff/src/gradient.jl:0
 [10] gradient(f::Function, x::OffsetVector{Int64, Vector{Int64}}, cfg::ForwardDiff.GradientConfig{ForwardDiff.Tag{typeof(sum), Int64}, Int64, 3, OffsetVector{Dual{ForwardDiff.Tag{typeof(sum), Int64}, Int64, 3}, Vector{Dual{ForwardDiff.Tag{typeof(sum), Int64}, Int64, 3}}}}) (repeats 2 times)
    @ ForwardDiff ~/.julia/dev/ForwardDiff/src/gradient.jl:17
 [11] top-level scope
    @ REPL[162]:1

julia> ForwardDiff.gradient(sum, OffsetArray([1,2,3], 3))  # after
ERROR: ArgumentError: offset arrays are not supported but got an array with index other than 1
```