### PR TITLE
Explicit derivatives for complex analytic functions

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -726,6 +726,22 @@ end
     Dual{Tz}(muladd(x, y, value(z)), partials(z))      # z_body
 )
 
+# inv(Complex) #
+#--------#
+
+function Base.inv(d::Complex{<:Dual{T}}) where{T}
+    FD = ForwardDiff
+    x = complex(FD.value(real(d)), FD.value(imag(d)))
+    val = inv(x)
+    deriv = - val * val
+    re_deriv, im_deriv = reim(deriv)
+    re_partials = FD.partials(real(d))
+    im_partials = FD.partials(imag(d))
+    re_retval = FD.dual_definition_retval(Val{T}(), real(val), re_deriv, re_partials, -im_deriv, im_partials)
+    im_retval = FD.dual_definition_retval(Val{T}(), imag(val), im_deriv, re_partials, re_deriv, im_partials)
+    return complex(re_retval, im_retval)
+end
+
 # sin/cos #
 #--------#
 

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -245,11 +245,11 @@ function unary_dual_definition(M, f)
             return $FD.dual_definition_retval(Val{T}(), val, deriv, $FD.partials(d))
         end
     end
-    if (M, f) in ((:Base, :abs), (:Base, :abs2))
+    if (M, f) in ((:Base, :abs), (:Base, :abs2), (:Base, :inv))
         return real_diff_exp
     else
         complex_diff_expr = quote
-            @inline function $M.$f(d::Complex{$FD.Dual{T, V, N}}) where{T, V, N}
+            @inline function $M.$f(d::Complex{<:$FD.Dual{T}}) where{T}
                 x = complex($FD.value(real(d)), $FD.value(imag(d)))
                 $work
                 re_deriv, im_deriv = reim(deriv)
@@ -760,7 +760,7 @@ end
     return (Dual{T}(sd, cd * partials(d)), Dual{T}(cd, -sd * partials(d)))
 end
 
-function Base.sin(d::Complex{Dual{T, V, N}}) where{T, V, N}
+function Base.sin(d::Complex{<:Dual{T}}) where{T}
     FD = ForwardDiff
     x = complex(FD.value(real(d)), FD.value(imag(d)))
     val = sin(x)
@@ -773,7 +773,7 @@ function Base.sin(d::Complex{Dual{T, V, N}}) where{T, V, N}
     return complex(re_retval, im_retval)
 end
 
-function Base.cos(d::Complex{Dual{T, V, N}}) where{T, V, N}
+function Base.cos(d::Complex{<:Dual{T}}) where{T}
     FD = ForwardDiff
     x = complex(FD.value(real(d)), FD.value(imag(d)))
     val = cos(x)

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -238,12 +238,29 @@ function unary_dual_definition(M, f)
         val = $Mf(x)
         deriv = $(DiffRules.diffrule(M, f, :x))
     end)
-    return quote
+    real_diff_exp = quote
         @inline function $M.$f(d::$FD.Dual{T}) where T
             x = $FD.value(d)
             $work
             return $FD.dual_definition_retval(Val{T}(), val, deriv, $FD.partials(d))
         end
+    end
+    if (M, f) in ((:Base, :abs), (:Base, :abs2))
+        return real_diff_exp
+    else
+        complex_diff_expr = quote
+            @inline function $M.$f(d::Complex{$FD.Dual{T, V, N}}) where{T, V, N}
+                x = complex($FD.value(real(d)), $FD.value(imag(d)))
+                $work
+                re_deriv, im_deriv = reim(deriv)
+                re_partials = $FD.partials(real(d))
+                im_partials = $FD.partials(imag(d))
+                re_retval = $FD.dual_definition_retval(Val{T}(), real(val), re_deriv, re_partials, -im_deriv, im_partials)
+                im_retval = $FD.dual_definition_retval(Val{T}(), imag(val), im_deriv, re_partials, re_deriv, im_partials)
+                return complex(re_retval, im_retval)
+            end
+        end
+        return Expr(:block, real_diff_exp, complex_diff_expr)
     end
 end
 
@@ -725,6 +742,32 @@ end
 @inline function Base.sincos(d::Dual{T}) where T
     sd, cd = sincos(value(d))
     return (Dual{T}(sd, cd * partials(d)), Dual{T}(cd, -sd * partials(d)))
