### PR TITLE
make Chunk(::StaticArray) type stable by default

### DIFF
--- a/ext/ForwardDiffStaticArraysExt.jl
+++ b/ext/ForwardDiffStaticArraysExt.jl
@@ -10,6 +10,10 @@ using ForwardDiff: Dual, partials, GradientConfig, JacobianConfig, HessianConfig
                    vector_mode_jacobian, vector_mode_jacobian!, valtype, value
 using DiffResults: DiffResult, ImmutableDiffResult, MutableDiffResult
 
+_chunk(::Length{l}, s::StaticArray) where {l} = Chunk{l}()
+
+ForwardDiff.Chunk(s::StaticArray) = _chunk(Length(s), s)
+
 @generated function dualize(::Type{T}, x::StaticArray) where T
     N = length(x)
     dx = Expr(:tuple, [:(Dual{T}(x[$i], chunk, Val{$i}())) for i in 1:N]...)

--- a/src/prelude.jl
+++ b/src/prelude.jl
@@ -17,6 +17,10 @@ function Chunk(::Val{input_length}, ::Val{threshold} = DEFAULT_CHUNK_THRESHOLD) 
     return Chunk{N}()
 end
 
+function Chunk(input_length::Integer, threshold::Integer = _getval(DEFAULT_CHUNK_THRESHOLD))
+    return Chunk(Val(input_length), Val(threshold))
+end
+
 function Chunk(x::AbstractArray, ::Val{threshold} = DEFAULT_CHUNK_THRESHOLD) where {threshold}
     return Chunk(length(x), threshold)
 end

--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -160,6 +160,13 @@ end
     @test isempty(g_grad_const(zeros(Float64, 0)))
 end
 
+# chunk now takes Val, but this was added to avoid API breakage
+# the constructor does not otherwise get tested
+@testset "chunk constructor methods" begin
+    @test ForwardDiff.Chunk([1.0], 10) == ForwardDiff.Chunk{1}()
+    @test ForwardDiff.Chunk(ones(10), 4) == ForwardDiff.Chunk{4}()
+end
+
 @testset "dimension errors for gradient" begin
     @test_throws DimensionMismatch ForwardDiff.gradient(identity, 2pi) # input
     @test_throws DimensionMismatch ForwardDiff.gradient(identity, fill(2pi, 2)) # vector_mode_gradient

--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -136,6 +136,9 @@ end
     @test DiffResults.gradient(sresult1) == DiffResults.gradient(result)
     @test DiffResults.gradient(sresult2) == DiffResults.gradient(result)
     @test DiffResults.gradient(sresult3) == DiffResults.gradient(result)
+
+    # make sure this is not a source of type instability
+    @inferred ForwardDiff.GradientConfig(f, sx)
 end
 
 @testset "exponential function at base zero" begin

--- a/test/JacobianTest.jl
+++ b/test/JacobianTest.jl
@@ -222,6 +222,9 @@ for T in (StaticArrays.SArray, StaticArrays.MArray)
     @test DiffResults.jacobian(sresult1) == DiffResults.jacobian(result)
     @test DiffResults.jacobian(sresult2) == DiffResults.jacobian(result)
     @test DiffResults.jacobian(sresult3) == DiffResults.jacobian(result)
+
+    # make sure this is not a source of type instability
+    @inferred ForwardDiff.JacobianConfig(f, sx)
 end
 
 #########

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,5 +1,4 @@
 import ForwardDiff
-using ForwardDiff: DEFAULT_CHUNK_THRESHOLD
 using Test
 using Random
 
@@ -7,6 +6,7 @@ using Random
 # so we don't have to retune EPS for arbitrary inputs
 Random.seed!(1)
 
+const DEFAULT_CHUNK_THRESHOLD = ForwardDiff._getval(ForwardDiff.DEFAULT_CHUNK_THRESHOLD)
 const XLEN = DEFAULT_CHUNK_THRESHOLD + 1
 const YLEN = div(DEFAULT_CHUNK_THRESHOLD, 2) + 1
 const X, Y = rand(XLEN), rand(YLEN)


### PR DESCRIPTION
The function `Chunk(x)` is manifestly type unstable.  In many cases when the value is not directly used, the compiler is clever enough to elide this, but in some cases its mere presence can cause significant performance penalties.

In particular, I encountered this when trying to get `DifferentiationInterface.jl` to behave nicely with static arrays.  That package calls `GradientConfig` (or `JacobianConfig`, etc) and for whatever reason the compiler gets upset about the calls to `Chunk` and the whole thing is wildly inefficient.

This PR attempts to address that issue by defining a `StaticArray` method for `Chunk` and setting the size to the arrays length.  It is not entirely clear to me that this is the desired behavior, but `dualize` already seems to do this.  Also this ignores the global chunk size limit setting, but again, `dualize` appears to already do this.

Note that I have explicitly confirmed that the `@inferred` tests I have added fail without this PR but succeed with it.

(btw I am getting a failure in one of the tests for allocations during `seed!` when I run on my end, but it looks totally unrelated to this so I'm not sure what's going on there.  Maybe it'll pass in CI/CD, who knows)