### PR TITLE
Seed dense arrays of isbits duals without scalar indexing (fixes GPU jacobians)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ForwardDiff"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "1.4.1"
+version = "1.4.2"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"
@@ -28,6 +28,7 @@ DiffRules = "1.4"
 DiffTests = "0.1"
 IrrationalConstants = "0.1, 0.2"
 JET = "0.9, 0.10, 0.11"
+JLArrays = "0.1, 0.2"
 LogExpFunctions = "0.3, 1"
 NaNMath = "1"
 Preferences = "1"
@@ -41,9 +42,10 @@ DiffTests = "de460e47-3fe3-5279-bb4a-814414816d5d"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Calculus", "DiffTests", "IrrationalConstants", "JET", "SparseArrays", "StaticArrays", "Test", "InteractiveUtils"]
+test = ["Calculus", "DiffTests", "IrrationalConstants", "JET", "JLArrays", "SparseArrays", "StaticArrays", "Test", "InteractiveUtils"]

--- a/Project.toml
+++ b/Project.toml
@@ -28,6 +28,7 @@ DiffRules = "1.4"
 DiffTests = "0.1"
 IrrationalConstants = "0.1, 0.2"
 JET = "0.9, 0.12"
+JLArrays = "0.1, 0.2"
 LogExpFunctions = "0.3, 1"
 NaNMath = "1"
 Preferences = "1"
@@ -41,9 +42,10 @@ DiffTests = "de460e47-3fe3-5279-bb4a-814414816d5d"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Calculus", "DiffTests", "IrrationalConstants", "JET", "SparseArrays", "StaticArrays", "Test", "InteractiveUtils"]
+test = ["Calculus", "DiffTests", "IrrationalConstants", "JET", "JLArrays", "SparseArrays", "StaticArrays", "Test", "InteractiveUtils"]

--- a/src/apiutils.jl
+++ b/src/apiutils.jl
@@ -70,11 +70,29 @@ function structural_eachindex(x::Diagonal, y::AbstractArray)
     return diagind(x)
 end
 
+@inline function dense_seedable(duals, x, ::Type{V}) where {V}
+    return duals isa DenseArray && isbitstype(V) && !Base.has_offset_axes(duals, x)
+end
+
+struct SeededDual{D,S}
+    seeds::S
+    offset::Int
+end
+
+@inline (f::SeededDual{D})(x) where {D} = D(x, f.seeds)
+@inline (f::SeededDual{D})(x, i) where {D} = D(x, f.seeds[i - f.offset])
+
 # Copies the values of `x` into `duals` with zero partials. Used both to remove seeds `duals` is
 # currently carrying and to initialize a freshly allocated work buffer, whose elements must all be
 # written before the target function reads them.
-seed_zero_partials!(duals::AbstractArray{Dual{T,V,N}}, x) where {T,V,N} =
-    _seed_zero_partials!(duals, x, structural_eachindex(duals, x))
+function seed_zero_partials!(duals::AbstractArray{Dual{T,V,N}}, x) where {T,V,N}
+    seed = zero(Partials{N,V})
+    if dense_seedable(duals, x, V) && axes(duals) == axes(x)
+        duals .= Dual{T,V,N}.(x, Ref(seed))
+        return duals
+    end
+    return _seed_zero_partials!(duals, x, structural_eachindex(duals, x))
+end
 
 # Zeroes the partials of `count` elements starting at structural position `index`. Chunk mode only
 # needs to clear the chunk it just seeded, so writing through to the end of the array would be O(n)
@@ -82,6 +100,15 @@ seed_zero_partials!(duals::AbstractArray{Dual{T,V,N}}, x) where {T,V,N} =
 # `seed!(duals, x, index, seeds, chunksize)`.
 function seed_zero_partials!(duals::AbstractArray{Dual{T,V,N}}, x, index,
                              count = N) where {T,V,N}
