### PR TITLE
add back the iteration based seeding for `Array`

### DIFF
--- a/src/apiutils.jl
+++ b/src/apiutils.jl
@@ -46,10 +46,26 @@ function seed!(duals::AbstractArray{Dual{T,V,N}}, x,
     return duals
 end
 
+function seed!(duals::Array{Dual{T,V,N}}, x,
+               seed::Partials{N,V} = zero(Partials{N,V})) where {T,V,N}
+    @inbounds for i in eachindex(duals)
+        duals[i] = Dual{T,V,N}(x[i], seed)
+    end
+    return duals
+end
+
 function seed!(duals::AbstractArray{Dual{T,V,N}}, x,
                seeds::NTuple{N,Partials{N,V}}) where {T,V,N}
     dual_inds = 1:N
     duals[dual_inds] .= Dual{T,V,N}.(view(x,dual_inds), seeds)
+    return duals
+end
+
+function seed!(duals::Array{Dual{T,V,N}}, x,
+               seeds::NTuple{N,Partials{N,V}}) where {T,V,N}
+    @inbounds for i in 1:N
+        duals[i] = Dual{T,V,N}(x[i], seeds[i])
+    end
     return duals
 end
 
@@ -61,11 +77,33 @@ function seed!(duals::AbstractArray{Dual{T,V,N}}, x, index,
     return duals
 end
 
+function seed!(duals::Array{Dual{T,V,N}}, x, index,
+               seed::Partials{N,V} = zero(Partials{N,V})) where {T,V,N}
+    offset = index - 1
+    @inbounds for i in 1:N
+        j = i + offset
+        duals[j] = Dual{T,V,N}(x[j], seed)
+    end
+    return duals
+end
+
+
 function seed!(duals::AbstractArray{Dual{T,V,N}}, x, index,
                seeds::NTuple{N,Partials{N,V}}, chunksize = N) where {T,V,N}
     offset = index - 1
     seed_inds = 1:chunksize
     dual_inds = seed_inds .+ offset
     duals[dual_inds] .= Dual{T,V,N}.(view(x, dual_inds), getindex.(Ref(seeds), seed_inds))
+    return duals
+end
+
+
+function seed!(duals::Array{Dual{T,V,N}}, x, index,
+               seeds::NTuple{N,Partials{N,V}}, chunksize = N) where {T,V,N}
+    offset = index - 1
+    @inbounds for i in 1:chunksize
+        j = i + offset
+        duals[j] = Dual{T,V,N}(x[j], seeds[i])
+    end
     return duals
 end


### PR DESCRIPTION
These were removed in https://github.com/JuliaDiff/ForwardDiff.jl/pull/472 and while I was a bit uncomfortable with it I did not protest. However, now after doing some benchmarks I see that this has a runtime cost that is very much nonsignificant.

Below is a profile and the big peaks are from `seed!`. 

![gnome-shell-screenshot-57lfk9](https://user-images.githubusercontent.com/1282691/224047006-2526a78e-a96c-44f4-b2c3-1faf0e423344.png)

If I use the iteration-based seed function they completely disappear. In order to not break anything, I added these back but with a restriction to `Array` so that e.g. GPU arrays will keep using the broadcast based seeding.