### PR TITLE
Proposal: Tagging API

### DIFF
--- a/ext/ForwardDiffStaticArraysExt.jl
+++ b/ext/ForwardDiffStaticArraysExt.jl
@@ -51,12 +51,12 @@ ForwardDiff._lyap_div!!(A::StaticArrays.MMatrix, λ::AbstractVector) = ForwardDi
 end
 
 @inline function ForwardDiff.vector_mode_gradient(f::F, x::StaticArray) where {F}
-    T = typeof(maketag(f,eltype(x)))
+    T = maketagtype(f,eltype(x))
     return extract_gradient(T, f(dualize(T, x)), x)
 end
 
 @inline function ForwardDiff.vector_mode_gradient!(result, f::F, x::StaticArray) where {F}
-    T = typeof(maketag(f,eltype(x)))
+    T = maketagtype(f,eltype(x))
     return extract_gradient!(T, result, f(dualize(T, x)))
 end
 
@@ -81,7 +81,7 @@ end
 end
 
 @inline function ForwardDiff.vector_mode_jacobian(f::F, x::StaticArray) where {F}
-    T = typeof(maketag(f,eltype(x)))
+    T = maketagtype(f,eltype(x))
     return extract_jacobian(T, f(dualize(T, x)), x)
 end
 
@@ -91,7 +91,7 @@ function extract_jacobian(::Type{T}, ydual::AbstractArray, x::StaticArray) where
 end
 
 @inline function ForwardDiff.vector_mode_jacobian!(result, f::F, x::StaticArray) where {F}
-    T = typeof(maketag(f,eltype(x)))
+    T = maketagtype(f,eltype(x))
     ydual = f(dualize(T, x))
     result = extract_jacobian!(T, result, ydual, length(x))
     result = extract_value!(T, result, ydual)
@@ -99,7 +99,7 @@ end
 end
 
 @inline function ForwardDiff.vector_mode_jacobian!(result::ImmutableDiffResult, f::F, x::StaticArray) where {F}
-    T = typeof(maketag(f,eltype(x)))
+    T = maketagtype(f,eltype(x))
     ydual = f(dualize(T, x))
     result = DiffResults.jacobian!(result, extract_jacobian(T, ydual, x))
     result = DiffResults.value!(Base.Fix1(value, T), result, ydual)
