### PR TITLE
Add test of second-order derivative of `t -> abs(t)^2`

### DIFF
--- a/test/MiscTest.jl
+++ b/test/MiscTest.jl
@@ -158,4 +158,7 @@ end
 @test ForwardDiff.derivative(x -> rem2pi(x, RoundUp), rand()) == 1
 @test ForwardDiff.derivative(x -> rem2pi(x, RoundDown), rand()) == 1
 
+# example from https://github.com/JuliaDiff/DiffRules.jl/pull/98#issuecomment-1574420052
+@test only(ForwardDiff.hessian(t -> abs(t[1])^2, [0.0])) == 2
+
 end # module


### PR DESCRIPTION
This PR adds the example in https://github.com/JuliaDiff/DiffRules.jl/pull/98#issuecomment-1574420052 as a test, to avoid that upstream reintroduces this bug (DiffRules runs downstream tests of ForwardDiff).