### PR TITLE
Resolve `NaN` in hypot near zero

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -587,11 +587,18 @@ end
 #-------#
 
 @inline function calc_hypot(x, y, z, ::Type{T}) where T
+    pm1(x) = signbit(x) ? -1 : 1
+
     vx = value(x)
     vy = value(y)
     vz = value(z)
     h = hypot(vx, vy, vz)
-    p = (vx / h) * partials(x) + (vy / h) * partials(y) + (vz / h) * partials(z)
+    p = if iszero(h)
+        hp = sqrt(sum(abs2, partials(x)) + sum(abs2, partials(y)) + sum(abs2, partials(z)))
+        pm1(vx) * partials(x) / hp + pm1(vy) * partials(y) / hp + pm1(vz) * partials(z) / hp
+    else
+        (vx / h) * partials(x) + (vy / h) * partials(y) + (vz / h) * partials(z)
+    end
     return Dual{T}(h, p)
 end
 

--- a/test/MiscTest.jl
+++ b/test/MiscTest.jl
@@ -140,6 +140,9 @@ let i, j
         i != j && @test h[i, j] ≈ 0.0
     end
 end
+hypotx(x) = hypot(x, 0.0, 0.0)
+@test ForwardDiff.derivative(hypotx, 0.0) ≈ 1
+@test ForwardDiff.derivative(hypotx, -0.0) ≈ -1
 
 ########
 # misc #


### PR DESCRIPTION
This checks whether `hypot` of the value component is zero,
and if so switches to a next-order method.

This may be slightly controversial since it exploits the difference between 0.0 and -0.0 to give the correct sign behavior at the origin.