### PR TITLE
Order nested Dual tags by provable containment (supersedes #807)

### DIFF
--- a/src/config.jl
+++ b/src/config.jl
@@ -20,10 +20,16 @@ end
 
 Tag(::Nothing, ::Type{V}) where {V} = nothing
 
+@inline tagdepth(::Type) = 0
+@inline tagdepth(::Type{<:Dual{T,V,N}}) where {T,V,N} = 1 + tagdepth(V)
+@inline tagdepth(::Type{<:Tag{F,V}}) where {F,V} = 1 + tagdepth(V)
 
 @inline function ≺(::Type{Tag{F1,V1}}, ::Type{Tag{F2,V2}}) where {F1,V1,F2,V2}
-    tagcount(Tag{F1,V1}) < tagcount(Tag{F2,V2})
-end
+      d1 = tagdepth(Tag{F1,V1})
+      d2 = tagdepth(Tag{F2,V2})
+      d1 != d2 && return d1 < d2
+      return tagcount(Tag{F1,V1}) < tagcount(Tag{F2,V2})
+  end
 
 struct InvalidTagException{E,O} <: Exception
 end

--- a/src/config.jl
+++ b/src/config.jl
@@ -20,16 +20,44 @@ end
 
 Tag(::Nothing, ::Type{V}) where {V} = nothing
 
-@inline tagdepth(::Type) = 0
-@inline tagdepth(::Type{<:Dual{T,V,N}}) where {T,V,N} = 1 + tagdepth(V)
-@inline tagdepth(::Type{<:Tag{F,V}}) where {F,V} = 1 + tagdepth(V)
+# A tag `T1` provably nests a tag `T2` when `T2` appears inside `T1`'s type
+# structure: in the seeded value type `V1`, or captured by the function type `F1`
+# (closure/struct fields and type parameters). In that case `T1` was necessarily
+# created while `T2`'s derivative was already in progress, so `Dual{T1}` must be
+# composed outside `Dual{T2}` — independent of `tagcount`, whose values can be
+# baked in an arbitrary order by precompilation (see #714).
+function _containstag(@nospecialize(T), @nospecialize(target), seen::Base.IdSet{Any}, depth::Int)
+    T === target && return true
+    depth <= 0 && return false
+    if T isa Union
+        return _containstag(T.a, target, seen, depth - 1) ||
+               _containstag(T.b, target, seen, depth - 1)
+    elseif T isa UnionAll
+        return _containstag(Base.unwrap_unionall(T), target, seen, depth - 1)
+    end
+    T isa DataType || return false
+    T in seen && return false
+    push!(seen, T)
+    for p in T.parameters
+        p isa Type && _containstag(p, target, seen, depth - 1) && return true
+    end
+    if isconcretetype(T) && isstructtype(T)
+        for ft in fieldtypes(T)
+            ft isa Type && _containstag(ft, target, seen, depth - 1) && return true
+        end
+    end
+    return false
+end
+
+@generated function containstag(::Type{T1}, ::Type{T2}) where {T1,T2}
+    return _containstag(T1, T2, Base.IdSet{Any}(), 32) ? :(true) : :(false)
+end
 
 @inline function ≺(::Type{Tag{F1,V1}}, ::Type{Tag{F2,V2}}) where {F1,V1,F2,V2}
-      d1 = tagdepth(Tag{F1,V1})
-      d2 = tagdepth(Tag{F2,V2})
-      d1 != d2 && return d1 < d2
-      return tagcount(Tag{F1,V1}) < tagcount(Tag{F2,V2})
-  end
+    containstag(Tag{F1,V1}, Tag{F2,V2}) && return false
+    containstag(Tag{F2,V2}, Tag{F1,V1}) && return true
+    return tagcount(Tag{F1,V1}) < tagcount(Tag{F2,V2})
+end
 
 struct InvalidTagException{E,O} <: Exception
 end

--- a/test/ConfusionTest.jl
+++ b/test/ConfusionTest.jl
@@ -72,5 +72,56 @@ end
     end
 end == 0.0
 
+# Nested differentiation must not depend on tagcount instantiation order (#714) #
+#-------------------------------------------------------------------------------#
+
+# containstag: nesting through the seeded value type V
+struct TagOrderOuterMarker end
+struct TagOrderInnerMarker end
+let Tag = ForwardDiff.Tag, Dual = ForwardDiff.Dual
+    Touter = Tag{TagOrderOuterMarker, Float64}
+    Tinner = Tag{TagOrderInnerMarker, Dual{Touter, Float64, 1}}
+    @test ForwardDiff.containstag(Tinner, Touter)
+    @test !ForwardDiff.containstag(Touter, Tinner)
+    # bake tagcounts in inverted order: containment must win regardless
+    ForwardDiff.tagcount(Tinner)
+    ForwardDiff.tagcount(Touter)
+    @test ForwardDiff.:(≺)(Touter, Tinner)
+    @test !ForwardDiff.:(≺)(Tinner, Touter)
+end
+
+# Second derivative with tagcount baked in inverted order, as precompilation can
+# do: the inner tag nests the outer through V, so ordering must not consult
+# tagcount at all.
+struct TagOrderInnerV end
+(::TagOrderInnerV)(y) = y^3
+struct TagOrderOuterV end
+(::TagOrderOuterV)(x) = ForwardDiff.derivative(TagOrderInnerV(), x)
+ForwardDiff.tagcount(ForwardDiff.Tag{TagOrderInnerV, ForwardDiff.Dual{ForwardDiff.Tag{TagOrderOuterV, Float64}, Float64, 1}})
+ForwardDiff.tagcount(ForwardDiff.Tag{TagOrderOuterV, Float64})
+@test ForwardDiff.derivative(TagOrderOuterV(), 2.0) ≈ 12.0
+
+# Same with the outer perturbation entering through a capture in F (both tags
+# have V === Float64): nesting is only visible through the callable's fields.
+struct TagOrderOuterF end
+struct TagOrderInnerF
+    x_dual::ForwardDiff.Dual{ForwardDiff.Tag{TagOrderOuterF, Float64}, Float64, 1}
+end
+(c::TagOrderInnerF)(y) = sin(c.x_dual * y)
+(::TagOrderOuterF)(x_dual::ForwardDiff.Dual{ForwardDiff.Tag{TagOrderOuterF, Float64}, Float64, 1}) =
+    ForwardDiff.derivative(TagOrderInnerF(x_dual), 1.0)
+ForwardDiff.tagcount(ForwardDiff.Tag{TagOrderInnerF, Float64})
+ForwardDiff.tagcount(ForwardDiff.Tag{TagOrderOuterF, Float64})
+@test ForwardDiff.derivative(TagOrderOuterF(), 0.5) ≈ cos(0.5) - 0.5 * sin(0.5)
+
+# Three-level nesting where the innermost derivative is seeded with a plain
+# Float64 while the outer perturbations enter through closure captures. A
+# depth-only fast path mis-orders this case; it must keep working.
+let
+    inner_deriv(d) = ForwardDiff.derivative(y -> y^2 * d, 1.0)
+    middle_grad(v) = ForwardDiff.gradient(u -> sum(inner_deriv(ui) * ui for ui in u), v)
+    outer_fn(x) = sum(middle_grad([x, 2x]))
+    @test ForwardDiff.derivative(outer_fn, 0.5) ≈ 12.0
+end
 
 end # module


### PR DESCRIPTION
This is the updated version of #807, superseding it: same goal (fix #714's precompilation-inverted tag ordering, and with it [SciML/OrdinaryDiffEq.jl#3381](https://github.com/SciML/OrdinaryDiffEq.jl/issues/3381) and [SciML/NonlinearSolve.jl#932](https://github.com/SciML/NonlinearSolve.jl/pull/932)), but with the depth-only fast path replaced by the containment proof discussed in #807's review thread. Opened as a separate PR only because #807's head branch can't be pushed to from this account; @ChrisRackauckas can instead pull this into #807's branch to keep the discussion in one place:

```
git fetch https://github.com/ChrisRackauckas-Claude/ForwardDiff.jl containment-tag-ordering
git push git@github.com:JuliaDiff/ForwardDiff.jl.git FETCH_HEAD:ChrisRackauckas-patch-1 --force-with-lease
```

**Note: please treat this as pending until reviewed by @ChrisRackauckas.**

## The problem

`tagcount` is a `@generated` function whose literal is baked at first compile, so precompilation can bake an outer and an inner tag's counts in inverted order (#714). Tag ordering (`≺`) is a pure `tagcount` comparison, so nested differentiation then composes Duals in the wrong nesting order — the stochastic `DualMismatchError` / `MethodError: no method matching Float64(::Dual{...})` class of failures seen downstream.

## The fix: order by provable containment, fall back to tagcount

#807's original depth-only fast path had two confirmed counterexamples (thanks @devmotion, confirmed by @riftsim-jarod): `tagdepth` read nesting off `V` only, so it both regressed a 3-level case where nesting lives in the closure type `F`, and missed the same-depth case where both tags have `V === Float64`.

This version replaces the depth heuristic with a containment proof. `containstag(T1, T2)` walks `T1`'s type structure at compile time — the seeded value type `V`, plus the function type `F`'s type parameters and concrete field types (closure captures) — and checks whether `T2` genuinely appears inside it. If it does, `T1` was necessarily created while `T2`'s derivative was already in progress, so `Dual{T1}` must compose outside `Dual{T2}`, regardless of what `tagcount` says:

```julia
@inline function ≺(::Type{Tag{F1,V1}}, ::Type{Tag{F2,V2}}) where {F1,V1,F2,V2}
    containstag(Tag{F1,V1}, Tag{F2,V2}) && return false
    containstag(Tag{F2,V2}, Tag{F1,V1}) && return true
    return tagcount(Tag{F1,V1}) < tagcount(Tag{F2,V2})
end
```

When neither tag provably nests the other, behavior is exactly master's. The walk is a `@generated` function (cycle-guarded, depth-bounded at 32), so `≺` still folds to a constant at compile time. This is the "prove that one tag genuinely nests the other" safety check from the #807 thread — extended through `F` as well as `V`, which is what also fixes the same-`V` case (the nesting there is only visible through the callable's fields).

