### PR TITLE
Broaden promote_rule for Dual to include AbstractIrrational

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -434,7 +434,7 @@ function Base.promote_rule(::Type{Dual{T,A,N}},
     return Dual{T,promote_type(A, B),N}
 end
 
-for R in (Irrational, Real, BigFloat, Bool)
+for R in (AbstractIrrational, Real, BigFloat, Bool)
     if isconcretetype(R) # issue #322
         @eval begin
             Base.promote_rule(::Type{$R}, ::Type{Dual{T,V,N}}) where {T,V,N} = Dual{T,promote_type($R, V),N}


### PR DESCRIPTION
Fix for method ambiguity in https://github.com/JuliaDiff/ForwardDiff.jl/issues/686.

Couldn't tell if/how tests should be updated to reflect this change, happy to do that too if someone more knowledgeable can give me a pointer.