### PR TITLE
Make duals' operations through steprange use linrange instead

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -775,6 +775,17 @@ function LinearAlgebra.eigen(A::SymTridiagonal{<:Dual{Tg,T,N}}) where {Tg,T<:Rea
     Eigen(λ,Dual{Tg}.(Q, tuple.(parts...)))
 end
 
+# StepRange - default to operate with LinRange to avoid TwicePrecision #
+#----------------------------------------------------------------------#
+
+Base.:*(x::Dual, r::StepRangeLen{<:Real,<:Base.TwicePrecision}) =
+    LinRange(x * first(r), x * last(r), length(r))
+
+Base.:/(r::StepRangeLen{<:Real,<:Base.TwicePrecision}, x::Dual) =
+    LinRange(first(r) / x, last(r) / x, length(r))
+
+Base.:(:)(start::T, step::Dual, stop::T) where {T<:Real} = range(start, step, stop)
+
 # Functions in SpecialFunctions which return tuples #
 # Their derivatives are not defined in DiffRules    #
 #---------------------------------------------------#

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -659,4 +659,13 @@ end
     @test ForwardDiff.derivative(float, 1)::Float64 === 1.0
 end
 
+@testset "steprange" begin # issue #380
+    @test Dual(1,1) * (0:0.1:1) isa LinRange{Dual{Nothing, Float64, 1}, Int64}
+    @test (0:0.1:1) / Dual(1,1) isa LinRange{Dual{Nothing, Float64, 1}, Int64}
+    @test 0:Dual(1,1):2 isa LinRange{Dual{Nothing, Float64, 1}, Int64}
+end
+
+
+
+
 end # module


### PR DESCRIPTION
Trying to solve https://github.com/JuliaDiff/ForwardDiff.jl/issues/380.
Does not fix the "show" ambiguity.
A bit naively done, please review and advise if there's anything that needs to be done differently.