### PR TITLE
v1.2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ForwardDiff"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"


### PR DESCRIPTION
Release PRs #771 and #751.

Specifically I want a release because of the former, to cut down on sysimage invalidation when loading ForwardDiff.