## Verification (all run locally)

| Check | Result |
|---|---|
| Full FD suite, Julia 1.11, default mode | 9045/9045 |
| Full FD suite, Julia 1.12, NaN-safe mode | 9129/9129 |
| [8-case downstream matrix](https://github.com/JuliaDiff/ForwardDiff.jl/pull/807#issuecomment-4472620435) (6× OrdinaryDiffEq spec/u0 combos + both counterexamples), Julia 1.12 | **8/8** (depth-only #807: 6/8; master: 1/8) |
| @devmotion example 1 (3-level, constant inner seed) | `12.0` — #807's regression gone |
| @devmotion example 2 (same-depth, inverted tagcount) | `cos(0.5) - 0.5·sin(0.5)` — fixed |
| SciML/OrdinaryDiffEq.jl#3381 original MWE | no longer throws; identical to `AutoFiniteDiff` reference (9 digits); FD Jacobian vs analytic: `3e-8` |

Regression tests added to `test/ConfusionTest.jl`, covering containment ordering under explicitly inverted tagcounts in both shapes (`V`-nesting and `F`-capture) plus the 3-level constant-seed case. The `F`-capture test throws `DualMismatchError` on master and passes here.

Two caveats for review:

1. The hybrid ordering (containment first, tagcount fallback) is not a proven total order: a three-way mix where A nests B but A–C and B–C resolve by tagcount could in principle order inconsistently. Master's pure tagcount has the same in-principle exposure once precompilation inverts counts, and the containment direction is the semantically forced one, so this is strictly an improvement — but it is a heuristic layered on tagcount, not a replacement for it.
2. `containstag` only unwraps `Union`/`UnionAll` and walks concrete field types; pathological/truncated cases fall back to tagcount (master behavior) rather than guessing.

The "Julia pre" CI failures are pre-existing — all six pre jobs fail identically on the latest master push run (JET `@test_opt` in `test/QATest.jl` flagging Julia 1.13-rc1 Base broadcast-inference regressions; reproduced locally on unmodified master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
