### PR TITLE
Fix ternary `hypot` flattening `Dual`s with different tags

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -599,24 +599,39 @@ end
 # hypot #
 #-------#
 
-@inline function calc_hypot(x, y, z, ::Type{T}) where T
-    vx = value(x)
-    vy = value(y)
-    vz = value(z)
+# Only the arguments that carry the tag `T` may be unwrapped with `value`/`partials`.
+# The remaining ones are constants with respect to `T`, and since `Dual <: Real` they
+# are simply passed on to the recursive `hypot` call, which keeps the perturbations of
+# their (necessarily inner) tags nested inside the returned `Dual{T}`.
+@inline function calc_hypot_xyz(x::Dual{T}, y::Dual{T}, z::Dual{T}) where T
+    vx, vy, vz = value(x), value(y), value(z)
     h = hypot(vx, vy, vz)
     p = (vx / h) * partials(x) + (vy / h) * partials(y) + (vz / h) * partials(z)
     return Dual{T}(h, p)
 end
 
+@inline function calc_hypot_xy(x::Dual{T}, y::Dual{T}, z::Real) where T
+    vx, vy = value(x), value(y)
+    h = hypot(vx, vy, z)
+    return Dual{T}(h, (vx / h) * partials(x) + (vy / h) * partials(y))
+end
+
+@inline function calc_hypot_x(x::Dual{T}, y::Real, z::Real) where T
+    vx = value(x)
+    h = hypot(vx, y, z)
+    return Dual{T}(h, (vx / h) * partials(x))
+end
+
+# `hypot` is symmetric in its arguments, so the remaining cases are permutations
 @define_ternary_dual_op(
     Base.hypot,
-    calc_hypot(x, y, z, Txyz),
-    calc_hypot(x, y, z, Txy),
-    calc_hypot(x, y, z, Txz),
-    calc_hypot(x, y, z, Tyz),
-    calc_hypot(x, y, z, Tx),
-    calc_hypot(x, y, z, Ty),
-    calc_hypot(x, y, z, Tz),
+    calc_hypot_xyz(x, y, z),
+    calc_hypot_xy(x, y, z),
+    calc_hypot_xy(x, z, y),
+    calc_hypot_xy(y, z, x),
+    calc_hypot_x(x, y, z),
+    calc_hypot_x(y, x, z),
+    calc_hypot_x(z, x, y),
 )
 
 # fma #

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -598,24 +598,39 @@ end
 # hypot #
 #-------#
 
-@inline function calc_hypot(x, y, z, ::Type{T}) where T
-    vx = value(x)
-    vy = value(y)
-    vz = value(z)
+# Only the arguments that carry the tag `T` may be unwrapped with `value`/`partials`.
+# The remaining ones are constants with respect to `T`, and since `Dual <: Real` they
+# are simply passed on to the recursive `hypot` call, which keeps the perturbations of
+# their (necessarily inner) tags nested inside the returned `Dual{T}`.
+@inline function calc_hypot_xyz(x::Dual{T}, y::Dual{T}, z::Dual{T}) where T
+    vx, vy, vz = value(x), value(y), value(z)
     h = hypot(vx, vy, vz)
     p = (vx / h) * partials(x) + (vy / h) * partials(y) + (vz / h) * partials(z)
     return Dual{T}(h, p)
 end
 