@@ -119,7 +119,7 @@ ForwardDiff.hessian!(result::ImmutableDiffResult, f::F, x::StaticArray, cfg::Hes
 ForwardDiff.hessian!(result::ImmutableDiffResult, f::F, x::StaticArray, cfg::HessianConfig, ::Val) where {F} = hessian!(result, f, x)
 
 function ForwardDiff.hessian!(result::ImmutableDiffResult, f::F, x::StaticArray) where {F}
-    T = typeof(maketag(f,eltype(x)))
+    T = maketagtype(f,eltype(x))
     d1 = dualize(T, x)
     d2 = dualize(T, d1)
     fd2 = f(d2)

--- a/ext/ForwardDiffStaticArraysExt.jl
+++ b/ext/ForwardDiffStaticArraysExt.jl
@@ -3,7 +3,7 @@ module ForwardDiffStaticArraysExt
 using ForwardDiff, StaticArrays
 using ForwardDiff.LinearAlgebra
 using ForwardDiff.DiffResults
-using ForwardDiff: Dual, partials, npartials, Partials, GradientConfig, JacobianConfig, HessianConfig, Tag, Chunk,
+using ForwardDiff: Dual, partials, npartials, Partials, GradientConfig, JacobianConfig, HessianConfig, Tag, Chunk, maketag
                    gradient, hessian, jacobian, gradient!, hessian!, jacobian!,
                    extract_gradient!, extract_jacobian!, extract_value!,
                    vector_mode_gradient, vector_mode_gradient!,
@@ -51,12 +51,12 @@ ForwardDiff._lyap_div!!(A::StaticArrays.MMatrix, λ::AbstractVector) = ForwardDi
 end
 
 @inline function ForwardDiff.vector_mode_gradient(f::F, x::StaticArray) where {F}
-    T = typeof(Tag(f, eltype(x)))
+    T = typeof(maketag(f,eltype(x)))
     return extract_gradient(T, f(dualize(T, x)), x)
 end
 
 @inline function ForwardDiff.vector_mode_gradient!(result, f::F, x::StaticArray) where {F}
-    T = typeof(Tag(f, eltype(x)))
+    T = typeof(maketag(f,eltype(x)))
     return extract_gradient!(T, result, f(dualize(T, x)))
 end
 
@@ -81,7 +81,7 @@ end
 end
 
 @inline function ForwardDiff.vector_mode_jacobian(f::F, x::StaticArray) where {F}
-    T = typeof(Tag(f, eltype(x)))
+    T = typeof(maketag(f,eltype(x)))
     return extract_jacobian(T, f(dualize(T, x)), x)
 end
 
@@ -91,7 +91,7 @@ function extract_jacobian(::Type{T}, ydual::AbstractArray, x::StaticArray) where
 end
 
 @inline function ForwardDiff.vector_mode_jacobian!(result, f::F, x::StaticArray) where {F}
-    T = typeof(Tag(f, eltype(x)))
+    T = typeof(maketag(f,eltype(x)))
     ydual = f(dualize(T, x))
     result = extract_jacobian!(T, result, ydual, length(x))
     result = extract_value!(T, result, ydual)
@@ -99,7 +99,7 @@ end
 end
 
 @inline function ForwardDiff.vector_mode_jacobian!(result::ImmutableDiffResult, f::F, x::StaticArray) where {F}
-    T = typeof(Tag(f, eltype(x)))
+    T = typeof(maketag(f,eltype(x)))
     ydual = f(dualize(T, x))
     result = DiffResults.jacobian!(result, extract_jacobian(T, ydual, x))
     result = DiffResults.value!(Base.Fix1(value, T), result, ydual)
@@ -119,7 +119,7 @@ ForwardDiff.hessian!(result::ImmutableDiffResult, f::F, x::StaticArray, cfg::Hes
 ForwardDiff.hessian!(result::ImmutableDiffResult, f::F, x::StaticArray, cfg::HessianConfig, ::Val) where {F} = hessian!(result, f, x)
 
 function ForwardDiff.hessian!(result::ImmutableDiffResult, f::F, x::StaticArray) where {F}
-    T = typeof(Tag(f, eltype(x)))
+    T = typeof(maketag(f,eltype(x)))
     d1 = dualize(T, x)
     d2 = dualize(T, d1)
     fd2 = f(d2)

--- a/ext/ForwardDiffStaticArraysExt.jl
+++ b/ext/ForwardDiffStaticArraysExt.jl
@@ -3,7 +3,7 @@ module ForwardDiffStaticArraysExt
 using ForwardDiff, StaticArrays
 using ForwardDiff.LinearAlgebra
 using ForwardDiff.DiffResults
-using ForwardDiff: Dual, partials, npartials, Partials, GradientConfig, JacobianConfig, HessianConfig, Tag, Chunk, maketag
+using ForwardDiff: Dual, partials, npartials, Partials, GradientConfig, JacobianConfig, HessianConfig, Tag, Chunk, maketagtype,
                    gradient, hessian, jacobian, gradient!, hessian!, jacobian!,
                    extract_gradient!, extract_jacobian!, extract_value!,
                    vector_mode_gradient, vector_mode_gradient!,

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,19 +1,3 @@
-#= 
-######
-# AbstractTag interface
-
-Required definitions: 
-- ≺ (between two AbstractTags of the same type)
-- maketagtype(f,::Type{V}) where {V <: Real}
-
-Optional definitions:
-- ≺ (between two AbstractTags of the of different type)
-- maketag(f,::Type{V}) where {V <: Real} (default: defined in terms of maketagtype)
-- checktag(tag::MyTagType,f,x)
-###### 
-=#
-abstract type AbstractTag{F,V} end
-
 #######
 # Tag #
 #######
@@ -38,10 +22,8 @@ Tag(::Nothing, ::Type{V}) where {V} = nothing
     tagcount(Tag{F1,V1}) < tagcount(Tag{F2,V2})
 end
 
+#default implementation of maketagtyp
 @inline maketagtype(f::F,::Type{V}) where {F,V} = Tag{F,V}
-@inline maketagtype(f::Nothing,::Type{V}) where {V} = Nothing
-
-@inline maketag(f::F,::Type{V}) where {F,V} = maketagtype(f,V)()
 
 struct InvalidTagException{E,O} <: Exception
 end

--- a/src/config.jl
+++ b/src/config.jl
@@ -38,10 +38,10 @@ Tag(::Nothing, ::Type{V}) where {V} = nothing
     tagcount(Tag{F1,V1}) < tagcount(Tag{F2,V2})
 end
 
-@inline maketagtype(f::F,::Type{V}) = Tag{F,V}
-@inline maketagtype(f::Nothing,::Type{V}) = Nothing
+@inline maketagtype(f::F,::Type{V}) where {F,V} = Tag{F,V}
+@inline maketagtype(f::Nothing,::Type{V}) where {F,V} = Nothing
 
-@inline maketag(f::F,::Type{V}) = maketagtype(f,V)()
+@inline maketag(f::F,::Type{V}) where {F,V} = maketagtype(f,V)()
 
 struct InvalidTagException{E,O} <: Exception
 end

--- a/src/config.jl
+++ b/src/config.jl
@@ -22,13 +22,8 @@ Tag(::Nothing, ::Type{V}) where {V} = nothing
     tagcount(Tag{F1,V1}) < tagcount(Tag{F2,V2})
 end
 
-#default implementation of maketagtype
-@inline maketagtype(f::F,::Type{V}) where {F,V} = Tag{F,V}
-
 #default implementation of maketag.
-#Tag needs the two-arg form to register the tagcount
 maketag(f::F,::Type{V}) where {F,V} = Tag(f,V)
-#@inline maketag(f::F,::Type{V}) where {F,V} = maketagtype(f,V)()
 
 struct InvalidTagException{E,O} <: Exception
 end

--- a/src/config.jl
+++ b/src/config.jl
@@ -18,7 +18,6 @@ abstract type AbstractTag{F,V} end
 # Tag #
 #######
 struct Tag{F,V} <: AbstractTag{F,V} end
-end
 
 const TAGCOUNT = Threads.Atomic{UInt}(0)
 

--- a/src/config.jl
+++ b/src/config.jl
@@ -39,7 +39,7 @@ Tag(::Nothing, ::Type{V}) where {V} = nothing
 end
 
 @inline maketagtype(f::F,::Type{V}) where {F,V} = Tag{F,V}
-@inline maketagtype(f::Nothing,::Type{V}) where {F,V} = Nothing
+@inline maketagtype(f::Nothing,::Type{V}) where {V} = Nothing
 
 @inline maketag(f::F,::Type{V}) where {F,V} = maketagtype(f,V)()
 
@@ -59,7 +59,7 @@ checktag(::Type{Tag{FT,VT}}, f::F, x::AbstractArray{V}) where {FT<:Tuple,VT,F,V}
 checktag(::Type{AbstractTag{FT,VT}}, f::F, x::AbstractArray{V}) where {FT<:Tuple,VT,F,V} = true
 
 #AbstractTag support
-checktag(T::Type{AbstractTag{FT,VT}}, f::F, x::AbstractArray{V}) where {FT,VT,F,V} =
+function checktag(T::Type{AbstractTag{FT,VT}}, f::F, x::AbstractArray{V}) where {FT,VT,F,V}
     T2 = maketagtype(f,V) #maketag(f::F,type{V})::AbstractTag{F2,V2} is not equivalent to Tag{F,V}
     T2 !== T && throw(InvalidTagException{T,T2}())
     return true

--- a/src/config.jl
+++ b/src/config.jl
@@ -22,8 +22,13 @@ Tag(::Nothing, ::Type{V}) where {V} = nothing
     tagcount(Tag{F1,V1}) < tagcount(Tag{F2,V2})
 end
 
-#default implementation of maketagtyp
+#default implementation of maketagtype
 @inline maketagtype(f::F,::Type{V}) where {F,V} = Tag{F,V}
+
+#default implementation of maketag.
+#Tag needs the two-arg form to register the tagcount
+maketag(f::F,::Type{V}) where {F,V} = Tag(f,V)
+#@inline maketag(f::F,::Type{V}) where {F,V} = maketagtype(f,V)()
 
 struct InvalidTagException{E,O} <: Exception
 end

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,8 +1,23 @@
+#= 
+######
+# AbstractTag interface
+
+Required definitions: 
+- ≺ (between two AbstractTags of the same type)
+- maketagtype(f,::Type{V}) where {V <: Real}
+
+Optional definitions:
+- ≺ (between two AbstractTags of the of different type)
+- maketag(f,::Type{V}) where {V <: Real} (default: defined in terms of maketagtype)
+- checktag(tag::MyTagType,f,x)
+###### 
+=#
+abstract type AbstractTag{F,V} end
+
 #######
 # Tag #
 #######
-
-struct Tag{F,V}
+struct Tag{F,V} <: AbstractTag{F,V} end
 end
 
 const TAGCOUNT = Threads.Atomic{UInt}(0)
@@ -20,10 +35,14 @@ end
 
 Tag(::Nothing, ::Type{V}) where {V} = nothing
 
-
 @inline function ≺(::Type{Tag{F1,V1}}, ::Type{Tag{F2,V2}}) where {F1,V1,F2,V2}
     tagcount(Tag{F1,V1}) < tagcount(Tag{F2,V2})
 end
+
+@inline maketagtype(f::F,::Type{V}) = Tag{F,V}
+@inline maketagtype(f::Nothing,::Type{V}) = Nothing
+
+@inline maketag(f::F,::Type{V}) = maketagtype(f,V)()
 
 struct InvalidTagException{E,O} <: Exception
 end
@@ -38,13 +57,18 @@ checktag(::Type{Tag{F,V}}, f::F, x::AbstractArray{V}) where {F,V} = true
 
 # no easy way to check Jacobian tag used with Hessians as multiple functions may be used
 checktag(::Type{Tag{FT,VT}}, f::F, x::AbstractArray{V}) where {FT<:Tuple,VT,F,V} = true
+checktag(::Type{AbstractTag{FT,VT}}, f::F, x::AbstractArray{V}) where {FT<:Tuple,VT,F,V} = true
 
-# custom tag: you're on your own.
+#AbstractTag support
+checktag(T::Type{AbstractTag{FT,VT}}, f::F, x::AbstractArray{V}) where {FT,VT,F,V} =
+    T2 = maketagtype(f,V) #maketag(f::F,type{V})::AbstractTag{F2,V2} is not equivalent to Tag{F,V}
+    T2 !== T && throw(InvalidTagException{T,T2}())
+    return true
+end
+
+# custom tag not in the tag API: you're on your own.
 checktag(z, f, x) = true
 
-#Tag maker function
-maketag(f::F,::Type{V}) where {F,V} = maketag(f, V)
-maketag(::Nothing,::Type{V}) where {V} = nothing
 
 ##################
 # AbstractConfig #

--- a/src/config.jl
+++ b/src/config.jl
@@ -42,6 +42,9 @@ checktag(::Type{Tag{FT,VT}}, f::F, x::AbstractArray{V}) where {FT<:Tuple,VT,F,V}
 # custom tag: you're on your own.
 checktag(z, f, x) = true
 
+#Tag maker function
+maketag(f::F,::Type{V}) where {F,V} = maketag(f, V)
+maketag(::Nothing,::Type{V}) where {V} = nothing
 
 ##################
 # AbstractConfig #
@@ -82,7 +85,7 @@ This constructor does not store/modify `y` or `x`.
 function DerivativeConfig(f::F,
                           y::AbstractArray{Y},
                           x::X,
-                          tag::T = Tag(f, X)) where {F,X<:Real,Y<:Real,T}
+                          tag::T = maketag(f, X)) where {F,X<:Real,Y<:Real,T}
     duals = similar(y, Dual{T,Y,1})
     return DerivativeConfig{T,typeof(duals)}(duals)
 end
@@ -117,7 +120,7 @@ This constructor does not store/modify `x`.
 function GradientConfig(f::F,
                         x::AbstractArray{V},
                         ::Chunk{N} = Chunk(x),
-                        ::T = Tag(f, V)) where {F,V,N,T}
+                        ::T = maketag(f, V)) where {F,V,N,T}
     seeds = construct_seeds(Partials{N,V})
     duals = similar(x, Dual{T,V,N})
     return GradientConfig{T,V,N,typeof(duals)}(seeds, duals)
