### PR TITLE
dual exponent

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -332,6 +332,8 @@ Base.fld(x::Dual, y::Dual) = fld(value(x), value(y))
 
 Base.cld(x::Dual, y::Dual) = cld(value(x), value(y))
 
+Base.exponent(x::Dual) = exponent(value(x))
+
 if VERSION ≥ v"1.4"
     Base.div(x::Dual, y::Dual, r::RoundingMode) = div(value(x), value(y), r)
 else

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -242,7 +242,7 @@ ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
     @test ForwardDiff.isconstant(one(NESTED_FDNUM))
     @test ForwardDiff.isconstant(NESTED_FDNUM) == (N == 0)
 
-    # Recall that FDNUM = Dual{TestTag()}(PRIMAL, PARTIALS) has N partials,
+    # Recall that FDNUM = Dual{TestTag()}(PRIMAL, PARTIALS) has N partials, 
     # and FDNUM2 has everything with a 2, and all random numbers nonzero.
     # M is the length of M_PARTIALS, which affects:
     # NESTED_FDNUM = Dual{TestTag()}(Dual{TestTag()}(PRIMAL, M_PARTIALS), NESTED_PARTIALS)
@@ -254,12 +254,12 @@ ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
     if PRIMAL == PRIMAL2
         @test isequal(FDNUM, Dual{TestTag()}(PRIMAL, PARTIALS2)) == (PARTIALS == PARTIALS2)
         @test isequal(FDNUM, FDNUM2) == (PARTIALS == PARTIALS2)
-
+        
         @test (FDNUM == FDNUM2) == (PARTIALS == PARTIALS2)
         @test (NESTED_FDNUM == NESTED_FDNUM2) == ((M_PARTIALS == M_PARTIALS2) && (NESTED_PARTIALS == NESTED_PARTIALS2))
     else
         @test !isequal(FDNUM, FDNUM2)
-
+        
         @test FDNUM != FDNUM2
         @test NESTED_FDNUM != NESTED_FDNUM2
     end

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -44,7 +44,7 @@ ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
     PARTIALS3 = Partials{N,V}(ntuple(n -> intrand(V), N))
     PRIMAL3 = intrand(V)
     FDNUM3 = Dual{TestTag()}(PRIMAL3, PARTIALS3)
-    
+
     if !allunique([PRIMAL, PRIMAL2, PRIMAL3])
         @info "testing with non-unique primals" PRIMAL PRIMAL2 PRIMAL3
     end
@@ -162,6 +162,10 @@ ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
         @test fld(FDNUM, PRIMAL2) === fld(PRIMAL, PRIMAL2)
         @test fld(PRIMAL, FDNUM2) === fld(PRIMAL, PRIMAL2)
 
+        @test exponent(FDNUM) === exponent(PRIMAL)
+        @test exponent(FDNUM2) === exponent(PRIMAL2)
+        @test exponent(NESTED_FDNUM) === exponent(PRIMAL)
+
         @test cld(FDNUM, FDNUM2) === cld(PRIMAL, PRIMAL2)
         @test cld(FDNUM, PRIMAL2) === cld(PRIMAL, PRIMAL2)
         @test cld(PRIMAL, FDNUM2) === cld(PRIMAL, PRIMAL2)
@@ -238,7 +242,7 @@ ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
     @test ForwardDiff.isconstant(one(NESTED_FDNUM))
     @test ForwardDiff.isconstant(NESTED_FDNUM) == (N == 0)
 
-    # Recall that FDNUM = Dual{TestTag()}(PRIMAL, PARTIALS) has N partials, 
+    # Recall that FDNUM = Dual{TestTag()}(PRIMAL, PARTIALS) has N partials,
     # and FDNUM2 has everything with a 2, and all random numbers nonzero.
     # M is the length of M_PARTIALS, which affects:
     # NESTED_FDNUM = Dual{TestTag()}(Dual{TestTag()}(PRIMAL, M_PARTIALS), NESTED_PARTIALS)
@@ -250,12 +254,12 @@ ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
     if PRIMAL == PRIMAL2
         @test isequal(FDNUM, Dual{TestTag()}(PRIMAL, PARTIALS2)) == (PARTIALS == PARTIALS2)
         @test isequal(FDNUM, FDNUM2) == (PARTIALS == PARTIALS2)
-        
+
         @test (FDNUM == FDNUM2) == (PARTIALS == PARTIALS2)
         @test (NESTED_FDNUM == NESTED_FDNUM2) == ((M_PARTIALS == M_PARTIALS2) && (NESTED_PARTIALS == NESTED_PARTIALS2))
     else
         @test !isequal(FDNUM, FDNUM2)
-        
+
         @test FDNUM != FDNUM2
         @test NESTED_FDNUM != NESTED_FDNUM2
     end
@@ -414,7 +418,7 @@ ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
     #----------#
 
     if M > 0 && N > 0
-        # Recall that FDNUM = Dual{TestTag()}(PRIMAL, PARTIALS) has N partials, 
+        # Recall that FDNUM = Dual{TestTag()}(PRIMAL, PARTIALS) has N partials,
         # all random numbers nonzero, and FDNUM2 another draw. M only affects NESTED_FDNUM.
         @test Dual{1}(FDNUM) / Dual{1}(PRIMAL) === Dual{1}(FDNUM / PRIMAL)
         @test Dual{1}(PRIMAL) / Dual{1}(FDNUM) === Dual{1}(PRIMAL / FDNUM)


### PR DESCRIPTION
This issue came up in https://github.com/FluxML/Zygote.jl/pull/1324#issuecomment-1311196153. 

The problem is that on Julia 1.6, the GPU was sensing it could hit a code branch where `exponent(::Dual)` was being called, and unfortunately, `exponent(::Dual)` does not exist, so the GPU threw a dynamic call error and gave up. This pull request fixes this.

Solving this problem is pretty easy since exponent: Real --> Int function, so you can take a similar path compared to `trunc` and define the Dual argument to return the primal value, which I did.