+    if dense_seedable(duals, x, V)
+        length(duals) == length(x) || throw(DimensionMismatch())
+        last_index = min(index + count - 1, length(duals))
+        dual_inds = index:last_index
+        seed = zero(Partials{N,V})
+        f = SeededDual{Dual{T,V,N},typeof(seed)}(seed, 0)
+        map!(f, view(duals, dual_inds), view(x, dual_inds))
+        return duals
+    end
     idxs = Iterators.take(Iterators.drop(structural_eachindex(duals, x), index - 1), count)
     return _seed_zero_partials!(duals, x, idxs)
 end
@@ -106,7 +133,12 @@ end
 
 function seed!(duals::AbstractArray{Dual{T,V,N}}, x,
                seeds::NTuple{N,Partials{N,V}}) where {T,V,N}
-    if isbitstype(V)
+    if dense_seedable(duals, x, V)
+        length(duals) == length(x) || throw(DimensionMismatch())
+        dual_inds = 1:min(N, length(duals))
+        f = SeededDual{Dual{T,V,N},typeof(seeds)}(seeds, 0)
+        map!(f, view(duals, dual_inds), view(x, dual_inds), dual_inds)
+    elseif isbitstype(V)
         for (i, idx) in zip(1:N, structural_eachindex(duals, x))
             duals[idx] = Dual{T,V,N}(x[idx], seeds[i])
         end
@@ -124,6 +156,14 @@ end
 
 function seed!(duals::AbstractArray{Dual{T,V,N}}, x, index,
                seeds::NTuple{N,Partials{N,V}}, chunksize = N) where {T,V,N}
+    if dense_seedable(duals, x, V)
+        length(duals) == length(x) || throw(DimensionMismatch())
+        shift = index - 1
+        dual_inds = (1 + shift):min(shift + chunksize, length(duals))
+        f = SeededDual{Dual{T,V,N},typeof(seeds)}(seeds, shift)
+        map!(f, view(duals, dual_inds), view(x, dual_inds), dual_inds)
+        return duals
+    end
     offset = index - 1
     idxs = Iterators.drop(structural_eachindex(duals, x), offset)
     if isbitstype(V)

--- a/src/apiutils.jl
+++ b/src/apiutils.jl
@@ -70,9 +70,21 @@ function structural_eachindex(x::Diagonal, y::AbstractArray)
     return diagind(x)
 end
 
+# Dense arrays with isbits values need no structural-index or unset-element
+# handling, so they can be seeded with broadcast/`map!` over contiguous views.
+# This keeps GPU arrays (`AbstractGPUArray <: DenseArray`) free of scalar
+# indexing and avoids the O(index) `Iterators.drop` walk of the structural
+# path. Broadcast is fastest for the bulk writes; the chunk writes use `map!`
+# with an index range because slicing the seeds tuple at runtime allocates.
+@inline function dense_seedable(duals, x, ::Type{V}) where {V}
+    duals isa DenseArray && isbitstype(V) && !Base.has_offset_axes(duals, x)
+end
+
 function seed!(duals::AbstractArray{Dual{T,V,N}}, x,
                seed::Partials{N,V} = zero(Partials{N,V})) where {T,V,N}
-    if isbitstype(V)
+    if dense_seedable(duals, x, V) && axes(duals) == axes(x)
+        duals .= Dual{T,V,N}.(x, Ref(seed))
+    elseif isbitstype(V)
         for idx in structural_eachindex(duals, x)
             duals[idx] = Dual{T,V,N}(x[idx], seed)
         end
@@ -90,7 +102,12 @@ end
 
 function seed!(duals::AbstractArray{Dual{T,V,N}}, x,
                seeds::NTuple{N,Partials{N,V}}) where {T,V,N}