@@ -154,7 +157,7 @@ This constructor does not store/modify `x`.
 function JacobianConfig(f::F,
                         x::AbstractArray{V},
                         ::Chunk{N} = Chunk(x),
-                        ::T = Tag(f, V)) where {F,V,N,T}
+                        ::T = maketag(f, V)) where {F,V,N,T}
     seeds = construct_seeds(Partials{N,V})
     duals = similar(x, Dual{T,V,N})
     return JacobianConfig{T,V,N,typeof(duals)}(seeds, duals)
@@ -180,7 +183,7 @@ function JacobianConfig(f::F,
                         y::AbstractArray{Y},
                         x::AbstractArray{X},
                         ::Chunk{N} = Chunk(x),
-                        ::T = Tag(f, X)) where {F,Y,X,N,T}
+                        ::T = maketag(f, X)) where {F,Y,X,N,T}
     seeds = construct_seeds(Partials{N,X})
     yduals = similar(y, Dual{T,Y,N})
     xduals = similar(x, Dual{T,X,N})
@@ -221,7 +224,7 @@ This constructor does not store/modify `x`.
 function HessianConfig(f::F,
                        x::AbstractArray{V},
                        chunk::Chunk = Chunk(x),
-                       tag = Tag(f, V)) where {F,V}
+                       tag = maketag(f, V)) where {F,V}
     jacobian_config = JacobianConfig(f, x, chunk, tag)
     gradient_config = GradientConfig(f, jacobian_config.duals, chunk, tag)
     return HessianConfig(jacobian_config, gradient_config)
