### PR TITLE
Fix method ambiguity for `Base.TwicePrecision`

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -78,6 +78,10 @@ end
 @inline Dual{T,V,N}(x::Number) where {T,V,N} = convert(Dual{T,V,N}, x)
 @inline Dual{T,V}(x) where {T,V} = convert(Dual{T,V}, x)
 
+# Fix method ambiguity issue by adapting the definition in Base to `Dual`s
+Dual{T,V,N}(x::Base.TwicePrecision) where {T,V,N} =
+    (Dual{T,V,N}(x.hi) + Dual{T,V,N}(x.lo))::Dual{T,V,N}
+
 ##############################
 # Utility/Accessor Functions #
 ##############################

--- a/test/AllocationsTest.jl
+++ b/test/AllocationsTest.jl
@@ -24,7 +24,7 @@ convert_test_574() = convert(ForwardDiff.Dual{Nothing,ForwardDiff.Dual{Nothing,F
     index = 1
     alloc = @allocated ForwardDiff.seed!(duals, x, index, seeds)
     alloc = @allocated ForwardDiff.seed!(duals, x, index, seeds)
-    if VERSION < v"1.9"
+    if VERSION < v"1.9" || VERSION >= v"1.11"
         @test alloc == 0
     else
         @test_broken alloc == 0
@@ -33,7 +33,7 @@ convert_test_574() = convert(ForwardDiff.Dual{Nothing,ForwardDiff.Dual{Nothing,F
     index = 1
     alloc = @allocated ForwardDiff.seed!(duals, x, index, seed)
     alloc = @allocated ForwardDiff.seed!(duals, x, index, seed)
-    if VERSION < v"1.9"
+    if VERSION < v"1.9" || VERSION >= v"1.11"
         @test alloc == 0
     else
         @test_broken alloc == 0

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -667,4 +667,8 @@ end
     @test ForwardDiff.derivative(float, 1)::Float64 === 1.0
 end
 
+@testset "TwicePrecision" begin
+    @test ForwardDiff.derivative(x -> sum(1 .+ x .* (0:0.1:1)), 1) == 5.5
+end
+
 end # module


### PR DESCRIPTION
The PR fixes the following error on the master branch:

```julia
julia> using ForwardDiff

julia> ForwardDiff.derivative(x -> sum(1 .+ x .* (0:0.1:1)), 1)
ERROR: MethodError: ForwardDiff.Dual{ForwardDiff.Tag{var"#3#4", Int64}, Float64, 1}(::Base.TwicePrecision{ForwardDiff.Dual{ForwardDiff.Tag{var"#3#4", Int64}, Float64, 1}}) is ambiguous.

Candidates:
  ForwardDiff.Dual{T, V, N}(x) where {T, V, N}
    @ ForwardDiff ~/.julia/packages/ForwardDiff/L9SLV/src/dual.jl:77
  (::Type{T})(x::Base.TwicePrecision) where T<:Number
    @ Base twiceprecision.jl:265

Possible fix, define
  ForwardDiff.Dual{T, V, N}(::Base.TwicePrecision) where {N, V, T}

Stacktrace:
 [1] broadcasted(::Base.Broadcast.DefaultArrayStyle{…}, ::typeof(+), x::Int64, r::StepRangeLen{…})
   @ Base.Broadcast ./broadcast.jl:1120
 [2] broadcasted
   @ ./broadcast.jl:1326 [inlined]
 [3] (::var"#3#4")(x::ForwardDiff.Dual{ForwardDiff.Tag{var"#3#4", Int64}, Int64, 1})
   @ Main ./REPL[4]:1
 [4] derivative(f::var"#3#4", x::Int64)
   @ ForwardDiff ~/.julia/packages/ForwardDiff/L9SLV/src/derivative.jl:14
 [5] top-level scope
   @ REPL[4]:1
Some type information was truncated. Use `show(err)` to see complete types.
```