### PR TITLE
Skip JET QA tests on Julia 1.13 until JET supports it

### DIFF
--- a/test/QATest.jl
+++ b/test/QATest.jl
@@ -5,12 +5,20 @@ using Test
 
 using JET: @test_opt
 
-@testset "JET" begin
-    # issue #778
-    @test_opt ForwardDiff.derivative(identity, 1.0)
-    @test_opt ForwardDiff.gradient(only, [1.0], ForwardDiff.GradientConfig(only, [1.0], ForwardDiff.Chunk{1}()))
-    @test_opt ForwardDiff.jacobian(identity, [1.0], ForwardDiff.JacobianConfig(identity, [1.0], ForwardDiff.Chunk{1}()))
-    @test_opt ForwardDiff.hessian(only, [1.0], ForwardDiff.HessianConfig(only, [1.0], ForwardDiff.Chunk{1}()))
+# On Julia 1.13, JET produces false-positive runtime-dispatch reports for
+# concrete Base broadcast/view/CartesianIndex code reached by these calls:
+# native inference of every flagged frame is concrete and the kernels are
+# allocation-free, so nothing is actually mis-inferred in ForwardDiff.
+# Re-enable once JET supports Julia 1.13; tracked in
+# https://github.com/aviatesk/JET.jl/issues/839
+if VERSION < v"1.13.0-"
+    @testset "JET" begin
+        # issue #778
+        @test_opt ForwardDiff.derivative(identity, 1.0)
+        @test_opt ForwardDiff.gradient(only, [1.0], ForwardDiff.GradientConfig(only, [1.0], ForwardDiff.Chunk{1}()))
+        @test_opt ForwardDiff.jacobian(identity, [1.0], ForwardDiff.JacobianConfig(identity, [1.0], ForwardDiff.Chunk{1}()))
+        @test_opt ForwardDiff.hessian(only, [1.0], ForwardDiff.HessianConfig(only, [1.0], ForwardDiff.Chunk{1}()))
+    end
 end
 
 end # module

--- a/test/QATest.jl
+++ b/test/QATest.jl
@@ -5,13 +5,14 @@ using Test
 
 using JET: @test_opt
 
-# On Julia 1.13, JET produces false-positive runtime-dispatch reports for
-# concrete Base broadcast/view/CartesianIndex code reached by these calls:
-# native inference of every flagged frame is concrete and the kernels are
-# allocation-free, so nothing is actually mis-inferred in ForwardDiff.
-# Re-enable once JET supports Julia 1.13; tracked in
-# https://github.com/aviatesk/JET.jl/issues/839
-if VERSION < v"1.13.0-"
+# On Julia prereleases JET's analysis lags the compiler and produces
+# false-positive runtime-dispatch reports (e.g. on 1.13.0-rc1 for concrete
+# Base broadcast/view/CartesianIndex code reached by these calls: native
+# inference of every flagged frame is concrete and the kernels are
+# allocation-free, so nothing is actually mis-inferred in ForwardDiff;
+# https://github.com/aviatesk/JET.jl/issues/839). Only run the JET tests on
+# released Julia versions.
+if isempty(VERSION.prerelease)
     @testset "JET" begin
         # issue #778
         @test_opt ForwardDiff.derivative(identity, 1.0)


### PR DESCRIPTION
## Summary

Every "Julia pre" CI job has failed on master since the JET 0.11 compat bump: the
`JET.@test_opt` calls in `test/QATest.jl` report runtime dispatches on Julia
1.13.0-rc1 whose leaf frames are all in **Base** (broadcast `preprocess`,
`simd_index`/`CartesianIndex`, `SubArray` construction under `view`,
`mightalias`/`_isdisjoint`/`_in_tuple`).

These are false positives in JET's Julia 1.13 analysis, not ForwardDiff (or Base)
problems:

- Native inference (`Base.infer_return_type` / `code_typed`) of every flagged frame,
  with the exact argtypes from the reports, is concrete and dispatch-free — and
  identical on 1.12.6 and 1.13.0-rc1.
- The flagged kernels are allocation-free at runtime on both versions.
- The same reports reproduce with self-contained MWEs that don't involve ForwardDiff
  at all (e.g. `@report_opt view(rand(3,3), :, 1:2)` and a plain
  `CartesianIndex(1, CartesianIndex(2))` are flagged on 1.13-rc1, clean on 1.12.6,
  same JET 0.11.5).
- JET's own Julia 1.13 support is still in progress (aviatesk/JET.jl#815, #819), and
  the pending 1.13-compat PR does not fix these reports (verified against that
  branch).

Filed upstream with the reduced MWEs and evidence: aviatesk/JET.jl#839.

This PR gates the JET QA testset on `isempty(VERSION.prerelease)`, so it runs on
every released Julia version and skips on rc/beta/DEV builds, where JET's analysis
routinely lags the compiler (as it does now on 1.13.0-rc1). Comment links the
upstream issue. Test-skip explicitly authorized by @ChrisRackauckas for this case.

Verified locally: on Julia 1.12.6 (`VERSION.prerelease == ()`) the JET testset still
runs (4/4 pass); on 1.13.0-rc1 (`("rc1",)`) it is skipped and `QATest.jl` loads
cleanly.

---

> [!NOTE]
> Opened as a draft by an agent on behalf of @ChrisRackauckas. Please ignore
> until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
