### PR TITLE
Apply #656 to master

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -463,6 +463,7 @@ for R in (AbstractIrrational, Real, BigFloat, Bool)
 end
 
 @inline Base.convert(::Type{Dual{T,V,N}}, d::Dual{T}) where {T,V,N} = Dual{T}(V(value(d)), convert(Partials{N,V}, partials(d)))
+@inline Base.convert(::Type{Dual{T,Dual{T,V,M},N}}, d::Dual{T,V,M}) where {T,V,N,M} = Dual{T}(d, Partials{N,Dual{T,V,M}}(zero_tuple(NTuple{N,Dual{T,V,M}})))
 @inline Base.convert(::Type{Dual{T,V,N}}, x) where {T,V,N} = Dual{T}(V(x), zero(Partials{N,V}))
 @inline Base.convert(::Type{Dual{T,V,N}}, x::Number) where {T,V,N} = Dual{T}(V(x), zero(Partials{N,V}))
 Base.convert(::Type{D}, d::D) where {D<:Dual} = d

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -637,6 +637,8 @@ end
     @test typeof(dfmax) === typeof(d1)
     @test isfinite(dfmin)
     @test isfinite(dfmax)
+
+  @test floatmin(Dual{Nothing, ForwardDiff.Dual{Nothing, Float64, 2}, 1}) === Dual{Nothing}(Dual{Nothing}(floatmin(Float64),0.0,0.0),Dual{Nothing}(0.0,0.0,0.0))
 end
 
 @testset "Integer" begin


### PR DESCRIPTION
When investigating the [diff between master and release-0.10](https://github.com/JuliaDiff/ForwardDiff.jl/compare/master...release-0.10), I noticed that #656 was only applied to the release-0.10 branch. It doesn't contain any explanation or discussion, so it's a bit difficult to tell immediately how useful and important #656 is. But I think it'd be good to avoid such discrepancies between master and release-0.10.