### PR TITLE
Fix implementations of `eigen` and `eigvals`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ForwardDiff"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "1.4.5"
+version = "1.4.6"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"

--- a/ext/ForwardDiffStaticArraysExt.jl
+++ b/ext/ForwardDiffStaticArraysExt.jl
@@ -24,15 +24,28 @@ end
 @inline static_dual_eval(::Type{T}, f::F, x::StaticArray) where {T,F} = f(dualize(T, x))
 
 # To fix method ambiguity issues:
-function LinearAlgebra.eigvals(A::Symmetric{<:Dual{Tg,T,N}, <:StaticArrays.StaticMatrix}) where {Tg,T<:Real,N}
-    return ForwardDiff._eigvals(A)
+function LinearAlgebra.eigvals(A::Symmetric{Dual{T,V,N}, <:StaticArrays.StaticMatrix}) where {T,V<:Real,N}
+    return ForwardDiff._eigvals_hermitian(A)
 end
-function LinearAlgebra.eigen(A::Symmetric{<:Dual{Tg,T,N}, <:StaticArrays.StaticMatrix}) where {Tg,T<:Real,N}
-    return ForwardDiff._eigen(A)
+function LinearAlgebra.eigvals(A::Hermitian{Dual{T,V,N}, <:StaticArrays.StaticMatrix}) where {T,V<:Real,N}
+    return ForwardDiff._eigvals_hermitian(A)
+end
+function LinearAlgebra.eigvals(A::Hermitian{Complex{Dual{T,V,N}}, <:StaticArrays.StaticMatrix}) where {T,V<:Real,N}
+    return ForwardDiff._eigvals_hermitian(A)
+end
+
+function LinearAlgebra.eigen(A::Symmetric{Dual{T,V,N}, <:StaticArrays.StaticMatrix}) where {T,V<:Real,N}
+    return ForwardDiff._eigen_hermitian(A)
+end
+function LinearAlgebra.eigen(A::Hermitian{Dual{T,V,N}, <:StaticArrays.StaticMatrix}) where {T,V<:Real,N}
+    return ForwardDiff._eigen_hermitian(A)
+end
+function LinearAlgebra.eigen(A::Hermitian{Complex{Dual{T,V,N}}, <:StaticArrays.StaticMatrix}) where {T,V<:Real,N}
+    return ForwardDiff._eigen_hermitian(A)
 end
 
 # For `MMatrix` we can use the in-place method
-ForwardDiff._lyap_div!!(A::StaticArrays.MMatrix, λ::AbstractVector) = ForwardDiff._lyap_div!(A, λ)
+ForwardDiff._lyap_div_zero_diag!!(A::StaticArrays.MMatrix, λ::AbstractVector) = ForwardDiff._lyap_div_zero_diag!(A, λ)
 
 # Gradient
 @inline ForwardDiff.gradient(f::F, x::StaticArray) where {F} = vector_mode_gradient(f, x)

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -819,7 +819,7 @@ function _eigvals_hermitian(A::DualMatrixRealComplex{T,<:Real,N}) where {T,N}
     F = eigen(_structured_value(A))
     λ = F.values
     Q = F.vectors