@@ -246,7 +249,7 @@ function HessianConfig(f::F,
                        result::DiffResult,
                        x::AbstractArray{V},
                        chunk::Chunk = Chunk(x),
-                       tag = Tag(f, V)) where {F,V}
+                       tag = maketag(f, V)) where {F,V}
     jacobian_config = JacobianConfig((f,gradient), DiffResults.gradient(result), x, chunk, tag)
     gradient_config = GradientConfig(f, jacobian_config.duals[2], chunk, tag)
     return HessianConfig(jacobian_config, gradient_config)

--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -10,7 +10,7 @@ Return `df/dx` evaluated at `x`, assuming `f` is called as `f(x)`.
 This method assumes that `isa(f(x), Union{Real,AbstractArray})`.
 """
 @inline function derivative(f::F, x::R) where {F,R<:Real}
-    T = typeof(maketag(f, R))
+    T = maketagtype(f,R)
     return extract_derivative(T, f(Dual{T}(x, one(x))))
 end
 
@@ -44,7 +44,7 @@ This method assumes that `isa(f(x), Union{Real,AbstractArray})`.
 @inline function derivative!(result::Union{AbstractArray,DiffResult},
                              f::F, x::R) where {F,R<:Real}
     result isa DiffResult || require_one_based_indexing(result)
-    T = typeof(maketag(f, R))
+    T = maketagtype(f,R)
     ydual = f(Dual{T}(x, one(x)))
     result = extract_value!(T, result, ydual)
     result = extract_derivative!(T, result, ydual)

--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -10,7 +10,7 @@ Return `df/dx` evaluated at `x`, assuming `f` is called as `f(x)`.
 This method assumes that `isa(f(x), Union{Real,AbstractArray})`.
 """
 @inline function derivative(f::F, x::R) where {F,R<:Real}
