### PR TITLE
Add `public` declarations

### DIFF
--- a/src/ForwardDiff.jl
+++ b/src/ForwardDiff.jl
@@ -22,6 +22,13 @@ include("gradient.jl")
 include("jacobian.jl")
 include("hessian.jl")
 
+if VERSION >= v"1.11.0-DEV.469"
+    # This list matches /docs/src/user/api.md
+    eval(Meta.parse(
+        "public derivative, derivative!, gradient, gradient!, jacobian, jacobian!, 
+        hessian, hessian!, DerivativeConfig, GradientConfig, JacobianConfig, HessianConfig"))
+end
+
 if !isdefined(Base, :get_extension)
     include("../ext/ForwardDiffStaticArraysExt.jl")
 end


### PR DESCRIPTION
First commit adds only those in `api.md`, but perhaps we should add more... like `Dual`? 

```julia
help?> ForwardDiff.Dual
  │ Warning
  │
  │  The following bindings may be internal; they may change or be
  │  removed in future versions:
  │
  │    •  ForwardDiff.Dual
```


(`eval` is following this https://github.com/JuliaLang/julia/pull/55097/files )
