### PR TITLE
Declare documented API `public` (for downstream ExplicitImports)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ForwardDiff"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "1.4.1"
+version = "1.4.2"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"

--- a/src/ForwardDiff.jl
+++ b/src/ForwardDiff.jl
@@ -24,4 +24,8 @@ include("hessian.jl")
 
 export DiffResults
 
+@static if VERSION >= v"1.11.0-DEV.469"
+    eval(Expr(:public, :derivative, :derivative!, :gradient, :gradient!, :jacobian, :jacobian!, :hessian, :hessian!, :GradientConfig, :JacobianConfig, :HessianConfig, :DerivativeConfig, :Chunk, :Dual, :value, :can_dual))
+end
+
 end # module


### PR DESCRIPTION
## Motivation

ForwardDiff currently `export`s only `DiffResults` and does **not** declare any names `public`. As a result, downstream packages that access the documented API in qualified form — e.g. `ForwardDiff.jacobian`, `ForwardDiff.gradient`, `ForwardDiff.GradientConfig` — get flagged by [ExplicitImports.jl](https://github.com/ericphanson/ExplicitImports.jl)'s `check_all_qualified_accesses_are_public`, because to that tool every one of these reads as "non-public" (not exported, not declared `public`), even though the documentation presents them as the public API.

Many SciML packages (and others) run ExplicitImports as part of their QA suite, so each currently has to carry a manual ignore-list entry for ForwardDiff names. Declaring the documented surface `public` lets that boilerplate go away and makes the package's public/internal boundary explicit to tooling.

## What this does

Adds a single `Expr(:public, ...)` declaration near the end of `src/ForwardDiff.jl` covering the names that are documented as the public API:

- Core entry points (in the `@docs` blocks of `docs/src/user/api.md`): `derivative`, `derivative!`, `gradient`, `gradient!`, `jacobian`, `jacobian!`, `hessian`, `hessian!`
- Config types (also `@docs` in `api.md`): `DerivativeConfig`, `GradientConfig`, `JacobianConfig`, `HessianConfig`
- User-facing types/accessors documented in the user guides: `Chunk` (Configuring Chunk Size), `Dual` (Custom tags), `value` (Retrieving Lower-Order Results), and `can_dual` (has a `ForwardDiff.can_dual` docstring and is referenced as a user-extensible hook in the cannot-dual error message)

**Exports are unchanged** — this only marks names `public`, it does not bring anything into downstream scope unqualified.

`public` was added in Julia 1.11, so the declaration is `@static`-guarded (`VERSION >= v"1.11.0-DEV.469"`); **Julia 1.10 is completely unaffected** (the block is simply not evaluated there).

## Deliberately *not* included

I left out names that appear only in the internals/implementation doc (`docs/src/dev/how_it_works.md`) and are not presented to users as public API: `Partials`, `partials`, `npartials`, and `Tag`. If maintainers consider any of these part of the supported surface, I'm happy to add them.

## Note

This is a **draft / proposal** for maintainer consideration — please feel free to adjust the exact set of names. Marked draft and should be ignored until reviewed by @ChrisRackauckas.