### PR TITLE
Fix tests by using tag types instead of instances

### DIFF
--- a/test/MiscTest.jl
+++ b/test/MiscTest.jl
@@ -152,7 +152,7 @@ intrand(V) = V == Int ? rand(2:10) : rand(V)
 for N in (0,3), V in (Int, Float32), I in (Irrational, AbstractIrrational)
     PARTIALS = ForwardDiff.Partials{N,V}(ntuple(n -> intrand(V), N))
     PRIMAL = intrand(V)
-    FDNUM = ForwardDiff.Dual{TestTag()}(PRIMAL, PARTIALS)
+    FDNUM = ForwardDiff.Dual{TestTag}(PRIMAL, PARTIALS)
     
     @test promote_rule(typeof(FDNUM), I) == promote_rule(I, typeof(FDNUM))
     # π::Irrational, twoπ::AbstractIrrational


### PR DESCRIPTION
I noticed that in some tests currently tag instances are used as type parameters of `Dual` numbers, even though ForwardDiff is based on using tag types. Changing tests from tag instances to tag types seems to fix 4 broken tests. 