### PR TITLE
Use `round(::Dual, ::RoundingMode)` for rounding functions on 1.11+

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ForwardDiff"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "1.4.4"
+version = "1.4.5"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -325,17 +325,18 @@ end
 
 Base.rtoldefault(::Type{D}) where {D<:Dual} = Base.rtoldefault(valtype(D))
 
-Base.floor(::Type{R}, d::Dual) where {R<:Real} = floor(R, value(d))
-Base.floor(d::Dual) = floor(value(d))
+# Base derives floor/ceil/trunc/round from `round(x, ::RoundingMode)`:
+# https://docs.julialang.org/en/v1/manual/interfaces/#man-rounding-interface
+Base.round(d::Dual, r::RoundingMode) = round(value(d), r)
 
-Base.ceil(::Type{R}, d::Dual) where {R<:Real} = ceil(R, value(d))
-Base.ceil(d::Dual) = ceil(value(d))
-
-Base.trunc(::Type{R}, d::Dual) where {R<:Real} = trunc(R, value(d))
-Base.trunc(d::Dual) = trunc(value(d))
-
-Base.round(::Type{R}, d::Dual) where {R<:Real} = round(R, value(d))
-Base.round(d::Dual) = round(value(d))
+# Julia 1.11 added the generic `f(::Type{T}, x)` fallbacks, so these can be
+# dropped once 1.11 is the minimum supported version.
+if VERSION < v"1.11"
+    Base.floor(::Type{R}, d::Dual) where {R<:Real} = floor(R, value(d))
+    Base.ceil(::Type{R}, d::Dual) where {R<:Real} = ceil(R, value(d))
+    Base.trunc(::Type{R}, d::Dual) where {R<:Real} = trunc(R, value(d))
+    Base.round(::Type{R}, d::Dual) where {R<:Real} = round(R, value(d))
+end
 
 Base.fld(x::Dual, y::Dual) = fld(value(x), value(y))
 

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -172,6 +172,20 @@ ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
         @test round(FDNUM2) === round(PRIMAL2)
         @test round(NESTED_FDNUM) === round(PRIMAL)
 
+        for r in (RoundDown, RoundUp, RoundToZero, RoundNearest,
+                  RoundNearestTiesAway, RoundNearestTiesUp, RoundFromZero)
+            @test round(FDNUM, r) === round(PRIMAL, r)
+            @test round(FDNUM2, r) === round(PRIMAL2, r)
+            @test round(NESTED_FDNUM, r) === round(PRIMAL, r)
+        end
+
+        if VERSION >= v"1.11"
+            @test floor(Float32, FDNUM) === floor(Float32, PRIMAL)
+            @test ceil(Float32, FDNUM) === ceil(Float32, PRIMAL)
+            @test trunc(Float32, FDNUM) === trunc(Float32, PRIMAL)
+            @test round(Float32, FDNUM) === round(Float32, PRIMAL)
+        end
+
         @test fld(FDNUM, FDNUM2) === fld(PRIMAL, PRIMAL2)
         @test fld(FDNUM, PRIMAL2) === fld(PRIMAL, PRIMAL2)
         @test fld(PRIMAL, FDNUM2) === fld(PRIMAL, PRIMAL2)


### PR DESCRIPTION
The other functions like floor/trunc are already implemented in terms of that function in 1.11: https://docs.julialang.org/en/v1/manual/interfaces/#man-rounding-interface

Fixes these invalidations seen when loading CurveFit.jl on 1.13:
```julia
 inserting floor(::Type{R}, d::ForwardDiff.Dual) where R<:Real @ ForwardDiff ~/.julia/packages/ForwardDiff/IleGP/src/dual.jl:328 invalidated:                                                                                                  
   backedges: 1: superseding floor(::Type{T}, x) where T @ Base rounding.jl:484 with MethodInstance for floor(::Type{Int64}, ::Any) (658 children)                                                                                             
```