### PR TITLE
Add single-pass value_and_derivative(s) functions

### DIFF
--- a/docs/src/user/api.md
+++ b/docs/src/user/api.md
@@ -9,6 +9,8 @@ CurrentModule = ForwardDiff
 ```@docs
 ForwardDiff.derivative
 ForwardDiff.derivative!
+ForwardDiff.value_and_derivative
+ForwardDiff.value_and_derivatives
 ```
 
 ## Gradients of `f(x::AbstractArray)::Real`

--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -75,6 +75,32 @@ end
 derivative(f, x::AbstractArray) = throw(DimensionMismatch("derivative(f, x) expects that x is a real number. Perhaps you meant gradient(f, x)?"))
 derivative(f, x::Complex) = throw(DimensionMismatch("derivative(f, x) expects that x is a real number (does not support Wirtinger derivatives). Separate real and imaginary parts of the input."))
 
+"""
+    ForwardDiff.value_and_derivative(f, x::Real)
+
+Return `f(x)` and `df/dx` evaluated at `x` in a single pass, assuming `f` is called as `f(x)`.
+
+This method assumes that `isa(f(x), Union{Real,AbstractArray})`.
+"""
+@inline function value_and_derivative(f::F, x::R) where {F,R<:Real}
+    T = typeof(Tag(f, R))
+    ydual = f(Dual{T}(x, one(x)))
+    return value(T, ydual), extract_derivative(T, ydual)
+end
+
+"""
+    ForwardDiff.value_and_derivatives(f, x::Real)
+
+Return `f(x)` and its first and second derivatives evaluated at `x` in a single pass, assuming `f` is called as `f(x)`.
+
+This method assumes that `isa(f(x), Union{Real,AbstractArray})`.
+"""
+@inline function value_and_derivatives(f::F, x::R) where {F,R<:Real}
+    T = typeof(Tag(f, typeof(x)))
+    ydual, ddual = value_and_derivative(f, Dual{T}(x, one(x)))
+    return value(T, ydual), value(T, ddual), extract_derivative(T, ddual)
+end
+
 #####################
 # result extraction #
 #####################

--- a/test/DerivativeTest.jl
+++ b/test/DerivativeTest.jl
@@ -22,11 +22,22 @@ for f in DiffTests.NUMBER_TO_NUMBER_FUNCS
     v = f(x)
     d = ForwardDiff.derivative(f, x)
     @test isapprox(d, Calculus.derivative(f, x), atol=FINITEDIFF_ERROR)
+    d2 = ForwardDiff.derivative(x -> ForwardDiff.derivative(f, x), x)
 
     out = DiffResults.DiffResult(zero(v), zero(v))
     out = ForwardDiff.derivative!(out, f, x)
     @test isapprox(DiffResults.value(out), v)
     @test isapprox(DiffResults.derivative(out), d)
+
+    out = ForwardDiff.value_and_derivative(f, x)
+    @test length(out) == 2
+    @test isapprox(out[1], v)
+    @test isapprox(out[2], d)
+
+    out = ForwardDiff.value_and_derivatives(f, x)
+    @test isapprox(out[1], v)
+    @test isapprox(out[2], d)
+    @test isapprox(out[3], d2)
 end
 
 for f in DiffTests.NUMBER_TO_ARRAY_FUNCS


### PR DESCRIPTION
Closes #610.

## Proposal
I propose adding a `value_and_derivative` function for easy single-pass computation of value and derivative that has the same signature as `derivative` but returns a plain tuple. I also propose a `value_and_derivatives` function that also includes the second derivative. I'm not proposing methods for even higher order derivatives (honestly because I don't have a need for those), but if needed these could be added in the future via an optional argument (e.g. a`Val{n}`) in `value_and_derivatives`.

## Rationale
The rationale is the one I presented in #610. To mention it here, using the `DiffResults` API (which is intended for these use cases) for very simple scalar derivatives is somewhat convoluted, crucially requiring knowledge of the return types of the differentiated function ahead of time instead of just being able to let the compiler deal with the types.

This has caused implementations of functions like `value_and_derivative` to appear in other packages (including mine); but these have to rely on internals of `ForwardDiff` (i.e., `Dual` and related functions), which is not ideal.

## Naming
I considered the names `value_and_derivative` and `value_derivative`. I decided on the former as that's the [name that was chosen in the `AbstractDifferentiation` package](https://github.com/JuliaDiff/AbstractDifferentiation.jl/blob/211b67528c5ed91971bb524c57adb63837163367/src/AbstractDifferentiation.jl#L106C16-L106C16).

## Background
Initially I wanted to register a wrapper package with this functionality, but Registry maintainers asked me to consider a PR here instead. I agree and I hope these changes can be merged here.