### PR TITLE
make Gradient/Jacobian/Hessian-Config mutable

### DIFF
--- a/src/config.jl
+++ b/src/config.jl
@@ -94,9 +94,9 @@ Base.eltype(::Type{DerivativeConfig{T,D}}) where {T,D} = eltype(D)
 # GradientConfig #
 ##################
 
-struct GradientConfig{T,V,N,D} <: AbstractConfig{N}
-    seeds::NTuple{N,Partials{N,V}}
-    duals::D
+mutable struct GradientConfig{T,V,N,D} <: AbstractConfig{N}
+    const seeds::NTuple{N,Partials{N,V}}
+    const duals::D
 end
 
 """
@@ -130,9 +130,9 @@ Base.eltype(::Type{GradientConfig{T,V,N,D}}) where {T,V,N,D} = Dual{T,V,N}
 # JacobianConfig #
 ##################
 
-struct JacobianConfig{T,V,N,D} <: AbstractConfig{N}
-    seeds::NTuple{N,Partials{N,V}}
-    duals::D
+mutable struct JacobianConfig{T,V,N,D} <: AbstractConfig{N}
+    const seeds::NTuple{N,Partials{N,V}}
+    const duals::D
 end
 
 """
@@ -195,9 +195,9 @@ Base.eltype(::Type{JacobianConfig{T,V,N,D}}) where {T,V,N,D} = Dual{T,V,N}
 # HessianConfig #
 #################
 
-struct HessianConfig{T,V,N,DG,DJ} <: AbstractConfig{N}
-    jacobian_config::JacobianConfig{T,V,N,DJ}
-    gradient_config::GradientConfig{T,Dual{T,V,N},N,DG}
+mutable struct HessianConfig{T,V,N,DG,DJ} <: AbstractConfig{N}
+    const jacobian_config::JacobianConfig{T,V,N,DJ}
+    const gradient_config::GradientConfig{T,Dual{T,V,N},N,DG}
 end
 
 """


### PR DESCRIPTION
these often get quite large and the fact that they are non-mutable means Julia copies them which is quite expensive

Consider for example:

```julia
using ForwardDiff: ForwardDiff, HessianConfig, Chunk
using DiffResults

function test()
    x = rand(12)
    result = DiffResults.HessianResult(x)
    cfg = HessianConfig(sum, result, x, Chunk{12}())

    # Warmup
    ForwardDiff.hessian!(result, sum, x, cfg)

    @time ForwardDiff.hessian!(result, sum, x, cfg)

    @time for i in 1:100
        ForwardDiff.hessian!(result, sum, x, cfg)
    end
end

test()
```

Before this change it gives:

```
  0.000003 seconds (2 allocations: 16.000 KiB)
  0.000280 seconds (200 allocations: 1.562 MiB)
``` 

Now it instead gives

```
  0.000002 seconds (2 allocations: 160 bytes)
  0.000120 seconds (200 allocations: 15.625 KiB)
```

At some point, Julia might do this better.