### PR TITLE
Inline `dual_definition_retval` to fix nested `Dual` performance

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -210,10 +210,10 @@ macro define_ternary_dual_op(f, xyz_body, xy_body, xz_body, yz_body, x_body, y_b
 end
 
 # Support complex-valued functions such as `hankelh1`
-function dual_definition_retval(::Val{T}, val::Real, deriv::Real, partial::Partials) where {T}
+@inline function dual_definition_retval(::Val{T}, val::Real, deriv::Real, partial::Partials) where {T}
     return Dual{T}(val, deriv * partial)
 end
-function dual_definition_retval(::Val{T}, val::Real, deriv1::Real, partial1::Partials, deriv2::Real, partial2::Partials) where {T}
+@inline function dual_definition_retval(::Val{T}, val::Real, deriv1::Real, partial1::Partials, deriv2::Real, partial2::Partials) where {T}
     return Dual{T}(val, _mul_partials(partial1, partial2, deriv1, deriv2))
 end
 function dual_definition_retval(::Val{T}, val::Complex, deriv::Union{Real,Complex}, partial::Partials) where {T}

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -216,7 +216,7 @@ end
 @inline function dual_definition_retval(::Val{T}, val::Real, deriv1::Real, partial1::Partials, deriv2::Real, partial2::Partials) where {T}
     return Dual{T}(val, _mul_partials(partial1, partial2, deriv1, deriv2))
 end
-function dual_definition_retval(::Val{T}, val::Complex, deriv::Union{Real,Complex}, partial::Partials) where {T}
+@inline function dual_definition_retval(::Val{T}, val::Complex, deriv::Union{Real,Complex}, partial::Partials) where {T}
     reval, imval = reim(val)
     if deriv isa Real
         p = deriv * partial
@@ -226,7 +226,7 @@ function dual_definition_retval(::Val{T}, val::Complex, deriv::Union{Real,Comple
         return Complex(Dual{T}(reval, rederiv * partial), Dual{T}(imval, imderiv * partial))
     end
 end
-function dual_definition_retval(::Val{T}, val::Complex, deriv1::Union{Real,Complex}, partial1::Partials, deriv2::Union{Real,Complex}, partial2::Partials) where {T}
+@inline function dual_definition_retval(::Val{T}, val::Complex, deriv1::Union{Real,Complex}, partial1::Partials, deriv2::Union{Real,Complex}, partial2::Partials) where {T}
     reval, imval = reim(val)
     if deriv1 isa Real && deriv2 isa Real
         p = _mul_partials(partial1, partial2, deriv1, deriv2)


### PR DESCRIPTION
👨 I am generating some benchmarks for my JuliaCon talk for https://github.com/KristofferC/HyperHessians.jl, and I wanted to drill down into why HyperHessians was faster than ForwardDiff. One of the reasons was a failure to inline, which just seemed like a mistake, and I don't want to base conclusions of the presentation on performance bugs in other libraries. With this PR the performance of hessian is greatly improved.

---

🤖 

`dual_definition_retval` carries no `@inline` annotation. For plain `Dual`s the inliner picks it up anyway, but for nested `Dual`s (as used by `hessian`) the struct is large enough that Julia's inlining cost model declines it. Every DiffRules-generated operation -- including `*` and `/` -- then compiles to a scalar op plus out-of-line calls that return the full `Dual` through an `sret` memcpy (648 bytes for `Dual{T,Dual{T,Float64,8},8}`, per call, per op).

Forcing the inline turns e.g. the nested-`Dual` multiply into straight-line inlined code. Measured on
`Dual{Nothing,Dual{Nothing,Float64,8},8}` vectors (256 elements, ns per element):

|              | before | after |
|--------------|--------|-------|
| `*` (M4)     |  65.4  | 22.7  |
| `*` (Zen 4)  | 127.6  | 53.5  |
| `sqrt` (M4)  |  34.0  | 14.7  |
| `sqrt` (Zen 4) | 81.1 | 13.0  |

End-to-end `ForwardDiff.hessian!` at n=256, chunk 8: 28.3 -> 20.4 ms (ackley) and 41.2 -> 23.9 ms (rosenbrock) on an Apple M4; 46.3 -> 25.7 ms and 56.7 -> 34.0 ms on an AMD EPYC 9354. First-order (non-nested) `Dual`s already inlined before this change and are unaffected.