### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ForwardDiff"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.11.0-DEV"
+version = "1.0.0"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"


### PR DESCRIPTION
Updates the version number to 1.0.0. I also searched for deprecations on the master branch but couldn't find any.

Fixes #719.

---

In contrast to #728 the PR only updates the version number: https://github.com/JuliaDiff/ForwardDiff.jl/pull/728#discussion_r1873347384 Separate PRs with other changes could be merged before or after tagging 1.0.