+@inline function calc_hypot_xy(x::Dual{T}, y::Dual{T}, z::Real) where T
+    vx, vy = value(x), value(y)
+    h = hypot(vx, vy, z)
+    return Dual{T}(h, (vx / h) * partials(x) + (vy / h) * partials(y))
+end
+
+@inline function calc_hypot_x(x::Dual{T}, y::Real, z::Real) where T
+    vx = value(x)
+    h = hypot(vx, y, z)
+    return Dual{T}(h, (vx / h) * partials(x))
+end
+
+# `hypot` is symmetric in its arguments, so the remaining cases are permutations
 @define_ternary_dual_op(
     Base.hypot,
-    calc_hypot(x, y, z, Txyz),
-    calc_hypot(x, y, z, Txy),
-    calc_hypot(x, y, z, Txz),
-    calc_hypot(x, y, z, Tyz),
-    calc_hypot(x, y, z, Tx),
-    calc_hypot(x, y, z, Ty),
-    calc_hypot(x, y, z, Tz),
+    calc_hypot_xyz(x, y, z),
+    calc_hypot_xy(x, y, z),
+    calc_hypot_xy(x, z, y),
+    calc_hypot_xy(y, z, x),
+    calc_hypot_x(x, y, z),
+    calc_hypot_x(y, x, z),
+    calc_hypot_x(z, x, y),
 )
 
 # fma #

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -603,6 +603,14 @@ ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
 
     @test dual_isapprox(hypot(FDNUM, FDNUM2, FDNUM), sqrt(2*(FDNUM^2) + FDNUM2^2))
     @test dual_isapprox(hypot(FDNUM, FDNUM2, FDNUM3), sqrt(FDNUM^2 + FDNUM2^2 + FDNUM3^2))
+    # every argument position has to be checked: only the arguments carrying the tag may
+    # be unwrapped, so each case needs its own body
+    @test dual_isapprox(hypot(FDNUM, FDNUM2, PRIMAL3),  sqrt(FDNUM^2 + FDNUM2^2 + PRIMAL3^2))
+    @test dual_isapprox(hypot(FDNUM, PRIMAL2, FDNUM3),  sqrt(FDNUM^2 + PRIMAL2^2 + FDNUM3^2))
+    @test dual_isapprox(hypot(PRIMAL, FDNUM2, FDNUM3),  sqrt(PRIMAL^2 + FDNUM2^2 + FDNUM3^2))
+    @test dual_isapprox(hypot(FDNUM, PRIMAL2, PRIMAL3), sqrt(FDNUM^2 + PRIMAL2^2 + PRIMAL3^2))
+    @test dual_isapprox(hypot(PRIMAL, FDNUM2, PRIMAL3), sqrt(PRIMAL^2 + FDNUM2^2 + PRIMAL3^2))
+    @test dual_isapprox(hypot(PRIMAL, PRIMAL2, FDNUM3), sqrt(PRIMAL^2 + PRIMAL2^2 + FDNUM3^2))
 
     @test all(map(dual_isapprox, ForwardDiff.sincos(FDNUM), (sin(FDNUM), cos(FDNUM))))
 
@@ -718,6 +726,35 @@ end
 
 @testset "TwicePrecision" begin
     @test ForwardDiff.derivative(x -> sum(1 .+ x .* (0:0.1:1)), 1) == 5.5
+end
+
+@testset "ternary hypot" begin # issue #834
+    # Arguments carrying an inner tag must not be unwrapped: their perturbations have
+    # to stay nested inside the returned `Dual` instead of being flattened into (and
+    # summed with) the outer tag's partials. `sqrt` of the sum of squares is built
+    # from binary operations only and hence serves as a reference.
+    # `hypot` is symmetric, so every argument position has to be checked. Both tag layouts
+    # have to be checked as well: dispatch settles on one tag, and a different body runs
+    # depending on whether one or two of the arguments carry it.
+    for i in 1:3, args in ((x, y) -> ntuple(j -> j == i ? y : j * x, 3),     # one `y`, two `x`
+                           (x, y) -> ntuple(j -> j == i ? j * x : j * y, 3)) # one `x`, two `y`
+        f(x) = ForwardDiff.derivative(y -> hypot(args(x, y)...), 2.0)
+        g(x) = ForwardDiff.derivative(y -> sqrt(sum(a -> a^2, args(x, y))), 2.0)
+        @test f(3.0) ≈ g(3.0)
+        @test ForwardDiff.derivative(f, 3.0) ≈ ForwardDiff.derivative(g, 3.0)
+        @test ForwardDiff.derivative(f, 3.0) != 0
+    end
+
+    # all three tags distinct, so dispatch has to single out the outermost one
+    d3(f) = ForwardDiff.derivative(
+        x -> ForwardDiff.derivative(y -> ForwardDiff.derivative(z -> f(x, y, z), 4.0), 3.0),
+        2.0,
+    )
+    @test d3(hypot) ≈ d3((x, y, z) -> sqrt(x^2 + y^2 + z^2))
+    @test d3(hypot) != 0
+
+    # `hypot` must not form squares, otherwise the partials overflow
+    @test ForwardDiff.gradient(v -> hypot(v[1], v[2], v[3]), fill(1e200, 3)) ≈ fill(1 / sqrt(3), 3)
 end
 
 @testset "Givens rotations: consistency with `LinearAlgebra.givensAlgorithm` for zero partials (no duals)" begin

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -617,6 +617,14 @@ ForwardDiff.:≺(::Type{OuterTestTag}, ::Type{TestTag}) = false
 
     @test dual_isapprox(hypot(FDNUM, FDNUM2, FDNUM), sqrt(2*(FDNUM^2) + FDNUM2^2))
     @test dual_isapprox(hypot(FDNUM, FDNUM2, FDNUM3), sqrt(FDNUM^2 + FDNUM2^2 + FDNUM3^2))
