### PR TITLE
Do not seed structural zeros

### DIFF
--- a/src/apiutils.jl
+++ b/src/apiutils.jl
@@ -53,6 +53,22 @@ function seed!(duals::AbstractArray{Dual{T,V,N}}, x,
     return duals
 end
 
+# Triangular matrices
+function _nonzero_indices(x::UpperTriangular)
+    n = size(x, 1)
+    return (CartesianIndex(i, j) for j in 1:n for i in 1:j)
+end
+function _nonzero_indices(x::LowerTriangular)
+    n = size(x, 1)
+    return (CartesianIndex(i, j) for j in 1:n for i in j:n)
+end
+function seed!(duals::Union{LowerTriangular{Dual{T,V,N}},UpperTriangular{Dual{T,V,N}}}, x, seeds::NTuple{N,Partials{N,V}}) where {T,V,N}
+    for (idx, seed) in zip(_nonzero_indices(duals), seeds)
+        duals[idx] = Dual{T,V,N}(x[idx], seed)
+    end
+    return duals
+end
+
 function seed!(duals::AbstractArray{Dual{T,V,N}}, x, index,
                seed::Partials{N,V} = zero(Partials{N,V})) where {T,V,N}
     offset = index - 1

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -16,7 +16,7 @@ Set `check` to `Val{false}()` to disable tag checking. This can lead to perturba
 function gradient(f::F, x::AbstractArray, cfg::GradientConfig{T} = GradientConfig(f, x), ::Val{CHK}=Val{true}()) where {F, T, CHK}
     require_one_based_indexing(x)
     CHK && checktag(T, f, x)
-    if chunksize(cfg) == length(x)
+    if chunksize(cfg) == structural_length(x)
         return vector_mode_gradient(f, x, cfg)
     else
         return chunk_mode_gradient(f, x, cfg)
@@ -35,7 +35,7 @@ This method assumes that `isa(f(x), Real)`.
 function gradient!(result::Union{AbstractArray,DiffResult}, f::F, x::AbstractArray, cfg::GradientConfig{T} = GradientConfig(f, x), ::Val{CHK}=Val{true}()) where {T, CHK, F}
     result isa DiffResult ? require_one_based_indexing(x) : require_one_based_indexing(result, x)
     CHK && checktag(T, f, x)
-    if chunksize(cfg) == length(x)
+    if chunksize(cfg) == structural_length(x)
         vector_mode_gradient!(result, f, x, cfg)
     else
         chunk_mode_gradient!(result, f, x, cfg)
@@ -114,10 +114,10 @@ end
 
 function chunk_mode_gradient_expr(result_definition::Expr)
     return quote
-        @assert length(x) >= N "chunk size cannot be greater than length(x) ($(N) > $(length(x)))"
+        @assert structural_length(x) >= N "chunk size cannot be greater than ForwardDiff.structural_length(x) ($(N) > $(structural_length(x)))"
 
         # precalculate loop bounds
-        xlen = length(x)
+        xlen = structural_length(x)
         remainder = xlen % N
         lastchunksize = ifelse(remainder == 0, N, remainder)
         lastchunkindex = xlen - lastchunksize + 1

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -64,8 +64,8 @@ end
 
 extract_gradient!(::Type{T}, result::AbstractArray, y::Real) where {T} = fill!(result, zero(y))
 function extract_gradient!(::Type{T}, result::AbstractArray, dual::Dual) where {T}
-    idxs = _structural_nonzero_indices(result)
-    for (i, idx) in enumerate(idxs)
+    idxs = structural_eachindex(result)
+    for (i, idx) in zip(1:npartials(dual), idxs)
         result[idx] = partials(T, dual, i)
     end
     return result
@@ -73,9 +73,8 @@ end
 
 function extract_gradient_chunk!(::Type{T}, result, dual, index, chunksize) where {T}
     offset = index - 1
-    idxs = Iterators.drop(_structural_nonzero_indices(result), offset)
-    for (i, idx) in enumerate(idxs)
-        i > chunksize && break
+    idxs = Iterators.drop(structural_eachindex(result), offset)
+    for (i, idx) in zip(1:chunksize, idxs)
         result[idx] = partials(T, dual, i)
     end
     return result

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -65,6 +65,14 @@ end
 extract_gradient!(::Type{T}, result::AbstractArray, y::Real) where {T} = fill!(result, zero(y))
 extract_gradient!(::Type{T}, result::AbstractArray, dual::Dual) where {T}= copyto!(result, partials(T, dual))
 
+# Triangular matrices
+function extract_gradient!(::Type{T}, result::Union{UpperTriangular,LowerTriangular}, dual::Dual) where {T}
+    for (idx, p) in zip(_nonzero_indices(result), partials(T, dual))
+        result[idx] = p
+    end
+    return result
+end
+
 function extract_gradient_chunk!(::Type{T}, result, dual, index, chunksize) where {T}
     offset = index - 1
     for i in 1:chunksize

--- a/src/prelude.jl
+++ b/src/prelude.jl
@@ -12,8 +12,15 @@ function Chunk(input_length::Integer, threshold::Integer = DEFAULT_CHUNK_THRESHO
     Base.@nif 12 d->(N == d) d->(Chunk{d}()) d->(Chunk{N}())
 end
 
+_length_structural_nonzero_indices(x::AbstractArray) = length(x)
+function _length_structural_nonzero_indices(x::Union{LowerTriangular,UpperTriangular})
+    n = size(x, 1)
+    return (n * (n + 1)) >> 1
+end
+_length_structural_nonzero_indices(x::Diagonal) = size(x, 1)
+
 function Chunk(x::AbstractArray, threshold::Integer = DEFAULT_CHUNK_THRESHOLD)
-    return Chunk(length(x), threshold)
+    return Chunk(_length_structural_nonzero_indices(x), threshold)
 end
 
 # Constrained to `N <= threshold`, minimize (in order of priority):

--- a/src/prelude.jl
+++ b/src/prelude.jl
@@ -12,15 +12,15 @@ function Chunk(input_length::Integer, threshold::Integer = DEFAULT_CHUNK_THRESHO
     Base.@nif 12 d->(N == d) d->(Chunk{d}()) d->(Chunk{N}())
 end
 
-_length_structural_nonzero_indices(x::AbstractArray) = length(x)
-function _length_structural_nonzero_indices(x::Union{LowerTriangular,UpperTriangular})
+structural_length(x::AbstractArray) = length(x)
+function structural_length(x::Union{LowerTriangular,UpperTriangular})
     n = size(x, 1)
     return (n * (n + 1)) >> 1
 end
-_length_structural_nonzero_indices(x::Diagonal) = size(x, 1)
+structural_length(x::Diagonal) = size(x, 1)
 
 function Chunk(x::AbstractArray, threshold::Integer = DEFAULT_CHUNK_THRESHOLD)
-    return Chunk(_length_structural_nonzero_indices(x), threshold)
+    return Chunk(structural_length(x), threshold)
 end
 
 # Constrained to `N <= threshold`, minimize (in order of priority):

--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -226,4 +226,13 @@ end
     @test dx ≈ sum(a * b)
 end
 
+# issue #738
+@testset "LowerTriangular and UpperTriangular" begin
+    M = rand(3, 3)
+    for T in (LowerTriangular, UpperTriangular)
+        @test ForwardDiff.gradient(sum, T(randn(3, 3))) == T(ones(3, 3))
+        @test ForwardDiff.gradient(x -> dot(M, x), T(randn(3, 3))) == T(M)
+    end
+end
+
 end # module

--- a/test/GradientTest.jl
+++ b/test/GradientTest.jl
@@ -227,11 +227,13 @@ end
 end
 
 # issue #738
-@testset "LowerTriangular and UpperTriangular" begin
-    M = rand(3, 3)
-    for T in (LowerTriangular, UpperTriangular)
-        @test ForwardDiff.gradient(sum, T(randn(3, 3))) == T(ones(3, 3))
-        @test ForwardDiff.gradient(x -> dot(M, x), T(randn(3, 3))) == T(M)
+@testset "LowerTriangular, UpperTriangular and Diagonal" begin
+    for n in (3, 10, 20)
+        M = rand(n, n)
+        for T in (LowerTriangular, UpperTriangular, Diagonal)
+            @test ForwardDiff.gradient(sum, T(randn(n, n))) == T(ones(n, n))
+            @test ForwardDiff.gradient(x -> dot(M, x), T(randn(n, n))) == T(M)
+        end
     end
 end
 


### PR DESCRIPTION
Fixes #738.

Since I had made https://github.com/JuliaDiff/ForwardDiff.jl/pull/695 I felt somewhat responsible for #738. Defining `seed!` and `extract_gradient!` for triangular matrices seems to fix the example.

Probably this should b extended to additional matrix types.