### PR TITLE
Allow failures on nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,15 @@ jobs:
         version:
           - '1.6'
           - '1'
-          - 'nightly'
         os:
           - ubuntu-latest
         arch:
           - x64
+        include:
+          - version: 'nightly'
+            os: ubuntu-latest
+            arch: x64
+            allow_failure: true
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           - version: 'nightly'
             os: ubuntu-latest
             arch: x64
-            allow_failure: true
+            continue-on-error: true
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
While it's good to test on nightly, we shouldn't allow it to cause overall failure for the PR.