### PR TITLE
Fix flaky gamma_inc partials test

### DIFF
--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -635,14 +635,6 @@ ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
         tolval = tol^(one(tol) / 2^(isempty(ind) ? 0 : first(ind)))
         for i in 1:2
             @test value(pq[i]) ≈ gamma_inc(a, 1 + PRIMAL, ind...)[i] rtol=tolval
-            # ForwardDiff computes the analytic derivative (independent of
-            # `ind`), so compare against a finite difference of the
-            # full-accuracy (`ind = 0`) Float64 evaluation: differencing the
-            # reduced-accuracy `ind` variants (or the V-precision function for
-            # V === Float32) puts the reference's own error at or above `tol`,
-            # which makes this test flake for random `a`/`PRIMAL`.
-            # Float64(1 + PRIMAL) keeps the evaluation point exactly the
-            # primal of `fdnum` (convert after the V-precision addition).
             der = Calculus.derivative(x -> gamma_inc(Float64(a), x, 0)[i], Float64(1 + PRIMAL))
             @test partials(pq[i]) ≈ PARTIALS * der rtol=tol
         end

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -632,10 +632,19 @@ ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
         # We have to adjust tolerances if lower accuracy is requested
         # Therefore we don't use `dual_isapprox`
         tol = V === Float32 ? 5f-4 : 1e-5
-        tol = tol^(one(tol) / 2^(isempty(ind) ? 0 : first(ind)))
+        tolval = tol^(one(tol) / 2^(isempty(ind) ? 0 : first(ind)))
         for i in 1:2
-            @test value(pq[i]) ≈ gamma_inc(a, 1 + PRIMAL, ind...)[i] rtol=tol
-            @test partials(pq[i]) ≈ PARTIALS * Calculus.derivative(x -> gamma_inc(a, x, ind...)[i], 1 + PRIMAL) rtol=tol
+            @test value(pq[i]) ≈ gamma_inc(a, 1 + PRIMAL, ind...)[i] rtol=tolval
+            # ForwardDiff computes the analytic derivative (independent of
+            # `ind`), so compare against a finite difference of the
+            # full-accuracy (`ind = 0`) Float64 evaluation: differencing the
+            # reduced-accuracy `ind` variants (or the V-precision function for
+            # V === Float32) puts the reference's own error at or above `tol`,
+            # which makes this test flake for random `a`/`PRIMAL`.
+            # Float64(1 + PRIMAL) keeps the evaluation point exactly the
+            # primal of `fdnum` (convert after the V-precision addition).
+            der = Calculus.derivative(x -> gamma_inc(Float64(a), x, 0)[i], Float64(1 + PRIMAL))
+            @test partials(pq[i]) ≈ PARTIALS * der rtol=tol
         end
     end
 end


### PR DESCRIPTION
## Summary

The `gamma_inc` partials assertions in `test/DualTest.jl` fail sporadically on CI —
roughly one job per full-matrix run, on arbitrary OS/Julia-version combinations (e.g.
"Julia lts - windows-latest" in the 2026-06-22 master run, "Julia 1 - ubuntu-latest" in
the 2026-06-07 run), always of the form

```
partials(pq[i]) ≈ PARTIALS * Calculus.derivative(x -> gamma_inc(a, x, ind...)[i], 1 + PRIMAL) rtol=tol
```

with `V === Float32` and random `a`/`PRIMAL` narrowly missing `rtol = 5f-4`.

## Diagnosis

The reference, not ForwardDiff, is at fault, for two reasons:

1. For `V === Float32`, `Calculus.derivative` central-differences the **Float32**
   evaluation of `gamma_inc`, whose finite-difference error is of the same order as the
   `5f-4` tolerance — so random draws sporadically cross it (~4% of draws, measured).
2. For `ind = 1` / `ind = 2`, `gamma_inc` deliberately evaluates a reduced-accuracy
   approximation (~14 / ~6 significant digits). Finite-differencing a function with
   ~1e-6 intrinsic noise amplifies that noise by `1/h`; the measured reference error
   reaches 2000–3000% of the true derivative in the worst draws. The existing
   `tol^(1/2^ind)` loosening (up to `rtol ≈ 0.15`) was compensating for this.

In every sampled failing draw, ForwardDiff's Float32 derivative was within 4e-8
relative of the true derivative (Float64 dual evaluation), while the finite-difference
reference was off by 2%–3000%.

## Fix

ForwardDiff's rule (`src/dual.jl`) is the analytic `exp(-x)·x^(a-1)/Γ(a)`, independent
of `ind`. So compare the partials against a finite difference of the **full-accuracy
(`ind = 0`) Float64** evaluation, at the **base** tolerance — the `ind`-dependent
loosening remains only on the value comparison, where it belongs (values genuinely
differ by the requested approximation accuracy). `Float64(1 + PRIMAL)` converts after
the V-precision addition, so the reference is evaluated at exactly the primal of the
dual input.

Measured over 300000 random `(a, PRIMAL, PARTIALS)` draws × all `ind` variants
(2.4M assertions): old reference fails ~4% of draws; new reference fails **0**, even at
the base (unloosened) tolerance.

`test/DualTest.jl` passes locally (Julia 1.12, `--check-bounds=yes`).

---

> [!NOTE]
> Opened as a draft by an agent on behalf of @ChrisRackauckas. Please ignore
> until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
