### PR TITLE
use `Base.Fix1` instead of closures in `ForwardDiffStaticArraysExt.jl`

### DIFF
--- a/ext/ForwardDiffStaticArraysExt.jl
+++ b/ext/ForwardDiffStaticArraysExt.jl
@@ -103,16 +103,16 @@ end
     T = typeof(Tag(f, eltype(x)))
     ydual = static_dual_eval(T, f, x)
     result = DiffResults.jacobian!(result, extract_jacobian(T, ydual, x))
-    result = DiffResults.value!(d -> value(T,d), result, ydual)
+    result = DiffResults.value!(Base.Fix1(value, T), result, ydual)
     return result
 end
 
 # Hessian
-ForwardDiff.hessian(f::F, x::StaticArray) where {F} = jacobian(y -> gradient(f, y), x)
+ForwardDiff.hessian(f::F, x::StaticArray) where {F} = jacobian(Base.Fix1(gradient, f), x)
 ForwardDiff.hessian(f::F, x::StaticArray, cfg::HessianConfig) where {F} = hessian(f, x)
 ForwardDiff.hessian(f::F, x::StaticArray, cfg::HessianConfig, ::Val) where {F} = hessian(f, x)
 
-ForwardDiff.hessian!(result::AbstractArray, f::F, x::StaticArray) where {F} = jacobian!(result, y -> gradient(f, y), x)
+ForwardDiff.hessian!(result::AbstractArray, f::F, x::StaticArray) where {F} = jacobian!(result, Base.Fix1(gradient, f), x)
 
 ForwardDiff.hessian!(result::MutableDiffResult, f::F, x::StaticArray) where {F} = hessian!(result, f, x, HessianConfig(f, result, x))
 

--- a/test/JacobianTest.jl
+++ b/test/JacobianTest.jl
@@ -259,6 +259,24 @@ end
 @testset "type stability" begin
     g!(dy, y) = dy[1] = y[1]
     @inferred ForwardDiff.jacobian(g!, [1.0], [0.0])
+
+    @testset "issue 639" begin
+        f(x) = SA[x[1]^2+x[2]^2, x[2]^2+x[3]^2]
+        x = SA[1.0, 2.0, 3.0]
+        y = f(x)
+        imdr = DiffResults.JacobianResult(y, x)
+        @inferred ForwardDiff.jacobian!(imdr, f, x)
+    end
+
+    @testset "pr 735" begin
+        f(x) = x .^ 2 ./ 2
+        function withjacobian(x)
+            res = DiffResults.JacobianResult(x)
+            res = ForwardDiff.jacobian!(res, f, x)
+            return DiffResults.value(res), DiffResults.jacobian(res)
+        end
+        @inferred withjacobian(SA[1.0, 2.0])
+    end
 end
 
 end # module


### PR DESCRIPTION
Constant propagation of the tag `T` into the closure `d -> value(T,d)` seems to fail in `ForwardDiff.vector_mode_jacobian!(::ImmutableDiffResult, ...)`

https://github.com/JuliaDiff/ForwardDiff.jl/blob/7d6374800b82b37a5ffcebea7832b64a33347fb8/ext/ForwardDiffStaticArraysExt.jl#L102-L108

so I replaced the closure with `Base.Fix1`. I preemptively replaced two other closures as well.