-    parts = ntuple(j -> real(diag(Q' * _structured_partials(A, j) * Q)), N)
+    parts = ntuple(j -> real(diag(Q' * (_structured_partials(A, j) * Q))), N)
     return _to_duals(Val(T), λ, parts)
 end
 
@@ -856,7 +856,9 @@ function _eigen_hermitian(A::DualMatrixRealComplex{T,<:Real,N}) where {T,N}
     F = eigen(_structured_value(A))
     λ = F.values
     Q = F.vectors
-    Qt_∂A_Q = ntuple(j -> Q' * _structured_partials(A, j) * Q, N)
+    # `Q' * (∂A * Q)`, not `(Q' * ∂A) * Q`: the latter hits `Adjoint * Symmetric`, which has no BLAS
+    # specialization and so allocates an extra temporary and skips `symm`/`hemm`
+    Qt_∂A_Q = ntuple(j -> Q' * (_structured_partials(A, j) * Q), N)
     λ_partials = map(real ∘ diag, Qt_∂A_Q)
     Q_partials = map(Qt_∂Aj_Q -> Q*_lyap_div_zero_diag!!(Qt_∂Aj_Q, λ), Qt_∂A_Q)
     return Eigen(_to_duals(Val(T), λ, λ_partials), _to_duals(Val(T), Q, Q_partials))

--- a/test/JacobianTest.jl
+++ b/test/JacobianTest.jl
@@ -254,6 +254,7 @@ end
     eigen_vec1_symtridiag(x) = eigen(SymTridiagonal(x, x[begin:(end - 1)])).vectors[:,1]
     
     # Note: SymTridiagonal is not supported for StaticArrays
+    x0 = [1.0, 2.0]
     for T in (Int, Float32, Float64), A in (Array, SArray, MArray)
         if A <: StaticArrays.StaticArray
             x = A{Tuple{2},T}(x0)

--- a/test/JacobianTest.jl
+++ b/test/JacobianTest.jl
@@ -312,6 +312,29 @@ end
             @test ForwardDiff.jacobian(eigvals, x) ≈ ForwardDiff.jacobian(eigen_vals, x)
         end
     end
+
+    # The matrices above are all of the form `x*x'` and hence symmetric, so `:U` and `:L` wrap the
+    # same matrix. Here the raw storage is deliberately not symmetric/Hermitian: the values and the
+    # partials both have to be read from the triangle that `uplo` selects.
+    @testset "uplo = :$uplo" for uplo in (:U, :L)
+        # `2*x[1]+x[2]^2` rather than something proportional to the off-diagonal entry, so that the
+        # eigenvector direction actually depends on `x` and the eigenvector test is not vacuous
+        raw_real(x) = [x[1] x[2]; 3*x[2] 2*x[1]+x[2]^2]
+        raw_complex(x) = complex.(raw_real(x), [0 x[1]; -2*x[2] 0])
+        x0 = [1.0, 2.0]
+
+        @testset "$name" for (name, wrap) in (
+            ("Symmetric{<:Real}", x -> Symmetric(raw_real(x), uplo)),
+            ("Hermitian{<:Real}", x -> Hermitian(raw_real(x), uplo)),
+            ("Hermitian{<:Complex}", x -> Hermitian(raw_complex(x), uplo)),
+        )
+            for ev in (x -> eigvals(wrap(x)),
+                       x -> eigen(wrap(x)).values,
+                       x -> map(abs2, eigen(wrap(x)).vectors[:, 1]))
+                @test ForwardDiff.jacobian(ev, x0) ≈ Calculus.finite_difference_jacobian(ev, x0)
+            end
+        end
+    end
 end
 
 @testset "type stability" begin

--- a/test/MiscTest.jl
+++ b/test/MiscTest.jl
@@ -182,26 +182,26 @@ end
 # example from https://github.com/JuliaDiff/DiffRules.jl/pull/98#issuecomment-1574420052
 @test only(ForwardDiff.hessian(t -> abs(t[1])^2, [0.0])) == 2
 
-@testset "_lyap_div!!" begin
+@testset "_lyap_div_zero_diag!!" begin
     # In-place version for `Matrix`
     A = rand(3, 3)
     Acopy = copy(A)
     λ = rand(3)
-    B = @inferred(ForwardDiff._lyap_div!!(A, λ))
+    B = @inferred(ForwardDiff._lyap_div_zero_diag!!(A, λ))
     @test B === A
-    @test B[diagind(B)] == Acopy[diagind(Acopy)]
+    @test iszero(B[diagind(B)])
     no_diag(X) = [X[i] for i in eachindex(X) if !(i in diagind(X))]
     @test no_diag(B) == no_diag(Acopy ./ (λ' .- λ))
 
     # Immutable static arrays
     A_smatrix = SMatrix{3,3}(Acopy)
     λ_svector = SVector{3}(λ)
-    B_smatrix = @inferred(ForwardDiff._lyap_div!!(A_smatrix, λ_svector))
+    B_smatrix = @inferred(ForwardDiff._lyap_div_zero_diag!!(A_smatrix, λ_svector))
     @test B_smatrix !== A_smatrix
     @test B_smatrix isa SMatrix{3,3}
     @test B_smatrix == B
     λ_mvector = MVector{3}(λ)
-    B_smatrix = @inferred(ForwardDiff._lyap_div!!(A_smatrix, λ_mvector))
+    B_smatrix = @inferred(ForwardDiff._lyap_div_zero_diag!!(A_smatrix, λ_mvector))
     @test B_smatrix !== A_smatrix
     @test B_smatrix isa SMatrix{3,3}
     @test B_smatrix == B
@@ -209,12 +209,12 @@ end
     # Mutable static arrays
     A_mmatrix = MMatrix{3,3}(Acopy)
     λ_svector = SVector{3}(λ)
-    B_mmatrix = @inferred(ForwardDiff._lyap_div!!(A_mmatrix, λ_svector))
+    B_mmatrix = @inferred(ForwardDiff._lyap_div_zero_diag!!(A_mmatrix, λ_svector))
     @test B_mmatrix === A_mmatrix
     @test B_mmatrix == B
     A_mmatrix = MMatrix{3,3}(Acopy)
     λ_mvector = MVector{3}(λ)
-    B_mmatrix = @inferred(ForwardDiff._lyap_div!!(A_mmatrix, λ_mvector))
+    B_mmatrix = @inferred(ForwardDiff._lyap_div_zero_diag!!(A_mmatrix, λ_mvector))
     @test B_mmatrix === A_mmatrix
     @test B_mmatrix == B
 end


### PR DESCRIPTION
The PR adds missing definitions of `eigvals` and `eigen` for `Hermitian{<:Dual}` and of `eigen` for `Hermitian{<:Complex{<:Dual}}`.
Additionally, the PR adds more tests of `eigen` and `eigvals`, unifies the existing implementations, and removes duplicate calculations in the definitions of `eigen`.

Fixes #756 without GenericLinearAlgebra.

---

For the example in #756, I get on ForwardDiff@0.10 without GenericLinearAlgebra:

```julia
julia> test_hessian(Float64)
ERROR: MethodError: no method matching eigvals!(::Hermitian{ForwardDiff.Dual{…}, Matrix{…}}; sortby::Nothing)
The function `eigvals!` exists, but no method is defined for this combination of argument types.
...

julia> test_hessian(ComplexF64)
ERROR: MethodError: no method matching eigen!(::Hermitian{Complex{ForwardDiff.Dual{…}}, Matrix{Complex{…}}}; sortby::Nothing)
The function `eigen!` exists, but no method is defined for this combination of argument types.
...
```

And on ForwardDiff@0.10 with `import GenericLinearAlgebra: eigen`:

```julia
julia> @time test_hessian(Float64)
  0.000071 seconds (38 allocations: 33.750 KiB)
9×9 Matrix{Float64}:
 0.0  0.0  0.0  0.0  0.0          0.0  0.0  0.0          0.0
 0.0  0.0  0.0  0.0  0.0          0.0  0.0  0.0          0.0
 0.0  0.0  0.0  0.0  0.0          0.0  0.0  0.0          0.0
 0.0  0.0  0.0  0.0  0.0          0.0  0.0  0.0          0.0
 0.0  0.0  0.0  0.0  0.0          0.0  0.0  4.44089e-16  0.0
 0.0  0.0  0.0  0.0  0.0          0.0  0.0  0.0          0.0
 0.0  0.0  0.0  0.0  0.0          0.0  0.0  0.0          0.0
 0.0  0.0  0.0  0.0  4.44089e-16  0.0  0.0  2.66454e-15  0.0
 0.0  0.0  0.0  0.0  0.0          0.0  0.0  0.0          0.0

julia> @time test_hessian(ComplexF64)
  0.000556 seconds (1.97 k allocations: 1.387 MiB)
18×18 Matrix{Float64}:
 0.0  0.0  0.0  0.0   0.0          0.0  …  0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0     0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0     0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0     0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0  -6.93889e-18  0.0     0.0  0.0  0.0  -1.38778e-16  0.0
 0.0  0.0  0.0  0.0   0.0          0.0  …  0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0     0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   4.33681e-19  0.0     0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0     0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0     0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0  …  0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0     0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0     0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0     0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0     0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0  …  0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   1.38778e-17  0.0     0.0  0.0  0.0   2.77556e-17  0.0
 0.0  0.0  0.0  0.0   0.0          0.0     0.0  0.0  0.0   0.0          0.0
```

On this PR I get **without GenericLinearAlgebra**:

```julia
julia> @time test_hessian(Float64)
  0.000071 seconds (215 allocations: 55.547 KiB)
9×9 Matrix{Float64}:
 0.0  0.0  0.0  0.0  0.0          0.0  0.0  0.0           0.0
 0.0  0.0  0.0  0.0  0.0          0.0  0.0  0.0           0.0
 0.0  0.0  0.0  0.0  0.0          0.0  0.0  0.0           0.0
 0.0  0.0  0.0  0.0  0.0          0.0  0.0  0.0           0.0
 0.0  0.0  0.0  0.0  0.0          0.0  0.0  2.77556e-17   0.0
 0.0  0.0  0.0  0.0  0.0          0.0  0.0  0.0           0.0
 0.0  0.0  0.0  0.0  0.0          0.0  0.0  0.0           0.0
 0.0  0.0  0.0  0.0  2.77556e-17  0.0  0.0  0.0          -2.77556e-17
 0.0  0.0  0.0  0.0  0.0          0.0  0.0  2.77556e-17   0.0

julia> @time test_hessian(ComplexF64)
  0.000491 seconds (1.00 k allocations: 477.500 KiB)
18×18 Matrix{Float64}:
 0.0  0.0  0.0  0.0   0.0          0.0  …  0.0  0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0     0.0  0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0     0.0  0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0     0.0  0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   6.93889e-18  0.0     0.0  0.0  0.0  0.0  -1.38778e-17  0.0
 0.0  0.0  0.0  0.0   0.0          0.0  …  0.0  0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0     0.0  0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0     0.0  0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0  -6.93889e-18  0.0     0.0  0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0     0.0  0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0  …  0.0  0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0     0.0  0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0     0.0  0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0     0.0  0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0     0.0  0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0  …  0.0  0.0  0.0  0.0   0.0          0.0
 0.0  0.0  0.0  0.0   0.0          0.0     0.0  0.0  0.0  0.0   2.77556e-17  0.0
 0.0  0.0  0.0  0.0   0.0          0.0     0.0  0.0  0.0  0.0   0.0          0.0
```

---

Some benchmarks against master:

## master

```julia
julia> using ForwardDiff, Chairmarks, LinearAlgebra

## Symmetric{<:Real}
julia> @b rand(10) ForwardDiff.gradient(x -> sum(eigvals(Symmetric(x * x'))), _)
11.312 μs (110 allocs: 49.297 KiB)

julia> @b rand(10) ForwardDiff.gradient(x -> sum(eigen(Symmetric(x * x')).values), _)
29.083 μs (273 allocs: 115.469 KiB)

## Hermitian{<:Complex}
julia> @b rand(10) ForwardDiff.gradient(x -> sum(eigvals(Hermitian(complex.(x * x', x' * x)))), _)
71.625 μs (4136 allocs: 542.594 KiB)

julia> @b rand(10) ForwardDiff.gradient(x -> sum(eigen(Hermitian(complex.(x * x', x' * x))).values), _)
ERROR: MethodError: no method matching eigen!(::Hermitian{Complex{ForwardDiff.Dual{…}}, Matrix{Complex{…}}}; sortby::Nothing)
...

## SymTridiagonal{<:Real}
julia> @b rand(10) ForwardDiff.gradient(x -> sum(eigvals(SymTridiagonal(x, x[begin:(end-1)]))), _)
14.500 μs (128 allocs: 37.625 KiB)

julia> @b rand(10) ForwardDiff.gradient(x -> sum(eigen(SymTridiagonal(x, x[begin:(end-1)])).values), _)
32.625 μs (314 allocs: 101.422 KiB)

## Hermitian{<:Real}
julia> @b rand(10) ForwardDiff.gradient(x -> sum(eigvals(Hermitian(x * x'))), _)
ERROR: MethodError: no method matching eigvals!(::Hermitian{ForwardDiff.Dual{ForwardDiff.Tag{…}, Float64, 10}, Matrix{ForwardDiff.Dual{…}}}; sortby::Nothing)
The function `eigvals!` exists, but no method is defined for this combination of argument types.
...

julia> @b rand(10) ForwardDiff.gradient(x -> sum(eigen(Hermitian(x * x')).values), _)
ERROR: MethodError: no method matching eigen!(::Hermitian{ForwardDiff.Dual{ForwardDiff.Tag{…}, Float64, 10}, Matrix{ForwardDiff.Dual{…}}}; sortby::Nothing)
The function `eigen!` exists, but no method is defined for this combination of argument types.
...
```

## This PR

```julia
julia> using ForwardDiff, Chairmarks, LinearAlgebra

## Symmetric{<:Real}
julia> @b rand(10) ForwardDiff.gradient(x -> sum(eigvals(Symmetric(x * x'))), _)
15.834 μs (110 allocs: 49.297 KiB)

julia> @b rand(10) ForwardDiff.gradient(x -> sum(eigen(Symmetric(x * x')).values), _)
19.500 μs (133 allocs: 67.594 KiB)

## Hermitian{<:Complex}
julia> @b rand(10) ForwardDiff.gradient(x -> sum(eigvals(Hermitian(complex.(x * x', x' * x)))), _)
32.625 μs (136 allocs: 98.062 KiB)

julia> @b rand(10) ForwardDiff.gradient(x -> sum(eigen(Hermitian(complex.(x * x', x' * x))).values), _)
39.875 μs (159 allocs: 132.047 KiB)

## Symtridiagonal{<:Real}
julia> @b rand(10) ForwardDiff.gradient(x -> sum(eigvals(SymTridiagonal(x, x[begin:(end-1)]))), _)
10.938 μs (148 allocs: 31.062 KiB)

julia> @b rand(10) ForwardDiff.gradient(x -> sum(eigen(SymTridiagonal(x, x[begin:(end-1)])).values), _)
14.125 μs (171 allocs: 49.359 KiB)

## Hermitian{<:Real}
julia> @b rand(10) ForwardDiff.gradient(x -> sum(eigvals(Hermitian(x * x'))), _)
15.917 μs (110 allocs: 49.297 KiB)

julia> @b rand(10) ForwardDiff.gradient(x -> sum(eigen(Hermitian(x * x')).values), _)
19.250 μs (133 allocs: 67.594 KiB)
```
