### PR TITLE
Enable testing on prereleases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           - 'min'
           - 'lts'
           - '1'
+          - 'pre'
         os:
           - ubuntu-latest
     steps:


### PR DESCRIPTION
Noticed while setting up the GPU infrastructure that ForwardDiff CI tests were missing pre.