+    # every argument position has to be checked: only the arguments carrying the tag may
+    # be unwrapped, so each case needs its own body
+    @test dual_isapprox(hypot(FDNUM, FDNUM2, PRIMAL3),  sqrt(FDNUM^2 + FDNUM2^2 + PRIMAL3^2))
+    @test dual_isapprox(hypot(FDNUM, PRIMAL2, FDNUM3),  sqrt(FDNUM^2 + PRIMAL2^2 + FDNUM3^2))
+    @test dual_isapprox(hypot(PRIMAL, FDNUM2, FDNUM3),  sqrt(PRIMAL^2 + FDNUM2^2 + FDNUM3^2))
+    @test dual_isapprox(hypot(FDNUM, PRIMAL2, PRIMAL3), sqrt(FDNUM^2 + PRIMAL2^2 + PRIMAL3^2))
+    @test dual_isapprox(hypot(PRIMAL, FDNUM2, PRIMAL3), sqrt(PRIMAL^2 + FDNUM2^2 + PRIMAL3^2))
+    @test dual_isapprox(hypot(PRIMAL, PRIMAL2, FDNUM3), sqrt(PRIMAL^2 + PRIMAL2^2 + FDNUM3^2))
 
     @test all(map(dual_isapprox, ForwardDiff.sincos(FDNUM), (sin(FDNUM), cos(FDNUM))))
 
@@ -732,6 +740,35 @@ end
 
 @testset "TwicePrecision" begin
     @test ForwardDiff.derivative(x -> sum(1 .+ x .* (0:0.1:1)), 1) == 5.5
+end
+
+@testset "ternary hypot" begin # issue #834
+    # Arguments carrying an inner tag must not be unwrapped: their perturbations have
+    # to stay nested inside the returned `Dual` instead of being flattened into (and
+    # summed with) the outer tag's partials. `sqrt` of the sum of squares is built
+    # from binary operations only and hence serves as a reference.
+    # `hypot` is symmetric, so every argument position has to be checked. Both tag layouts
+    # have to be checked as well: dispatch settles on one tag, and a different body runs
+    # depending on whether one or two of the arguments carry it.
+    for i in 1:3, args in ((x, y) -> ntuple(j -> j == i ? y : j * x, 3),     # one `y`, two `x`
+                           (x, y) -> ntuple(j -> j == i ? j * x : j * y, 3)) # one `x`, two `y`
+        f(x) = ForwardDiff.derivative(y -> hypot(args(x, y)...), 2.0)
+        g(x) = ForwardDiff.derivative(y -> sqrt(sum(a -> a^2, args(x, y))), 2.0)
+        @test f(3.0) ≈ g(3.0)
+        @test ForwardDiff.derivative(f, 3.0) ≈ ForwardDiff.derivative(g, 3.0)
+        @test ForwardDiff.derivative(f, 3.0) != 0
+    end
+
+    # all three tags distinct, so dispatch has to single out the outermost one
+    d3(f) = ForwardDiff.derivative(
+        x -> ForwardDiff.derivative(y -> ForwardDiff.derivative(z -> f(x, y, z), 4.0), 3.0),
+        2.0,
+    )
+    @test d3(hypot) ≈ d3((x, y, z) -> sqrt(x^2 + y^2 + z^2))
+    @test d3(hypot) != 0
+
+    # `hypot` must not form squares, otherwise the partials overflow
+    @test ForwardDiff.gradient(v -> hypot(v[1], v[2], v[3]), fill(1e200, 3)) ≈ fill(1 / sqrt(3), 3)
 end
 
 @testset "Givens rotations: consistency with `LinearAlgebra.givensAlgorithm` for zero partials (no duals)" begin


