### PR TITLE
Fix exponentiation for `NaNMath.pow`

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -552,7 +552,7 @@ end
 # exponentiation #
 #----------------#
 
-for (f, log) in ((:(Base.:^), :(NaNMath.pow)), (:(NaNMath.pow), :(NaNMath.log)))
+for (f, log) in ((:(Base.:^), :(Base.log)), (:(NaNMath.pow), :(NaNMath.log)))
     @eval begin
         @define_binary_dual_op(
             $f,

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -552,73 +552,46 @@ end
 # exponentiation #
 #----------------#
 
-@define_binary_dual_op(
-    Base.:^,
-    begin
-        vx, vy = value(x), value(y)
-        expv = (^)(vx, vy)
-        powval = vy * (^)(vx, vy - 1)
-        if isconstant(y)
-            logval = one(expv)
-        elseif iszero(vx) && vy > 0
-            logval = zero(vx)
-        else
-            logval = expv * log(vx)
-        end
-        new_partials = _mul_partials(partials(x), partials(y), powval, logval)
-        return Dual{Txy}(expv, new_partials)
-    end,
-    begin
-        v = value(x)
-        expv = (^)(v, y)
-        if y == zero(y) || iszero(partials(x))
-            new_partials = zero(partials(x))
-        else
-            new_partials = partials(x) * y * (^)(v, y - 1)
-        end
-        return Dual{Tx}(expv, new_partials)
-    end,
-    begin
-        v = value(y)
-        expv = (^)(x, v)
-        deriv = (iszero(x) && v > 0) ? zero(expv) : expv * log(x)
-        return Dual{Ty}(expv, deriv * partials(y))
+for (f, log) in ((:(Base.:^), :(NaNMath.pow)), (:(NaNMath.pow), :(NaNMath.log)))
+    @eval begin
+        @define_binary_dual_op(
+            $f,
+            begin
+                vx, vy = value(x), value(y)
+                expv = ($f)(vx, vy)
+                powval = vy * ($f)(vx, vy - 1)
+                if isconstant(y)
+                    logval = one(expv)
+                elseif iszero(vx) && vy > 0
+                    logval = zero(vx)
+                else
+                    logval = expv * ($log)(vx)
+                end
+                new_partials = _mul_partials(partials(x), partials(y), powval, logval)
+                return Dual{Txy}(expv, new_partials)
+            end,
+            begin
+                v = value(x)
+                expv = ($f)(v, y)
+                if y == zero(y) || iszero(partials(x))
+                    new_partials = zero(partials(x))
+                else
+                    new_partials = partials(x) * y * ($f)(v, y - 1)
+                end
+                return Dual{Tx}(expv, new_partials)
+            end,
+            begin
+                v = value(y)
+                expv = ($f)(x, v)
+                deriv = (iszero(x) && v > 0) ? zero(expv) : expv*($log)(x)
+                return Dual{Ty}(expv, deriv * partials(y))
+            end
+        )
     end
-)
+end
 
-@define_binary_dual_op(
-    NaNMath.pow,
-    begin
-        vx, vy = value(x), value(y)
-        expv = NaNMath.pow(vx, vy)
-        powval = vy * NaNMath.pow(vx, vy - 1)
-        if isconstant(y)
-            logval = one(expv)
-        elseif iszero(vx) && vy > 0
-            logval = zero(vx)
-        else
-            logval = expv * NaNMath.log(vx)
-        end
-        new_partials = _mul_partials(partials(x), partials(y), powval, logval)
-        return Dual{Txy}(expv, new_partials)
-    end,
-    begin
-        v = value(x)
-        expv = NaNMath.pow(v, y)
-        if y == zero(y) || iszero(partials(x))
-            new_partials = zero(partials(x))
-        else
-            new_partials = partials(x) * y * NaNMath.pow(v, y - 1)
-        end
-        return Dual{Tx}(expv, new_partials)
-    end,
-    begin
-        v = value(y)
-        expv = NaNMath.pow(x, v)
-        deriv = (iszero(x) && v > 0) ? zero(expv) : expv*NaNMath.log(x)
-        return Dual{Ty}(expv, deriv * partials(y))
-    end
-)
+
+
 
 @inline Base.literal_pow(::typeof(^), x::Dual{T}, ::Val{0}) where {T} =
     Dual{T}(one(value(x)), zero(partials(x)))

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -590,9 +590,6 @@ for (f, log) in ((:(Base.:^), :(Base.log)), (:(NaNMath.pow), :(NaNMath.log)))
     end
 end
 
-
-
-
 @inline Base.literal_pow(::typeof(^), x::Dual{T}, ::Val{0}) where {T} =
     Dual{T}(one(value(x)), zero(partials(x)))
 

--- a/test/DerivativeTest.jl
+++ b/test/DerivativeTest.jl
@@ -1,6 +1,7 @@
 module DerivativeTest
 
 import Calculus
+import NaNMath
 
 using Test
 using Random

--- a/test/DerivativeTest.jl
+++ b/test/DerivativeTest.jl
@@ -93,6 +93,17 @@ end
     @test (x -> ForwardDiff.derivative(y -> x^y,  1.5))(0.0) === 0.0
 end
 
+@testset "exponentiation with NaNMath" begin
+    @test isnan(ForwardDiff.derivative(x -> NaNMath.pow(NaN, x), 1.0))
+    @test isnan(ForwardDiff.derivative(x -> NaNMath.pow(x,NaN), 1.0))
+    @test !isnan(ForwardDiff.derivative(x -> NaNMath.pow(1.0, x),1.0))
+    @test isnan(ForwardDiff.derivative(x -> NaNMath.pow(x,0.5), -1.0))
+
+    @test isnan(ForwardDiff.derivative(x -> x^NaN, 2.0))
+    @test ForwardDiff.derivative(x -> x^2.0,2.0) == 4.0
+    @test_throws DomainError ForwardDiff.derivative(x -> x^0.5, -1.0)
+end
+
 @testset "dimension error for derivative" begin
     @test_throws DimensionMismatch ForwardDiff.derivative(sum, fill(2pi, 3))
 end

--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -211,7 +211,6 @@ end
     @test_throws DomainError ForwardDiff.gradient(x -> x[1]^x[2], [-1.0, 0.5])
 end
 
-
 @testset "branches in mul!" begin
     a, b = rand(3,3), rand(3,3)
 

--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -200,6 +200,18 @@ end
     @test ForwardDiff.gradient(L -> logdet(L), Matrix(L)) ≈ [1.0 -1.3333333333333337; 0.0 1.666666666666667]
 end
 
+@testset "gradient for exponential with NaNMath"
+    @test isnan(ForwardDiff.gradient(x -> NaNMath.pow(x[1],x[1]), [NaN, 1.0])[1])
+    @test ForwardDiff.gradient(x -> NaNMath.pow(x[1], x[2]), [1.0, 1.0]) == [1.0, 0.0]
+    @test isnan(ForwardDiff.gradient((x) -> NaNMath.pow(x[1], x[2]), [-1.0, 0.5])[1])
+
+    @test isnan(ForwardDiff.gradient(x -> x[1]^x[2], [NaN, 1.0])[1])
+    @test ForwardDiff.gradient(x -> x[1]^x[2], [1.0, 1.0]) == [1.0, 0.0]
+    @test_throws DomainError ForwardDiff.gradient(x -> x[1]^x[2], [-1.0, 0.5])
+
+end
+
+
 @testset "branches in mul!" begin
     a, b = rand(3,3), rand(3,3)
 

--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -201,7 +201,7 @@ end
     @test ForwardDiff.gradient(L -> logdet(L), Matrix(L)) ≈ [1.0 -1.3333333333333337; 0.0 1.666666666666667]
 end
 
-@testset "gradient for exponential with NaNMath"
+@testset "gradient for exponential with NaNMath" begin
     @test isnan(ForwardDiff.gradient(x -> NaNMath.pow(x[1],x[1]), [NaN, 1.0])[1])
     @test ForwardDiff.gradient(x -> NaNMath.pow(x[1], x[2]), [1.0, 1.0]) == [1.0, 0.0]
     @test isnan(ForwardDiff.gradient((x) -> NaNMath.pow(x[1], x[2]), [-1.0, 0.5])[1])
@@ -209,7 +209,6 @@ end
     @test isnan(ForwardDiff.gradient(x -> x[1]^x[2], [NaN, 1.0])[1])
     @test ForwardDiff.gradient(x -> x[1]^x[2], [1.0, 1.0]) == [1.0, 0.0]
     @test_throws DomainError ForwardDiff.gradient(x -> x[1]^x[2], [-1.0, 0.5])
-
 end
 
 

--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -1,6 +1,7 @@
 module GradientTest
 
 import Calculus
+import NaNMath
 
 using Test
 using LinearAlgebra


### PR DESCRIPTION
Currently an example like this:
```julia
using ForwardDiff
using NaNMath

function new_pow(x)
    NaNMath.pow(x[1],x[2])
end

ForwardDiff.gradient(new_pow, [-1.0, 2.0])
```
errors. I'd like to make it so that it returns a `NaN` instead. 


Fixes https://github.com/JuliaDiff/ForwardDiff.jl/issues/716