-    T = typeof(Tag(f, R))
+    T = typeof(maketag(f, R))
     return extract_derivative(T, f(Dual{T}(x, one(x))))
 end
 
@@ -44,7 +44,7 @@ This method assumes that `isa(f(x), Union{Real,AbstractArray})`.
 @inline function derivative!(result::Union{AbstractArray,DiffResult},
                              f::F, x::R) where {F,R<:Real}
     result isa DiffResult || require_one_based_indexing(result)
-    T = typeof(Tag(f, R))
+    T = typeof(maketag(f, R))
     ydual = f(Dual{T}(x, one(x)))
     result = extract_value!(T, result, ydual)
     result = extract_derivative!(T, result, ydual)

--- a/src/prelude.jl
+++ b/src/prelude.jl
@@ -85,4 +85,4 @@ Optional definitions:
 abstract type AbstractTag{F,V} end
 
 @inline maketagtype(f::Nothing,::Type{V}) where {V} = Nothing
-@inline maketag(f::F,::Type{V}) where {F,V} = maketagtype(f,V)()
+function maketag end

--- a/src/prelude.jl
+++ b/src/prelude.jl
@@ -67,3 +67,22 @@ function qualified_cse!(expr)
     end
     return cse_expr
 end
+
+#= 
+######
+# AbstractTag interface
+
+Required definitions: 
+- ≺ (between two AbstractTags of the same type)
+- maketagtype(f,::Type{V}) where {V <: Real}
+
+Optional definitions:
+- ≺ (between two AbstractTags of the of different type)
+- maketag(f,::Type{V}) where {V <: Real} (default: defined in terms of maketagtype)
+- checktag(tag::MyTagType,f,x)
+###### 
+=#
+abstract type AbstractTag{F,V} end
+
+@inline maketagtype(f::Nothing,::Type{V}) where {V} = Nothing
+@inline maketag(f::F,::Type{V}) where {F,V} = maketagtype(f,V)()