### PR DESCRIPTION
Fixes #834.

All seven bodies of the `@define_ternary_dual_op` for `hypot` delegated to a single helper that unwraps every argument with the one-argument `value`/`partials`, regardless of its tag:

```julia
@inline function calc_hypot(x, y, z, ::Type{T}) where T
    vx = value(x)
    vy = value(y)
    vz = value(z)
    h = hypot(vx, vy, vz)
    p = (vx / h) * partials(x) + (vy / h) * partials(y) + (vz / h) * partials(z)
    return Dual{T}(h, p)
end
```

When the arguments carry different tags, the ones with an inner tag are flattened as well and their partials are summed into whichever tag dispatch selected — their perturbations are annihilated, and the surviving tag's partials are polluted by their contributions:

```julia
julia> inner(x) = ForwardDiff.derivative(y -> hypot(x, y, 1.0), 2.0);

julia> ForwardDiff.derivative(inner, 3.0)   # correct: -0.11454053224818188
0.0
```

Each case now gets its own body that only unwraps the arguments known to carry the tag, as `fma` and `muladd` already do. Arguments with an inner tag are passed on unchanged; since `Dual <: Real` they are handled by the recursive `hypot` call, which keeps their perturbations nested inside the returned `Dual`. Because `hypot` is symmetric, two helpers plus permutations of their arguments cover all seven cases.

Since the tag is now read off the helpers' signatures instead of being passed as a `::Type{T}` argument, this also makes ternary `hypot` work for non-`Type` tags, which previously threw a `MethodError`:

```julia
julia> hypot(Dual{:t}(1.0, 1.0), Dual{:t}(2.0, 1.0), Dual{:t}(3.0, 1.0))   # on master: MethodError
Dual{:t}(3.7416573867739413,1.6035674514745464)
```

Note that `calc_hypot` is not just arity plumbing and cannot simply be dropped in favour of composing binary operations: it calls Base's `hypot` on the values and applies the analytic `∂h/∂xᵢ = xᵢ/h`, so no squares are formed and the partials do not overflow. There is a test for this.

Unchanged: the values and partials for single-tag arguments (including gradients and Hessians), and the `NaN` when differentiating at the origin, where `hypot` genuinely has no gradient. `nansafe_mode` does not help there because the `NaN` originates in the coefficient `vx/h = 0/0` rather than in a zero partial, and the two-argument `hypot` from DiffRules behaves the same way.

### Tests

Each of the seven bodies is now covered twice over — once with the non-tagged arguments as plain `Real`s, in the "Special Cases" block, and once with them carrying an inner tag, in the new testset. Both are needed: dispatch settles on one tag, and a different body runs depending on whether one or two of the arguments carry it, so a nested `derivative` with the differently-tagged argument in only one position reaches just five of the seven bodies.

The new tests fail on master in all three argument positions and for three distinct tags (`0.0` instead of the correct derivative). Mis-permuting any of the six non-symmetric arguments of the `@define_ternary_dual_op` call also turns them into a `MethodError`, so the permutations are checked rather than merely written down.

Full test suite passes locally on Julia 1.12.6 with `nansafe_mode` disabled (9279/9279) and enabled (9361/9361).
