### PR TITLE
Add a copy method for GradientConfig.

### DIFF
--- a/src/config.jl
+++ b/src/config.jl
@@ -106,7 +106,8 @@ Return a `GradientConfig` instance based on the type of `f` and type/shape of th
 vector `x`.
 
 The returned `GradientConfig` instance contains all the work buffers required by
-`ForwardDiff.gradient` and `ForwardDiff.gradient!`.
+`ForwardDiff.gradient` and `ForwardDiff.gradient!`. For multi-threaded applications, you can
+use `Base.copy` to make a copy with new work buffers.
 
 If `f` is `nothing` instead of the actual target function, then the returned instance can
 be used with any target function. However, this will reduce ForwardDiff's ability to catch
@@ -121,6 +122,12 @@ function GradientConfig(f::F,
     seeds = construct_seeds(Partials{N,V})
     duals = similar(x, Dual{T,V,N})
     return GradientConfig{T,V,N,typeof(duals)}(seeds, duals)
+end
+
+function Base.copy(gradient_config::GradientConfig{T,V,N,D}) where {T,V,N,D}
+    seeds = construct_seeds(Partials{N,V})
+    duals = similar(gradient_config.duals)
+    GradientConfig{T,V,N,D}(seeds, duals)
 end
 
 checktag(::GradientConfig{T},f,x) where {T} = checktag(T,f,x)

--- a/test/MiscTest.jl
+++ b/test/MiscTest.jl
@@ -158,4 +158,11 @@ end
 @test ForwardDiff.derivative(x -> rem2pi(x, RoundUp), rand()) == 1
 @test ForwardDiff.derivative(x -> rem2pi(x, RoundDown), rand()) == 1
 
+@testset "copy work buffers" begin
+    gc = ForwardDiff.GradientConfig(x -> sum(abs2, x), zeros(3))
+    gc2 = copy(gc)
+    @test typeof(gc) ≡ typeof(gc2)
+    @test gc.duals ≢ gc2.duals
+end
+
 end # module


### PR DESCRIPTION
This is motivated by https://github.com/tpapp/LogDensityProblemsAD.jl/pull/8, where the user can supply a `GradientConfig`, but the unified API for thread-safe invocation would require that the resulting object can be `copy`ed.

Instead of relying on unexposed internals of this package, I thought it would be better to put this functionality here.