On the one hand, this is probably a compiler regression (though I'm not sure when; this bug occurs on both 1.9 and 1.11) that should be fixed elsewhere. But on the other hand, `StaticArrays` puts a lot of pressure on the compiler and closures are well-known to be finicky with respect to type inference, so IMO getting rid of the closures is worth the slight loss of readability.

## MWE

```julia
using StaticArrays, ForwardDiff, DiffResults

f(x) = x .^ 2 ./ 2

function withjacobian(x::SVector)
    res = DiffResults.JacobianResult(x)
    res = ForwardDiff.jacobian!(res, f, x)
    return DiffResults.value(res), DiffResults.jacobian(res)
end

@code_warntype withjacobian(SVector(1.0, 2.0))
@btime withjacobian($(SVector(1.0, 2.0)))
```

Without this PR:

```julia
MethodInstance for withjacobian(::SVector{2, Float64})
  from withjacobian(x::SVector) @ Main ~/ForwardDiffBug/bug.jl:8
Arguments
  #self#::Core.Const(Main.withjacobian)
  x::SVector{2, Float64}
Locals
  res::DiffResults.ImmutableDiffResult{1, _A, Tuple{SMatrix{2, 2, Float64, 4}}} where _A
Body::Tuple{Any, SMatrix{2, 2, Float64, 4}}
1 ─ %1  = DiffResults.JacobianResult::Core.Const(DiffResults.JacobianResult)
│         (res = (%1)(x))
│   %3  = ForwardDiff.jacobian!::Core.Const(ForwardDiff.jacobian!)
│   %4  = res::Core.PartialStruct(DiffResults.ImmutableDiffResult{1, SVector{2, Float64}, Tuple{SMatrix{2, 2, Float64, 4}}}, Any[SVector{2, Float64}, Core.Const(([0.0 0.0; 0.0 0.0],))])
│   %5  = Main.f::Core.Const(Main.f)
│         (res = (%3)(%4, %5, x))
│   %7  = DiffResults.value::Core.Const(DiffResults.value)
│   %8  = res::DiffResults.ImmutableDiffResult{1, _A, Tuple{SMatrix{2, 2, Float64, 4}}} where _A
│   %9  = (%7)(%8)::Any
│   %10 = DiffResults.jacobian::Core.Const(DiffResults.jacobian)
│   %11 = res::DiffResults.ImmutableDiffResult{1, _A, Tuple{SMatrix{2, 2, Float64, 4}}} where _A
│   %12 = (%10)(%11)::SMatrix{2, 2, Float64, 4}
│   %13 = Core.tuple(%9, %12)::Tuple{Any, SMatrix{2, 2, Float64, 4}}
└──       return %13

  2.998 μs (17 allocations: 752 bytes)
([0.5, 2.0], [1.0 0.0; 0.0 2.0])
```

With this PR:

```julia
MethodInstance for withjacobian(::SVector{2, Float64})
  from withjacobian(x::SVector) @ Main ~/ForwardDiffBug/bug.jl:8
Arguments
  #self#::Core.Const(Main.withjacobian)
  x::SVector{2, Float64}
Locals
  res::DiffResults.ImmutableDiffResult{1, SVector{2, Float64}, Tuple{SMatrix{2, 2, Float64, 4}}}
Body::Tuple{SVector{2, Float64}, SMatrix{2, 2, Float64, 4}}
1 ─ %1  = DiffResults.JacobianResult::Core.Const(DiffResults.JacobianResult)
│         (res = (%1)(x))
│   %3  = ForwardDiff.jacobian!::Core.Const(ForwardDiff.jacobian!)
│   %4  = res::Core.PartialStruct(DiffResults.ImmutableDiffResult{1, SVector{2, Float64}, Tuple{SMatrix{2, 2, Float64, 4}}}, Any[SVector{2, Float64}, Core.Const(([0.0 0.0; 0.0 0.0],))])
│   %5  = Main.f::Core.Const(Main.f)
│         (res = (%3)(%4, %5, x))
│   %7  = DiffResults.value::Core.Const(DiffResults.value)
│   %8  = res::DiffResults.ImmutableDiffResult{1, SVector{2, Float64}, Tuple{SMatrix{2, 2, Float64, 4}}}
│   %9  = (%7)(%8)::SVector{2, Float64}
│   %10 = DiffResults.jacobian::Core.Const(DiffResults.jacobian)
│   %11 = res::DiffResults.ImmutableDiffResult{1, SVector{2, Float64}, Tuple{SMatrix{2, 2, Float64, 4}}}
│   %12 = (%10)(%11)::SMatrix{2, 2, Float64, 4}
│   %13 = Core.tuple(%9, %12)::Tuple{SVector{2, Float64}, SMatrix{2, 2, Float64, 4}}
└──       return %13

  2.845 ns (0 allocations: 0 bytes)
([0.5, 2.0], [1.0 0.0; 0.0 2.0])
```

Version info:

```julia
julia> Pkg.status()
Status `~/ForwardDiffBug/Project.toml`
  [163ba53b] DiffResults v1.1.0
  [f6369f11] ForwardDiff v0.11.0-DEV `~/.julia/dev/ForwardDiff`
  [90137ffa] StaticArrays v1.9.11

julia> versioninfo()
Julia Version 1.11.3
Commit d63adeda50d (2025-01-21 19:42 UTC)
Build Info:
  Official https://julialang.org/ release
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 32 × AMD Ryzen 9 3950X 16-Core Processor
  WORD_SIZE: 64
  LLVM: libLLVM-16.0.6 (ORCJIT, znver2)
Threads: 32 default, 0 interactive, 16 GC (on 32 virtual cores)
```