-    if isbitstype(V)
+    if dense_seedable(duals, x, V)
+        length(duals) == length(x) || throw(DimensionMismatch())
+        dual_inds = 1:min(N, length(duals))
+        map!((xi, i) -> Dual{T,V,N}(xi, seeds[i]),
+             view(duals, dual_inds), view(x, dual_inds), dual_inds)
+    elseif isbitstype(V)
         for (i, idx) in zip(1:N, structural_eachindex(duals, x))
             duals[idx] = Dual{T,V,N}(x[idx], seeds[i])
         end
@@ -108,6 +125,14 @@ end
 
 function seed!(duals::AbstractArray{Dual{T,V,N}}, x, index,
                seed::Partials{N,V} = zero(Partials{N,V})) where {T,V,N}
+    if dense_seedable(duals, x, V)
+        length(duals) == length(x) || throw(DimensionMismatch())
+        dual_inds = index:length(duals)
+        # map! rather than broadcast: the dotview allocates under
+        # --check-bounds=yes on Julia 1.10
+        map!(xi -> Dual{T,V,N}(xi, seed), view(duals, dual_inds), view(x, dual_inds))
+        return duals
+    end
     offset = index - 1
     idxs = Iterators.drop(structural_eachindex(duals, x), offset)
     if isbitstype(V)
@@ -128,6 +153,14 @@ end
 
 function seed!(duals::AbstractArray{Dual{T,V,N}}, x, index,
                seeds::NTuple{N,Partials{N,V}}, chunksize = N) where {T,V,N}
+    if dense_seedable(duals, x, V)
+        length(duals) == length(x) || throw(DimensionMismatch())
+        shift = index - 1
+        dual_inds = (1 + shift):min(shift + chunksize, length(duals))
+        map!((xi, i) -> Dual{T,V,N}(xi, seeds[i - shift]),
+             view(duals, dual_inds), view(x, dual_inds), dual_inds)
+        return duals
+    end
     offset = index - 1
     idxs = Iterators.drop(structural_eachindex(duals, x), offset)
     if isbitstype(V)

--- a/test/GPUArraysTest.jl
+++ b/test/GPUArraysTest.jl
@@ -1,0 +1,56 @@
+module GPUArraysTest
+
+using ForwardDiff, Test
+using JLArrays
+
+# JLArrays emulates GPU array semantics (including the scalar-indexing ban) on
+# the CPU, so the dense-array `seed!` fast paths can be exercised on a GPU-like
+# array type without a physical GPU. GPU arrays are covered by the dense fast
+# paths because `AbstractGPUArray <: DenseArray`.
+JLArrays.allowscalar(false)
+
+@testset "ForwardDiff seeding on GPU arrays" begin
+    f(x) = x .^ 2 .+ 2 .* x
+
+    @testset "jacobian, vector mode (length $n)" for n in (1, 4, 8)
+        x = collect(Float64, 1:n)
+        @test Array(ForwardDiff.jacobian(f, JLArray(x))) == ForwardDiff.jacobian(f, x)
+    end
+
+    # lengths above the chunk size exercise the chunked `seed!` methods
+    @testset "jacobian, chunk mode (length $n, chunk $c)" for n in (16, 20, 27), c in (4, 8)
+        x = collect(Float64, 1:n)
+        cfg = ForwardDiff.JacobianConfig(f, JLArray(x), ForwardDiff.Chunk{c}())
+        @test Array(ForwardDiff.jacobian(f, JLArray(x), cfg)) == ForwardDiff.jacobian(f, x)
+    end
+
+    @testset "jacobian! into a GPU array (length $n)" for n in (4, 16)
+        x = collect(Float64, 1:n)
+        out = JLArray(zeros(n, n))
+        ForwardDiff.jacobian!(out, f, JLArray(x))
+        @test Array(out) == ForwardDiff.jacobian(f, x)
+    end
+
+    @testset "jacobian of f! with GPU input and output" begin
+        f!(y, x) = (y .= x .^ 2 .+ 2 .* x; nothing)
+        x = collect(Float64, 1:8)
+        y = zeros(8)
+        J = ForwardDiff.jacobian(f!, JLArray(y), JLArray(x))
+        @test Array(J) == ForwardDiff.jacobian(f!, y, x)
+    end
+
+    @testset "jacobian with matrix input (chunk $c)" for c in (3, 6)
+        X = reshape(collect(Float64, 1:12), 4, 3)
+        g(x) = x .* sum(x)
+        cfg = ForwardDiff.JacobianConfig(g, JLArray(X), ForwardDiff.Chunk{c}())
+        @test Array(ForwardDiff.jacobian(g, JLArray(X), cfg)) ≈ ForwardDiff.jacobian(g, X)
+    end
+
+    @testset "jacobian with view input" begin
+        X = JLArray(reshape(collect(Float64, 1:18), 6, 3))
+        xv = view(X, :, 2)
+        @test Array(ForwardDiff.jacobian(f, xv)) == ForwardDiff.jacobian(f, Array(xv))
+    end
+end
+
+end # module

