### PR TITLE
use `oneunit(T)` in `construct_seeds`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ForwardDiff"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.36"
+version = "0.10.37"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"
@@ -35,12 +35,13 @@ ForwardDiffStaticArraysExt = "StaticArrays"
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
 DiffTests = "de460e47-3fe3-5279-bb4a-814414816d5d"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Calculus", "DiffTests", "SparseArrays", "Test", "InteractiveUtils", "StaticArrays"]
+test = ["Calculus", "DiffTests", "SparseArrays", "Test", "InteractiveUtils", "StaticArrays", "Measurements"]
 
 [weakdeps]
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -360,6 +360,9 @@ end
 @inline Base.one(d::Dual) = one(typeof(d))
 @inline Base.one(::Type{Dual{T,V,N}}) where {T,V,N} = Dual{T}(one(V), zero(Partials{N,V}))
 
+@inline Base.oneunit(d::Dual) = oneunit(typeof(d))
+@inline Base.oneunit(::Type{Dual{T,V,N}}) where {T,V,N} = Dual{T}(oneunit(V), zero(Partials{N,V}))
+
 @inline function Base.Int(d::Dual)
     all(iszero, partials(d)) || throw(InexactError(:Int, Int, d))
     Int(value(d))

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -360,7 +360,7 @@ end
 @inline Base.one(d::Dual) = one(typeof(d))
 @inline Base.one(::Type{Dual{T,V,N}}) where {T,V,N} = Dual{T}(one(V), zero(Partials{N,V}))
 
-@inline Base.oneunit(d::Dual) = oneunit(typeof(d))
+@inline Base.oneunit(d::Dual{T}) where {T} = Dual{T}(oneunit(primal(d)), zero(partials(d)))
 @inline Base.oneunit(::Type{Dual{T,V,N}}) where {T,V,N} = Dual{T}(oneunit(V), zero(Partials{N,V}))
 
 @inline function Base.Int(d::Dual)

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -360,7 +360,7 @@ end
 @inline Base.one(d::Dual) = one(typeof(d))
 @inline Base.one(::Type{Dual{T,V,N}}) where {T,V,N} = Dual{T}(one(V), zero(Partials{N,V}))
 
-@inline Base.oneunit(d::Dual{T}) where {T} = Dual{T}(oneunit(primal(d)), zero(partials(d)))
+@inline Base.oneunit(d::Dual{T}) where {T} = Dual{T}(oneunit(value(d)), zero(partials(d)))
 @inline Base.oneunit(::Type{Dual{T,V,N}}) where {T,V,N} = Dual{T}(oneunit(V), zero(Partials{N,V}))
 
 @inline function Base.Int(d::Dual)

--- a/src/partials.jl
+++ b/src/partials.jl
@@ -7,7 +7,7 @@ end
 ##############################
 
 @generated function single_seed(::Type{Partials{N,V}}, ::Val{i}) where {N,V,i}
-    ex = Expr(:tuple, [ifelse(i === j, :(one(V)), :(zero(V))) for j in 1:N]...)
+    ex = Expr(:tuple, [ifelse(i === j, :(oneunit(V)), :(zero(V))) for j in 1:N]...)
     return :(Partials($(ex)))
 end
 

--- a/test/MiscTest.jl
+++ b/test/MiscTest.jl
@@ -6,6 +6,7 @@ using Test
 using ForwardDiff
 using DiffTests
 using SparseArrays: sparse
+using Measurements: Measurements
 
 include(joinpath(dirname(@__FILE__), "utils.jl"))
 
@@ -157,5 +158,9 @@ end
 # issue #290
 @test ForwardDiff.derivative(x -> rem2pi(x, RoundUp), rand()) == 1
 @test ForwardDiff.derivative(x -> rem2pi(x, RoundDown), rand()) == 1
+
+#issue 651, using Measurements
+f651(x) = 2.1*x + 1
+@test ForwardDiff.derivative(f651,Measurements.measurement(1.0, 0.001)) == 2.1
 
 end # module


### PR DESCRIPTION
replaces #652 , fixes #651