+end
+
+function Base.sin(d::Complex{Dual{T, V, N}}) where{T, V, N}
+    FD = ForwardDiff
+    x = complex(FD.value(real(d)), FD.value(imag(d)))
+    val = sin(x)
+    deriv = cos(x)
+    re_deriv, im_deriv = reim(deriv)
+    re_partials = FD.partials(real(d))
+    im_partials = FD.partials(imag(d))
+    re_retval = FD.dual_definition_retval(Val{T}(), real(val), re_deriv, re_partials, -im_deriv, im_partials)
+    im_retval = FD.dual_definition_retval(Val{T}(), imag(val), im_deriv, re_partials, re_deriv, im_partials)
+    return complex(re_retval, im_retval)
+end
+
+function Base.cos(d::Complex{Dual{T, V, N}}) where{T, V, N}
+    FD = ForwardDiff
+    x = complex(FD.value(real(d)), FD.value(imag(d)))
+    val = cos(x)
+    deriv = -sin(x)
+    re_deriv, im_deriv = reim(deriv)
+    re_partials = FD.partials(real(d))
+    im_partials = FD.partials(imag(d))
+    re_retval = FD.dual_definition_retval(Val{T}(), real(val), re_deriv, re_partials, -im_deriv, im_partials)
+    im_retval = FD.dual_definition_retval(Val{T}(), imag(val), im_deriv, re_partials, re_deriv, im_partials)
+    return complex(re_retval, im_retval)
 end
 
 # sincospi #

--- a/test/DerivativeTest.jl
+++ b/test/DerivativeTest.jl
@@ -113,4 +113,11 @@ end
     @test ForwardDiff.derivative(x -> (1+im)*x, 0) == (1+im)
 end
 
+@testset "analytic functions" begin
+    dexp(x) = ForwardDiff.derivative(y -> exp(complex(0, y)), x)
+    @test ForwardDiff.derivative(dexp, 0.0) ≈ -1
+    @test ForwardDiff.derivative(x -> exp(1im*x), 0.7) ≈ im * cis(0.7)
+    @test ForwardDiff.derivative(x -> sqrt(im + (1+im) * x), 1.23) ≈ (1+im) / (2 * sqrt(im + (1+im)*1.23))
+end
+
 end # module


### PR DESCRIPTION
Hi everyone,

As documented in #726, #514, #653  ForwardDiff encounters some difficulty when it comes to differentiating complex functions. The issue is similar to the one in #481 . This is a very serious issue which has been encountered by several people, including myself, and can be quite difficult to identify the first time, especially when using ForwardDiff as a "black box". Julia and ForwardDiff are widely used by mathematicians in the field of quantum chemistry, who manipulate complex number daily, and encountering this issue can result in a huge loss of time.
Up to a few exceptions (mainly the functions abs and abs2), all the rules defined in DiffRules can be extended to the complex domain with no modification. I worked a bit on the issue and came up with a start of fix by modifying unary_dual_definition as follows:
https://github.com/clguillot/ForwardDiff.jl/blob/114cfe90755df8591488c7d71bd3109be5325fb9/src/dual.jl#L234-L265
I simply define a version of the derivative for Complex{Dual} defined with the expression found in DiffRule and returning a new Complex{Dual}.
With this fix, I get the correct result when computing the order 2 derivative of exp(ix):
```julia
julia> f(x) = exp(1im*x);
julia> df(x) = ForwardDiff.derivative(f, x);
julia> ForwardDiff.derivative(df, 0.0)
-1.0 + 0.0im
```
Without the fix, the same computation (unless the modification in #481 is implemented) returns 0.0 + 0.0im, which is obviously wrong.
I also implemented sin and cos for Complex by hand
https://github.com/clguillot/ForwardDiff.jl/blob/114cfe90755df8591488c7d71bd3109be5325fb9/src/dual.jl#L747-L771
but avoiding sincos since I was lazy.

I believe having explicit derivatives in those cases will mostly free ForwardDiff from having to worry about how the functions are implemented in the libraries, since it never needs to actually go through this code with a Dual type. Moreover, I don't think it to be too harmful for the performances either.

One issue that I see with this pull request is the manual exclusion of some function. It would probably be more elegant to modify DiffRules to indicate which function can see its derivative extended to the complex domain, for example by defining a macro @define_analytic_diffrule which would make a call to @define_diffrules and put the function into a some kind of list indicating that it is analytic. Until something like this can be pulled up, the code above should at least provide a basis that returns the right answer in most cases.
It would also be nice to provide a similar fix for functions of several variables, but all in good time.