### PR TITLE
Require Julia v1.10+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - 'lts'
           - '1'
           # - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,6 @@ Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [weakdeps]
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
@@ -33,7 +32,7 @@ NaNMath = "1"
 Preferences = "1"
 SpecialFunctions = "1, 2"
 StaticArrays = "1.5"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"

--- a/src/ForwardDiff.jl
+++ b/src/ForwardDiff.jl
@@ -22,10 +22,6 @@ include("gradient.jl")
 include("jacobian.jl")
 include("hessian.jl")
 
-if !isdefined(Base, :get_extension)
-    include("../ext/ForwardDiffStaticArraysExt.jl")
-end
-
 export DiffResults
 
 end # module

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -300,14 +300,9 @@ Base.eps(::Type{D}) where {D<:Dual} = eps(valtype(D))
 
 # The `base` keyword was added in Julia 1.8:
 # https://github.com/JuliaLang/julia/pull/42428
-if VERSION < v"1.8.0-DEV.725"
-    Base.precision(d::Dual) = precision(value(d))
-    Base.precision(::Type{D}) where {D<:Dual} = precision(valtype(D))
-else
-    Base.precision(d::Dual; base::Integer=2) = precision(value(d); base=base)
-    function Base.precision(::Type{D}; base::Integer=2) where {D<:Dual}
-        precision(valtype(D); base=base)
-    end
+Base.precision(d::Dual; base::Integer=2) = precision(value(d); base=base)
+function Base.precision(::Type{D}; base::Integer=2) where {D<:Dual}
+    precision(valtype(D); base=base)
 end
 
 function Base.nextfloat(d::ForwardDiff.Dual{T,V,N}) where {T,V,N}

--- a/test/AllocationsTest.jl
+++ b/test/AllocationsTest.jl
@@ -24,7 +24,7 @@ convert_test_574() = convert(ForwardDiff.Dual{Nothing,ForwardDiff.Dual{Nothing,F
     index = 1
     alloc = @allocated ForwardDiff.seed!(duals, x, index, seeds)
     alloc = @allocated ForwardDiff.seed!(duals, x, index, seeds)
-    if VERSION < v"1.9" || VERSION >= v"1.11"
+    if VERSION >= v"1.11"
         @test alloc == 0
     else
         @test_broken alloc == 0
@@ -33,7 +33,7 @@ convert_test_574() = convert(ForwardDiff.Dual{Nothing,ForwardDiff.Dual{Nothing,F
     index = 1
     alloc = @allocated ForwardDiff.seed!(duals, x, index, seed)
     alloc = @allocated ForwardDiff.seed!(duals, x, index, seed)
-    if VERSION < v"1.9" || VERSION >= v"1.11"
+    if VERSION >= v"1.11"
         @test alloc == 0
     else
         @test_broken alloc == 0

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -118,12 +118,11 @@ ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
         @test precision(typeof(FDNUM)) === precision(V)
         @test precision(NESTED_FDNUM) === precision(PRIMAL)
         @test precision(typeof(NESTED_FDNUM)) === precision(V)
-        if VERSION >= v"1.8.0-DEV.725" # https://github.com/JuliaLang/julia/pull/42428
-            @test precision(FDNUM; base=10) === precision(PRIMAL; base=10)
-            @test precision(typeof(FDNUM); base=10) === precision(V; base=10)
-            @test precision(NESTED_FDNUM; base=10) === precision(PRIMAL; base=10)
-            @test precision(typeof(NESTED_FDNUM); base=10) === precision(V; base=10)
-        end
+        
+        @test precision(FDNUM; base=10) === precision(PRIMAL; base=10)
+        @test precision(typeof(FDNUM); base=10) === precision(V; base=10)
+        @test precision(NESTED_FDNUM; base=10) === precision(PRIMAL; base=10)
+        @test precision(typeof(NESTED_FDNUM); base=10) === precision(V; base=10)
 
         @test floor(Int, FDNUM) === floor(Int, PRIMAL)
         @test floor(Int, FDNUM2) === floor(Int, PRIMAL2)


### PR DESCRIPTION
I think with v1.0 it makes sense to drop the support for earlier versions of Julia before the LTS. The benefits are:

1. We can drop StaticArrays as a dependency
2. Makes it less restricted in terms of testing compatibility and adding features
3. Removal of a small amount of special cases in the tests