--- a/test/GPUArraysTest.jl
+++ b/test/GPUArraysTest.jl
@@ -1,0 +1,64 @@
+module GPUArraysTest
+
+using ForwardDiff, Test
+using JLArrays
+
+# Exercise GPU array semantics, including the scalar-indexing ban, without physical GPU hardware.
+JLArrays.allowscalar(false)
+
+@testset "ForwardDiff seeding on GPU arrays" begin
+    f(x) = x .^ 2 .+ 2 .* x
+
+    @testset "zero chunk tail" begin
+        values = collect(Float64, 1:20)
+        x = JLArray(values)
+        duals = JLArray([ForwardDiff.Dual{Nothing}(xi, 1.0) for xi in values])
+        ForwardDiff.seed_zero_partials!(duals, x, 5, 12)
+        result = Array(duals)
+        @test ForwardDiff.value.(result) == values
+        @test [ForwardDiff.partials(d)[1] for d in result] ==
+            [ones(4); zeros(12); ones(4)]
+    end
+
+    @testset "jacobian, vector mode (length $n)" for n in (1, 4, 8)
+        x = collect(Float64, 1:n)
+        @test Array(ForwardDiff.jacobian(f, JLArray(x))) == ForwardDiff.jacobian(f, x)
+    end
+
+    # lengths above the chunk size exercise the chunked `seed!` methods
+    @testset "jacobian, chunk mode (length $n, chunk $c)" for n in (16, 20, 27), c in (4, 8)
+        x = collect(Float64, 1:n)
+        cfg = ForwardDiff.JacobianConfig(f, JLArray(x), ForwardDiff.Chunk{c}())
+        @test Array(ForwardDiff.jacobian(f, JLArray(x), cfg)) == ForwardDiff.jacobian(f, x)
+    end
+
+    @testset "jacobian! into a GPU array (length $n)" for n in (4, 16)
+        x = collect(Float64, 1:n)
+        out = JLArray(zeros(n, n))
+        ForwardDiff.jacobian!(out, f, JLArray(x))
+        @test Array(out) == ForwardDiff.jacobian(f, x)
+    end
+
+    @testset "jacobian of f! with GPU input and output" begin
+        f!(y, x) = (y .= x .^ 2 .+ 2 .* x; nothing)
+        x = collect(Float64, 1:8)
+        y = zeros(8)
+        J = ForwardDiff.jacobian(f!, JLArray(y), JLArray(x))
+        @test Array(J) == ForwardDiff.jacobian(f!, y, x)
+    end
+
+    @testset "jacobian with matrix input (chunk $c)" for c in (3, 6)
+        X = reshape(collect(Float64, 1:12), 4, 3)
+        g(x) = x .* sum(x)
+        cfg = ForwardDiff.JacobianConfig(g, JLArray(X), ForwardDiff.Chunk{c}())
+        @test Array(ForwardDiff.jacobian(g, JLArray(X), cfg)) ≈ ForwardDiff.jacobian(g, X)
+    end
+
+    @testset "jacobian with view input" begin
+        X = JLArray(reshape(collect(Float64, 1:18), 6, 3))
+        xv = view(X, :, 2)
+        @test Array(ForwardDiff.jacobian(f, xv)) == ForwardDiff.jacobian(f, Array(xv))
+    end
+end
+
+end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,6 +43,11 @@ Random.seed!(SEED)
         t = @elapsed include("ConfusionTest.jl")
         println("##### done (took $t seconds).")
     end