--- a/src/prelude.jl
+++ b/src/prelude.jl
@@ -74,15 +74,15 @@ end
 
 Required definitions: 
 - ≺ (between two AbstractTags of the same type)
-- maketagtype(f,::Type{V}) where {V <: Real}
+- maketag(f,::Type{V}) where {V <: Real}
 
 Optional definitions:
 - ≺ (between two AbstractTags of the of different type)
-- maketag(f,::Type{V}) where {V <: Real} (default: defined in terms of maketagtype)
+- maketagtype(f,::Type{V}) where {V <: Real} (default: defined in terms of maketag)
 - checktag(tag::MyTagType,f,x)
 ###### 
 =#
 abstract type AbstractTag{F,V} end
 
-@inline maketagtype(f::Nothing,::Type{V}) where {V} = Nothing
-function maketag end
+maketag(::Nothing,::Type{V}) where {V} = nothing
+@inline maketagtype(f::F,::Type{V}) where {F,V} = typeof(maketag(f,V))

--- a/test/JacobianTest.jl
+++ b/test/JacobianTest.jl
@@ -110,7 +110,7 @@ for f in DiffTests.ARRAY_TO_ARRAY_FUNCS
     @test isapprox(j, Calculus.jacobian(x -> vec(f(x)), X, :forward), atol=1.3FINITEDIFF_ERROR)
     @testset "$f with chunk size = $c and tag = $(repr(tag))" for c in CHUNK_SIZES, tag in (nothing, Tag)
         if tag == Tag
-            tag = maketag(f, eltype(X))
+            tag = Tag(f, eltype(X))
         end
         cfg = JacobianConfig(f, X, ForwardDiff.Chunk{c}(), tag)
 

--- a/test/JacobianTest.jl
+++ b/test/JacobianTest.jl
@@ -110,7 +110,7 @@ for f in DiffTests.ARRAY_TO_ARRAY_FUNCS
     @test isapprox(j, Calculus.jacobian(x -> vec(f(x)), X, :forward), atol=1.3FINITEDIFF_ERROR)
     @testset "$f with chunk size = $c and tag = $(repr(tag))" for c in CHUNK_SIZES, tag in (nothing, Tag)
         if tag == Tag
-            tag = Tag(f, eltype(X))
+            tag = maketag(f, eltype(X))
         end
         cfg = JacobianConfig(f, X, ForwardDiff.Chunk{c}(), tag)
 


### PR DESCRIPTION
This PR proposes a Tagging API. the main objective is to provide external ForwardDiff users a way to control tag generation and comparison. The API is composed of:

- `AbstractTag{F,V}`: Abstract type for all tags following the Tagging API.
- `maketag(f::F,::Type{V})`: generates an instance of a tag, given an instance of a function `f` and a element type `V` will generate a tag that follows the tag API.

Some invariants:

- All tags are defined as a combination of a "callable" type `f` and a element type `V`.
- `V` should be a number (not enforced at the `AbstractTag` level, i don't know if any package does something weird here)
- dispatch for custom tags is done via dispatching on `f::F`, where `f` should behave according to the context it was used
- two tag types can be compared by the combination of the callable type and the element type. If they have the same callable type and the same element type, they are considered equal for the purposes of tag comparison.
  
Note that the invariants above do not imply that `maketagtype(f::F,::Type{V}) == MyTag{F,V}`. For example, `F` could have additional information about closed-over variables that we want to move over to `V`.

One application for this API is to create a `StaticTag` type that does comparisons via inspecting the fields of the closures (like what's proposed in #807), or for a `HashedTag` type (like what was tried in #748). More importantly, experimenting with new tag types can be done in external packages, instead of PRs to `ForwardDiff`.

Closes #813

Any comments are really appreciated.