### PR TITLE
Allow LogExpFunctions v1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ForwardDiff"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "1.3.3"
+version = "1.3.4"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"
@@ -28,7 +28,7 @@ DiffRules = "1.4"
 DiffTests = "0.1"
 IrrationalConstants = "0.1, 0.2"
 JET = "0.9, 0.10, 0.11"
-LogExpFunctions = "0.3"
+LogExpFunctions = "0.3, 1"
 NaNMath = "1"
 Preferences = "1"
 SpecialFunctions = "1, 2"


### PR DESCRIPTION
## Summary

[LogExpFunctions v1.0](https://github.com/JuliaStats/LogExpFunctions.jl) has been released, but ForwardDiff's `[compat]` entry still pins `LogExpFunctions = "0.3"`, which excludes the entire 1.x series. This PR widens the entry to `"0.3, 1"`, keeping the existing 0.3 series so no current users are dropped while allowing installation alongside LogExpFunctions v1.x.

`DiffRules` (ForwardDiff's dependency that actually consumes LogExpFunctions for its rule definitions) already allows v1 (`LogExpFunctions = "0.3.2, 1"`), so ForwardDiff's own cap is the remaining blocker for downstream packages that pull both the modern AD stack and LogExpFunctions 1.x.

## Changes

- `[compat] LogExpFunctions = "0.3"` → `"0.3, 1"`
- Patch version bump `1.3.3` → `1.3.4`

## Testing

The full test suite passes with LogExpFunctions **v1.0.1** resolved in the test environment (verified in both the test `Project.toml` and `Manifest.toml`). On Julia 1.10.11:

```
     Testing Running tests...
[ Info: Testing ForwardDiff with NaN-safe mode disabled
##### Running all ForwardDiff tests took 424.34 seconds.
Test Summary:  | Pass  Total     Time
ForwardDiff.jl | 9037   9037  7m04.3s
     Testing ForwardDiff tests passed
```

All test sets (Partials, Dual, Derivatives, Gradients, Jacobians, Hessians, Perturbation Confusion, Miscellaneous, Allocations, and the QA/JET checks) pass with no failures.

## Motivation

This unblocks downstream packages that depend on both ForwardDiff and LogExpFunctions v1.x simultaneously, without forcing a constraint conflict in their environments.