+    @testset "GPUArrays" begin
+        println("##### Testing seeding on GPU arrays...")
+        t = @elapsed include("GPUArraysTest.jl")
+        println("##### done (took $t seconds).")
+    end
     @testset "Miscellaneous" begin
         println("##### Testing miscellaneous functionality...")
         t = @elapsed include("MiscTest.jl")


### PR DESCRIPTION
## What changed and why

ForwardDiff GPU Jacobians currently fail because the seeding helpers scalar-index GPU arrays. An independent clean-checkout bisect found two regression points:

- `fce7f76cf8885ded3e150f11645c772961ce8dc5` (released in v1.0.1) replaced broadcast seeding with scalar `seed!` loops.
- `a337ee6658ed2a26bfa7251f1580da59c0b36625` (merged in PR 821 and released in v1.4.4) added the chunk-tail `seed_zero_partials!` call, which introduced a second scalar-indexing path.

The older `seed!` failure normally masks the newer tail-clear failure. This PR therefore fixes both paths: dense arrays with isbits values use broadcast for full-buffer writes and `map!` over contiguous views for chunk writes. A concrete isbits callable carries the seed tuple and offset into `map!`, avoiding captured closures. Structural wrappers, offset axes, and non-isbits values retain the existing structural fallback.

The runtime implementation uses only Base array interfaces and has no GPUArraysCore dependency or `AbstractGPUArray` dispatch. JLArrays is added only as a test dependency; it is MIT-licensed, matching ForwardDiff's license.

## Downstream fallout

DeepEquilibriumNetworks PR 243 works around the v1.4.4 failure by selecting `autodiff=false` for GPU steady-state adjoints. Do not revert that workaround before DeepEquilibriumNetworks requires a ForwardDiff release containing this PR: reverting earlier restores the CuArray failure.

After such a ForwardDiff release is required, the regression-specific need for PR 243 is gone. Whether to revert it is then a policy choice:

- Revert it if DeepEquilibriumNetworks intends to use ForwardDiff Jacobians on GPU, after an actual CUDA steady-state adjoint run passes; the direct GPUArraysCore dependency added by PR 243 can then move back to a test extra or be removed if unused.
- Keep it if DeepEquilibriumNetworks intends to continue matching SciMLSensitivity's own GPU-specific `autodiff=false` default.

In short: treat PR 243 as release-gated cleanup, not an immediate revert.

## Regression evidence

The final GPU-like test file was applied to clean `master` and run with scalar indexing disabled:

```text
zero chunk tail: Error During Test
  Scalar indexing is disallowed.
  [6] _seed_zero_partials!(...)
      @ ForwardDiff src/apiutils.jl:93

Test Summary:                               | Error  Total
ForwardDiff seeding on GPU arrays           |    16     16
ERROR: Some tests did not pass: 0 passed, 0 failed, 16 errored, 0 broken.
```

The same test on this PR passes:

```text
Test Summary:                     | Pass  Total   Time
ForwardDiff seeding on GPU arrays |   17     17  44.4s
```

The focused command was:

```bash
TMPDIR="$HOME/tmp" ~/.juliaup/bin/julia +release --startup-file=no -e \
  'using Pkg; Pkg.activate(; temp=true); Pkg.develop(path=pwd()); Pkg.add(name="JLArrays", version="0.2"); include("test/GPUArraysTest.jl")'
```

