### PR TITLE
Added non-allocating hessian!

### DIFF
--- a/ext/ForwardDiffStaticArraysExt.jl
+++ b/ext/ForwardDiffStaticArraysExt.jl
@@ -114,6 +114,8 @@ ForwardDiff.hessian(f::F, x::StaticArray, cfg::HessianConfig, ::Val) where {F} =
 
 ForwardDiff.hessian!(result::AbstractArray, f::F, x::StaticArray) where {F} = jacobian!(result, Base.Fix1(gradient, f), x)
 
+ForwardDiff.hessian!(result::AbstractArray, f::F, grad::AbstractArray, x::StaticArray) where {F} = hessian!(result, grad, f, x, HessianConfig(f, grad, x))
+
 ForwardDiff.hessian!(result::MutableDiffResult, f::F, x::StaticArray) where {F} = hessian!(result, f, x, HessianConfig(f, result, x))
 
 ForwardDiff.hessian!(result::ImmutableDiffResult, f::F, x::StaticArray, cfg::HessianConfig) where {F} = hessian!(result, f, x)

--- a/ext/ForwardDiffStaticArraysExt.jl
+++ b/ext/ForwardDiffStaticArraysExt.jl
@@ -114,7 +114,7 @@ ForwardDiff.hessian(f::F, x::StaticArray, cfg::HessianConfig, ::Val) where {F} =
 
 ForwardDiff.hessian!(result::AbstractArray, f::F, x::StaticArray) where {F} = jacobian!(result, Base.Fix1(gradient, f), x)
 
-ForwardDiff.hessian!(result::AbstractArray, f::F, grad::AbstractArray, x::StaticArray) where {F} = hessian!(result, grad, f, x, HessianConfig(f, grad, x))
+ForwardDiff.hessian!(result::AbstractArray, f::F, grad::AbstractArray, x::StaticArray) where {F} = hessian!(result, f, grad, x, HessianConfig(f, grad, x))
 
 ForwardDiff.hessian!(result::MutableDiffResult, f::F, x::StaticArray) where {F} = hessian!(result, f, x, HessianConfig(f, result, x))
 

--- a/src/config.jl
+++ b/src/config.jl
@@ -228,6 +228,32 @@ function HessianConfig(f::F,
 end
 
 """
+    ForwardDiff.HessianConfig(f, y::AbstractArray, x::AbstractArray, chunk::Chunk = Chunk(x))
+
+Return a `HessianConfig` instance based on the type of `f` and the types/shapes of `y` 
+and the input vector `x`.
+
+The returned `HessianConfig` instance contains all the work buffers required by
+`ForwardDiff.hessian!`. The buffers are configured for the case where `y` argument is an 
+`AbstractArray`.
+
+If `f` is `nothing` instead of the actual target function, then the returned instance can
+be used with any target function. However, this will reduce ForwardDiff's ability to catch
+and prevent perturbation confusion (see https://github.com/JuliaDiff/ForwardDiff.jl/issues/83).
+
+This constructor does not store/modify `x`.
+"""
+function HessianConfig(f::F,
+                       y::AbstractArray{Y},
+                       x::AbstractArray{X},
+                       chunk::Chunk = Chunk(x),
+                       tag = Tag(f, X)) where {F,Y,X}
+    jacobian_config = JacobianConfig(f, y, x, chunk, tag)
+    gradient_config = GradientConfig(f, jacobian_config.duals[2], chunk, tag)
+    return HessianConfig(jacobian_config, gradient_config)
+end
+
+"""
     ForwardDiff.HessianConfig(f, result::DiffResult, x::AbstractArray, chunk::Chunk = Chunk(x))
 
 Return a `HessianConfig` instance based on the type of `f`, types/storage in `result`, and

--- a/src/hessian.jl
+++ b/src/hessian.jl
@@ -36,7 +36,7 @@ function hessian!(result::AbstractArray, f::F, x::AbstractArray, cfg::HessianCon
     return result
 end
 
-# Struct for inner gradient in instead of 
+# Struct for inner gradient instead of 
 # a closure to avoid allocations
 struct InnerGradientForNallocHess{C,F}
     cfg::C


### PR DESCRIPTION
feat(hessian!): Add non-allocating in-place Hessian support for AbstractArrays

- Implemented an in-place Hessian computation method that avoids allocations for AbstractArray inputs.
- Added new `HessianConfig` to configure in-place Hessian evaluation.
- Added tests to ensure the correctness and stability of the new API.