### PR TITLE
Version 0.11

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,16 +16,16 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-Calculus = "0.2, 0.3, 0.4, 0.5"
+Calculus = "0.5"
 CommonSubexpressions = "0.3"
-DiffResults = "0.0.1, 0.0.2, 0.0.3, 0.0.4, 1.0.1"
-DiffRules = "1.4.0"
-DiffTests = "0.0.1, 0.1"
+DiffResults = "1.1"
+DiffRules = "1.4"
+DiffTests = "0.1"
 LogExpFunctions = "0.3"
-NaNMath = "0.2.2, 0.3, 1"
+NaNMath = "1"
 Preferences = "1"
-SpecialFunctions = "0.8, 0.9, 0.10, 1.0, 2"
-StaticArrays = "0.8.3, 0.9, 0.10, 0.11, 0.12, 1.0"
+SpecialFunctions = "1, 2"
+StaticArrays = "1.5"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ForwardDiff"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.33"
+version = "0.11-DEV"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"
@@ -26,7 +26,7 @@ NaNMath = "0.2.2, 0.3, 1"
 Preferences = "1"
 SpecialFunctions = "0.8, 0.9, 0.10, 1.0, 2"
 StaticArrays = "0.8.3, 0.9, 0.10, 0.11, 0.12, 1.0"
-julia = "1"
+julia = "1.6"
 
 [extras]
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"


### PR DESCRIPTION
After https://github.com/JuliaRegistries/General/pull/73304 we should probably tag changes as 0.11.

This PR just updates the version number. It drops Julia 1.0 to enable #599 without further surprises.  

We may wish to include other things in 0.11:
* `<=` as in #609
* `isinteger` and friends: https://github.com/JuliaDiff/ForwardDiff.jl/pull/481#issuecomment-1171251680
* Any of this list: https://github.com/JuliaDiff/ForwardDiff.jl/pull/481#discussion_r866863465