### PR TITLE
Add support for floatmax(value) and friends

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -830,6 +830,9 @@ function Base.show(io::IO, d::Dual{T,V,N}) where {T,V,N}
 end
 
 for op in (:(Base.typemin), :(Base.typemax), :(Base.floatmin), :(Base.floatmax))
+    @eval function $op(::ForwardDiff.Dual{T,V,N}) where {T,V,N}
+        ForwardDiff.Dual{T,V,N}($op(V))
+    end
     @eval function $op(::Type{ForwardDiff.Dual{T,V,N}}) where {T,V,N}
         ForwardDiff.Dual{T,V,N}($op(V))
     end

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -638,6 +638,12 @@ end
     @test isfinite(dfmin)
     @test isfinite(dfmax)
 
+    # Functions can be called with type or value
+    @test typemin(d1) == typemin(typeof(d1))
+    @test typemax(d1) == typemax(typeof(d1))
+    @test floatmin(d1) == floatmin(typeof(d1))
+    @test floatmax(d1) == floatmax(typeof(d1))
+
   @test floatmin(Dual{Nothing, ForwardDiff.Dual{Nothing, Float64, 2}, 1}) === Dual{Nothing}(Dual{Nothing}(floatmin(Float64),0.0,0.0),Dual{Nothing}(0.0,0.0,0.0))
 end
 


### PR DESCRIPTION
Fix https://github.com/JuliaMath/SpecialFunctions.jl/issues/475

The SpecialFunction `expint` is using `floatmax` on a value and thus the following currently fails:
```
ForwardDiff.derivative(x -> expint(im*x), 1.0)
```

I believe it makes sense to support both `floatmax(::T)` and `floatmax(::Type{T})` here since Base implements both.