## Full verification

```bash
TMPDIR="$HOME/tmp" ~/.juliaup/bin/julia +lts \
  --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
```

```text
Test Summary:  | Pass  Total     Time
ForwardDiff.jl | 9309   9309  8m15.3s
Testing ForwardDiff tests passed
```

```bash
TMPDIR="$HOME/tmp" ~/.juliaup/bin/julia +release \
  --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
```

```text
Test Summary:  | Pass  Total      Time
ForwardDiff.jl | 9327   9327  12m35.4s
Testing ForwardDiff tests passed
```

Both full runs include allocations and JET QA. These checks also exited successfully with no output:

```bash
~/.juliaup/bin/julia +release -m Runic --check test/GPUArraysTest.jl test/runtests.jl
typos Project.toml src/apiutils.jl test/GPUArraysTest.jl test/runtests.jl
git diff --check
```

Fresh Julia 1.12.6 process-local medians against current `master` after PR 821:

| benchmark | master | this PR |
|---|---:|---:|
| `gradient!`, n=1000 | 277.2 µs | 222.5 µs |
| `jacobian!`, n=100 | 39.3 µs | 27.2 µs |
| `jacobian!`, n=1000 | 4.13 ms | 3.30 ms |

Small n=10 gradient timings varied between process runs, so no directional claim is made for that case.

The review-requested replacement of captured closures with the concrete callable was also compared in fresh Julia processes. Against the preceding PR head, medians were 223.9 µs vs 222.5 µs for `gradient!` at n=1000, 38.6 µs vs 27.2 µs for `jacobian!` at n=100, and 3.86 ms vs 3.30 ms for `jacobian!` at n=1000. Allocation tests in the full suite remain green.

## CI

All 27 checks on current head `8697dff` pass, including the full Linux/macOS/Windows matrix across minimum-patch, LTS, Julia 1, and prerelease versions with NaN-safe mode enabled and disabled: https://github.com/JuliaDiff/ForwardDiff.jl/actions/runs/33137219763. Codecov reports 90.94% project coverage (+0.25% from `master`) and covers every modified line: https://app.codecov.io/gh/JuliaDiff/ForwardDiff.jl/pull/816.

The preceding tree-identical CI attempt had one randomized `gamma_inc` tolerance failure on Windows Julia 1.12.7. The exact values reproduce on clean `master` with that job's seed and do not involve this PR's code; the failing job and clean-master reproduction are documented at https://github.com/JuliaDiff/ForwardDiff.jl/pull/816#issuecomment-5447801230. No assertion was loosened or silenced.

## Not verified locally

- No physical CUDA GPU was available. JLArrays exercises GPU array dispatch and the scalar-indexing ban on CPU; CI still needs to cover actual device compilation.
- NaN-safe-enabled, prerelease Julia, Windows, and macOS jobs were not run locally.
- Documentation was not built because this changes no public API, docstring, or documentation source.

> [!NOTE]
> This remains a draft opened by an agent on behalf of @ChrisRackauckas. Please ignore it until reviewed by @ChrisRackauckas.

## Links

- ForwardDiff PR: https://github.com/JuliaDiff/ForwardDiff.jl/pull/816
- Chunk-tail change: https://github.com/JuliaDiff/ForwardDiff.jl/pull/821
- DeepEquilibriumNetworks workaround: https://github.com/SciML/DeepEquilibriumNetworks.jl/pull/243
- First scalar-seeding regression: https://github.com/JuliaDiff/ForwardDiff.jl/commit/fce7f76cf8885ded3e150f11645c772961ce8dc5
- Chunk-tail scalar-zeroing regression: https://github.com/JuliaDiff/ForwardDiff.jl/commit/a337ee6658ed2a26bfa7251f1580da59c0b36625

🤖 Generated with Codex CLI 0.150.1 (model: unknown; session: 01a04603-0ac8-7570-9713-851acf5b8f5d)
